### PR TITLE
Jank Index Work Around

### DIFF
--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/metrics/MetricSpanStats.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/metrics/MetricSpanStats.kt
@@ -10,8 +10,9 @@ import kotlin.math.max
 import kotlin.math.min
 
 @DatabaseModel
-@IndexSet(["type", "endpoint", "timeSpan", "timeStamp"])
-@IndexSet(["timeSpan", "timeStamp"])
+@IndexSetJankPatch(["type", "endpoint", "timeSpan", "timeStamp", ":", "timeSpan", "timeStamp"])
+//@IndexSet(["type", "endpoint", "timeSpan", "timeStamp"])
+//@IndexSet(["timeSpan", "timeStamp"])
 @Serializable
 data class MetricSpanStats(
     override val _id: String,

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/settings/loadSettings.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/settings/loadSettings.kt
@@ -1,6 +1,7 @@
 package com.lightningkite.lightningserver.settings
 
 import com.lightningkite.lightningserver.serialization.Serialization
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -29,7 +30,7 @@ fun loadSettings(settingsFile: File): Settings {
     }
     try {
         return Serialization.json.decodeFromStream(settingsFile.inputStream())
-    } catch (e: Exception) {
+    } catch (e: SerializationException) {
         val json = Json {
             encodeDefaults = true
             serializersModule = Serialization.module

--- a/server-dynamodb/src/main/kotlin/com/lightningkite/lightningserver/db/DynamoDbCollection.kt
+++ b/server-dynamodb/src/main/kotlin/com/lightningkite/lightningserver/db/DynamoDbCollection.kt
@@ -35,14 +35,14 @@ class DynamoDbCollection<T : Any>(
         //TODO: Need to use the serial name
         val orderKey = orderBy.map { it.field.property.name }
         val index = indices[orderKey]
-        val key = if(index != null) orderKey.first() else "_id"
+        val key = if (index != null) orderKey.first() else "_id"
         val c = condition.dynamo(serializer, key)
         if (c.never) return emptyFlow()
         val parsed = if (c.writeKey != null) {
             client.queryPaginator {
                 it.tableName(tableName)
                 index?.let { i -> it.indexName(tableName + "_" + i) }
-                if(orderBy.firstOrNull()?.ascending == false) it.scanIndexForward(false)
+                if (orderBy.firstOrNull()?.ascending == false) it.scanIndexForward(false)
                 if (c.local == null) it.limit(limit + skip)
                 it.apply(c)
             }.items().map { it to serializer.fromDynamoMap(it) }.asFlow()
@@ -50,7 +50,7 @@ class DynamoDbCollection<T : Any>(
             client.scanPaginator {
                 it.tableName(tableName)
                 index?.let { i -> it.indexName(tableName + "_" + i) }
-                if(orderBy.firstOrNull()?.ascending == false) throw IllegalArgumentException()
+                if (orderBy.firstOrNull()?.ascending == false) throw IllegalArgumentException()
                 if (c.local == null) it.limit(limit)
                 it.apply(c)
             }.items().map { it to serializer.fromDynamoMap(it) }.asFlow()
@@ -293,6 +293,7 @@ class DynamoDbCollection<T : Any>(
 
     private var prepared = false
     private lateinit var indices: Map<List<String>, String>
+
     @OptIn(ExperimentalSerializationApi::class)
     internal suspend fun prepare() {
         if (prepared) return
@@ -303,10 +304,88 @@ class DynamoDbCollection<T : Any>(
             descriptor.annotations.forEach {
                 when (it) {
                     is UniqueSet -> expectedIndices[it.fields.joinToString("_")] = it.fields.toList()
+
+                    is UniqueSetJankPatch -> {
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        sets.forEach { set ->
+                            expectedIndices[set.joinToString("_")] = set.toList()
+                        }
+                    }
+
                     is IndexSet -> expectedIndices[it.fields.joinToString("_")] = it.fields.toList()
+
+                    is IndexSetJankPatch -> {
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        sets.forEach { set ->
+                            expectedIndices[set.joinToString("_")] = set.toList()
+                        }
+                    }
+
                     is TextIndex -> throw IllegalArgumentException()
                     is NamedUniqueSet -> expectedIndices[it.indexName] = it.fields.toList()
+
+                    is NamedUniqueSetJankPatch -> {
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        val names = it.indexNames.split(":").map { it.trim() }
+
+                        sets.forEachIndexed { index, set ->
+                            expectedIndices[names.getOrNull(index) ?: set.joinToString("_")] = set.toList()
+                        }
+                    }
+
                     is NamedIndexSet -> expectedIndices[it.indexName] = it.fields.toList()
+
+                    is NamedIndexSetJankPatch -> {
+
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        val names = it.indexNames.split(":").map { it.trim() }
+
+                        sets.forEachIndexed { index, set ->
+                            expectedIndices[names.getOrNull(index) ?: set.joinToString("_")] = set.toList()
+                        }
+
+                    }
+
                     is NamedTextIndex -> throw IllegalArgumentException()
                 }
             }
@@ -338,13 +417,18 @@ class DynamoDbCollection<T : Any>(
                 it.billingMode(BillingMode.PAY_PER_REQUEST)
                 it.keySchema(KeySchemaElement.builder().attributeName("_id").keyType(KeyType.HASH).build())
                 val k = expectedIndices.values.flatten().toSet() + "_id"
-                it.attributeDefinitions((0 until serializer.descriptor.elementsCount).filter { serializer.descriptor.getElementName(it) in k }.mapNotNull { index ->
+                it.attributeDefinitions((0 until serializer.descriptor.elementsCount).filter {
+                    serializer.descriptor.getElementName(
+                        it
+                    ) in k
+                }.mapNotNull { index ->
                     serializer.descriptor.getElementDescriptor(index).dynamoType().scalar()?.let { t ->
-                        AttributeDefinition.builder().attributeName(serializer.descriptor.getElementName(index)).attributeType(t).build()
+                        AttributeDefinition.builder().attributeName(serializer.descriptor.getElementName(index))
+                            .attributeType(t).build()
                     }
                 })
                 it.globalSecondaryIndexes(expectedIndices.map {
-                    when(it.value.size) {
+                    when (it.value.size) {
                         1 -> GlobalSecondaryIndex.builder()
                             .indexName(tableName + "_" + it.key)
                             .keySchema(
@@ -355,6 +439,7 @@ class DynamoDbCollection<T : Any>(
                             )
                             .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
                             .build()
+
                         2 -> GlobalSecondaryIndex.builder()
                             .indexName(tableName + "_" + it.key)
                             .keySchema(
@@ -369,6 +454,7 @@ class DynamoDbCollection<T : Any>(
                             )
                             .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
                             .build()
+
                         else -> throw IllegalArgumentException("")
                     }
                 })

--- a/server-postgresql/src/main/kotlin/com/lightningkite/lightningserver/db/SerialDescriptorTable.kt
+++ b/server-postgresql/src/main/kotlin/com/lightningkite/lightningserver/db/SerialDescriptorTable.kt
@@ -57,10 +57,50 @@ class SerialDescriptorTable(name: String, val descriptor: SerialDescriptor) : Ta
                         columns = it.fields.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
                     )
 
+                    is UniqueSetJankPatch -> {
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        sets.forEach { set ->
+                            index(
+                                isUnique = true,
+                                columns = set.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
+                            )
+                        }
+                    }
+
                     is IndexSet -> index(
                         isUnique = false,
                         columns = it.fields.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
                     )
+
+                    is IndexSetJankPatch -> {
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        sets.forEach { set ->
+                            index(
+                                isUnique = true,
+                                columns = set.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
+                            )
+                        }
+                    }
 
                     is TextIndex -> {
                         // TODO
@@ -72,11 +112,59 @@ class SerialDescriptorTable(name: String, val descriptor: SerialDescriptor) : Ta
                         columns = it.fields.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
                     )
 
+                    is NamedUniqueSetJankPatch -> {
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        val names = it.indexNames.split(":").map { it.trim() }
+
+                        sets.forEachIndexed { index, set ->
+                            index(
+                                customIndexName = names.getOrNull(index),
+                                isUnique = true,
+                                columns = it.fields.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
+                            )
+                        }
+                    }
+
                     is NamedIndexSet -> index(
                         customIndexName = it.indexName,
                         isUnique = false,
                         columns = it.fields.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
                     )
+
+                    is NamedIndexSetJankPatch -> {
+
+                        val sets: MutableList<MutableList<String>> = mutableListOf()
+                        var current = mutableListOf<String>()
+                        it.fields.forEach { value ->
+                            if (value == ":") {
+                                sets.add(current)
+                                current = mutableListOf()
+                            } else {
+                                current.add(value)
+                            }
+                        }
+                        sets.add(current)
+                        val names = it.indexNames.split(":").map { it.trim() }
+
+                        sets.forEachIndexed { index, set ->
+                            index(
+                                customIndexName = names.getOrNull(index),
+                                isUnique = true,
+                                columns = it.fields.flatMap { columnsByDotPath[it.split('.')]!! }.toTypedArray()
+                            )
+                        }
+
+                    }
 
                     is NamedTextIndex -> {
                         // TODO

--- a/shared/src/main/kotlin/com/lightningkite/lightningdb/Annotations.kt
+++ b/shared/src/main/kotlin/com/lightningkite/lightningdb/Annotations.kt
@@ -138,15 +138,42 @@ annotation class TextIndex(val fields: Array<String>)
 @SerialInfo
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS)
-@Repeatable
+//@Repeatable
 annotation class IndexSet(val fields: Array<String>)
+
+// Jank patch? For what and how?
+// The problem this works around is that Repeatable annotations currently do not
+// work correct with kotlinx serialization. Only the last instance shows up.
+// To jank a patch for this, I created a second version that allows you to
+// include multiple sets by adding a delimiter, ":", into the list.
+// An example ["field1", "field2", ":", "field1", "field3"]
+// If the kotlinx issue is resolved, then this will become deprecated, and
+// repeatable added back into the normal one.
+@SerialInfo
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS)
+annotation class IndexSetJankPatch(val fields: Array<String>)
 
 
 @SerialInfo
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS)
-@Repeatable
+//@Repeatable
 annotation class UniqueSet(val fields: Array<String>)
+
+
+// Jank patch? For what and how?
+// The problem this works around is that Repeatable annotations currently do not
+// work correct with kotlinx serialization. Only the last instance shows up.
+// To jank a patch for this, I created a second version that allows you to
+// include multiple sets by adding a delimiter(":") into the list.
+// An example ["field1", "field2", ":", "field1", "field3"]
+// If the kotlinx issue is resolved, then this will become deprecated, and
+// repeatable added back into the normal one.
+@SerialInfo
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS)
+annotation class UniqueSetJankPatch(val fields: Array<String>)
 
 
 @SerialInfo
@@ -170,12 +197,40 @@ annotation class NamedTextIndex(val fields: Array<String>, val indexName: String
 @SerialInfo
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS)
-@Repeatable
+//@Repeatable
 annotation class NamedIndexSet(val fields: Array<String>, val indexName: String)
+
+
+// Jank patch? For what and how?
+// The problem this works around is that Repeatable annotations currently do not
+// work correct with kotlinx serialization. Only the last instance shows up.
+// To jank a patch for this, I created a second version that allows you to
+// include multiple sets by adding a delimiter(":") into the list and names.
+// An example ["field1", "field2", ":", "field1", "field3"], "Name 1:Name 2"
+// If the kotlinx issue is resolved, then this will become deprecated, and
+// repeatable added back into the normal one.
+@SerialInfo
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS)
+annotation class NamedIndexSetJankPatch(val fields: Array<String>, val indexNames: String)
 
 
 @SerialInfo
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS)
-@Repeatable
+//@Repeatable
 annotation class NamedUniqueSet(val fields: Array<String>, val indexName: String)
+
+
+// Jank patch? For what and how?
+// The problem this works around is that Repeatable annotations currently do not
+// work correct with kotlinx serialization. Only the last instance shows up.
+// To jank a patch for this, I created a second version that allows you to
+// include multiple sets by adding a delimiter(":") into the list.
+// An example ["field1", "field2", ":", "field1", "field3"], "Name 1:Name 2"
+// If the kotlinx issue is resolved, then this will become deprecated, and
+// repeatable added back into the normal one.
+@SerialInfo
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS)
+annotation class NamedUniqueSetJankPatch(val fields: Array<String>, val indexNames: String)


### PR DESCRIPTION
Added a janky work around for indexing with repeatable annotations not working correctly with KotlinX Serialization descriptors.