### PR TITLE
Disconnectable cold start improvements.

### DIFF
--- a/server-aws/src/main/kotlin/com/lightningkite/lightningserver/aws/AwsAdapter.kt
+++ b/server-aws/src/main/kotlin/com/lightningkite/lightningserver/aws/AwsAdapter.kt
@@ -212,6 +212,7 @@ abstract class AwsAdapter : RequestStreamHandler, Resource {
         println("Tasks.onSettingsReady() complete.")
         configureEngine
         httpMatcher
+        wsMatcher
         Core.getGlobalContext().register(this)
     }
 
@@ -227,7 +228,14 @@ abstract class AwsAdapter : RequestStreamHandler, Resource {
     }
 
     override fun afterRestore(context: org.crac.Context<out Resource>?) {
-        println("afterRestore()")
+        println("afterRestore() - opening all connections")
+        Settings.requirements.forEach { (key, value) ->
+            (value() as? Disconnectable)?.let {
+                println("Connecting $key...")
+                it.connect()
+            }
+        }
+        println("Connections Complete")
     }
 
     override fun handleRequest(input: InputStream, output: OutputStream, context: Context) {

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/core/Disconnectable.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/core/Disconnectable.kt
@@ -6,4 +6,5 @@ package com.lightningkite.lightningserver.core
  */
 interface Disconnectable {
     fun disconnect()
+    fun connect()
 }


### PR DESCRIPTION
Added wsMatcher to the Aws Adapters init block with the httpMatcher. Added a connect function to Disconnectable and made the connect call in the AwsAdapter's afterRestore. This will allow for better cold start optimizations if AWS Provisioning Concurrency is being used. But this will prevent lazy loading of these values.