### PR TITLE
Settings regex handlers

### DIFF
--- a/server-aws/src/main/kotlin/com/lightningkite/lightningserver/email/SesClient.kt
+++ b/server-aws/src/main/kotlin/com/lightningkite/lightningserver/email/SesClient.kt
@@ -44,7 +44,7 @@ class SesClient(
                         fromEmail = params["fromEmail"]?.first() ?: it.fromEmail ?: throw IllegalStateException("SES Email requires a fromEmail to be set.")
                     )
                 }
-                    ?: throw IllegalStateException("Invalid Mailgun URL. The URL should match the pattern: ses://[accessKey]:[secreteAccessKey]@[region]?[params]\nAvailable params are: fromEmail")
+                    ?: throw IllegalStateException("Invalid SES URL. The URL should match the pattern: ses://[accessKey]:[secreteAccessKey]@[region]?[params]\nAvailable params are: fromEmail")
             }
         }
     }

--- a/server-aws/src/main/kotlin/com/lightningkite/lightningserver/email/SesClient.kt
+++ b/server-aws/src/main/kotlin/com/lightningkite/lightningserver/email/SesClient.kt
@@ -29,22 +29,22 @@ class SesClient(
     companion object {
         init {
             EmailSettings.register("ses") {
-                Regex("""ses://([^:]*):([^@]*)@(.+)""").matchEntire(it.url)?.let { match ->
-                    val accessKey = match.groupValues[1]
-                    val secretAccessKey = match.groupValues[2]
-                    val region = match.groupValues[3]
+                Regex("""ses://(?<accessKey>[^:]*):(?<secretAccessKey>[^@]*)@(?<region>.+)(?:\?(?<params>.*))?""").matchEntire(it.url)?.let { match ->
+                    val accessKey = match.groups["accessKey"]!!.value
+                    val secretAccessKey = match.groups["secretAccessKey"]!!.value
+                    val params = EmailSettings.parseParameterString(match.groups["params"]?.value ?: "")
                     SesClient(
-                        region = Region.of(region),
+                        region = Region.of(match.groups["region"]!!.value),
                         credentialProvider = if (accessKey.isNotBlank() && secretAccessKey.isNotBlank()) {
                             StaticCredentialsProvider.create(object : AwsCredentials {
                                 override fun accessKeyId(): String = accessKey
                                 override fun secretAccessKey(): String = secretAccessKey
                             })
                         } else DefaultCredentialsProvider.create(),
-                        fromEmail = it.fromEmail ?: throw IllegalStateException("SES Email requires a fromEmail to be set.")
+                        fromEmail = params["fromEmail"]?.first() ?: it.fromEmail ?: throw IllegalStateException("SES Email requires a fromEmail to be set.")
                     )
                 }
-                    ?: throw IllegalStateException("Invalid Mailgun URL. The URL should match the pattern: mailgun://[key]@[domain]")
+                    ?: throw IllegalStateException("Invalid Mailgun URL. The URL should match the pattern: ses://[accessKey]:[secreteAccessKey]@[region]?[params]\nAvailable params are: fromEmail")
             }
         }
     }

--- a/server-aws/src/main/kotlin/com/lightningkite/lightningserver/files/S3FileSystem.kt
+++ b/server-aws/src/main/kotlin/com/lightningkite/lightningserver/files/S3FileSystem.kt
@@ -47,9 +47,9 @@ class S3FileSystem(
     companion object {
         init {
             FilesSettings.register("s3") {
-                Regex("""s3://(?<user>[^:]+):(?<password>[^@]+)@(?<bucket>[^.]+)\.(?<region>[^.]+)\.amazonaws.com/?""").matchEntire(it.storageUrl)?.let { match ->
-                    val user = match.groups["user"]!!.value
-                    val password = match.groups["password"]!!.value
+                Regex("""s3://(?:(?<user>[^:]+):(?<password>[^@]+)@)?(?<bucket>[^.]+)\.(?:s3-)?(?<region>[^.]+)\.amazonaws.com/?""").matchEntire(it.storageUrl)?.let { match ->
+                    val user = match.groups["user"]?.value ?: ""
+                    val password = match.groups["password"]?.value ?: ""
                     S3FileSystem(
                         Region.of(match.groups["region"]!!.value),
                         if (user.isNotBlank() && password.isNotBlank()) {

--- a/server-aws/src/main/kotlin/com/lightningkite/lightningserver/files/S3FileSystem.kt
+++ b/server-aws/src/main/kotlin/com/lightningkite/lightningserver/files/S3FileSystem.kt
@@ -47,18 +47,18 @@ class S3FileSystem(
     companion object {
         init {
             FilesSettings.register("s3") {
-                Regex("""s3://([^:]+)([^@]+)@([^.]+)\.([^.]+)\.amazonaws.com/""").matchEntire(it.storageUrl)?.let { match ->
-                    val user = match.groupValues[1]
-                    val password = match.groupValues[2]
+                Regex("""s3://(?<user>[^:]+):(?<password>[^@]+)@(?<bucket>[^.]+)\.(?<region>[^.]+)\.amazonaws.com/?""").matchEntire(it.storageUrl)?.let { match ->
+                    val user = match.groups["user"]!!.value
+                    val password = match.groups["password"]!!.value
                     S3FileSystem(
-                        Region.of(match.groupValues[4]),
+                        Region.of(match.groups["region"]!!.value),
                         if (user.isNotBlank() && password.isNotBlank()) {
                             StaticCredentialsProvider.create(object : AwsCredentials {
                                 override fun accessKeyId(): String = user
                                 override fun secretAccessKey(): String = password
                             })
                         } else DefaultCredentialsProvider.create(),
-                        match.groupValues[3],
+                        match.groups["bucket"]!!.value,
                         it.signedUrlExpiration?.toSeconds()?.toInt()
                     )
                 }

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/db/DatabaseSettings.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/db/DatabaseSettings.kt
@@ -35,11 +35,8 @@ data class DatabaseSettings(
             register("ram-preload") {
                 InMemoryDatabase(
                     Serialization.Internal.json.parseToJsonElement(
-                        File(
-                            it.url.substringAfter(
-                                "://"
-                            )
-                        ).readText()
+                        File(it.url.substringAfter("://"))
+                            .readText()
                     ) as? JsonObject
                 )
             }

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/email/EmailSettings.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/email/EmailSettings.kt
@@ -33,8 +33,9 @@ data class EmailSettings(
                     ?: throw IllegalStateException("Invalid Mailgun URL. The URL should match the pattern: mailgun://[key]@[domain]")
             }
             EmailSettings.register("smtp") {
-                Regex("""smtp://(?<username>[^:]+):(?<password>[^@]+)@(?<host>[^:]+):(?<port>[0-9]+)""").matchEntire(it.url)?.let { match ->
+                Regex("""smtp://(?<username>[^:]+):(?<password>[^@]+)@(?<host>[^:]+):(?<port>[0-9]+)(?:\?(?<params>.*))?""").matchEntire(it.url)?.let { match ->
                     val port = match.groups["port"]!!.value.toInt()
+                    val params = EmailSettings.parseParameterString(match.groups["params"]?.value ?: "")
                     SmtpEmailClient(
                         SmtpConfig(
                             hostName = match.groups["host"]!!.value,
@@ -42,11 +43,11 @@ data class EmailSettings(
                             username = match.groups["username"]!!.value,
                             password = match.groups["password"]!!.value,
                             useSSL = port != 25,
-                            fromEmail = it.fromEmail ?: throw IllegalStateException("SMTP Email requires a fromEmail to be set.")
+                            fromEmail = params["fromEmail"]?.first() ?: it.fromEmail ?: throw IllegalStateException("SMTP Email requires a fromEmail to be set.")
                         )
                     )
                 }
-                    ?: throw IllegalStateException("Invalid SMTP URL. The URL should match the pattern: smtp://[username]:[password]@[host]:[port]")
+                    ?: throw IllegalStateException("Invalid SMTP URL. The URL should match the pattern: smtp://[username]:[password]@[host]:[port]?[params]\nAvailable params are: fromEmail")
             }
         }
     }

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/email/EmailSettings.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/email/EmailSettings.kt
@@ -24,29 +24,29 @@ data class EmailSettings(
         init {
             EmailSettings.register("console") { ConsoleEmailClient }
             EmailSettings.register("mailgun") {
-                Regex("""mailgun://([^@]+)@(.+)""").matchEntire(it.url)?.let { match ->
+                Regex("""mailgun://(?<key>[^@]+)@(?<domain>.+)""").matchEntire(it.url)?.let { match ->
                     MailgunEmailClient(
-                        match.groupValues[1],
-                        match.groupValues[2]
+                        match.groups["key"]!!.value,
+                        match.groups["domain"]!!.value
                     )
                 }
                     ?: throw IllegalStateException("Invalid Mailgun URL. The URL should match the pattern: mailgun://[key]@[domain]")
             }
             EmailSettings.register("smtp") {
-                Regex("""smtp://([^:]+):([^@]+)@(.+)""").matchEntire(it.url)?.let { match ->
-                    val port = match.groupValues[4].takeIf { it.isNotBlank() }?.toIntOrNull() ?: 22
+                Regex("""smtp://(?<username>[^:]+):(?<password>[^@]+)@(?<host>[^:]+):(?<port>[0-9]+)""").matchEntire(it.url)?.let { match ->
+                    val port = match.groups["port"]!!.value.toInt()
                     SmtpEmailClient(
                         SmtpConfig(
-                            hostName = match.groupValues[3],
+                            hostName = match.groups["host"]!!.value,
                             port = port,
-                            username = match.groupValues[1],
-                            password = match.groupValues[2],
+                            username = match.groups["username"]!!.value,
+                            password = match.groups["password"]!!.value,
                             useSSL = port != 25,
                             fromEmail = it.fromEmail ?: throw IllegalStateException("SMTP Email requires a fromEmail to be set.")
                         )
                     )
                 }
-                    ?: throw IllegalStateException("Invalid SMTP URL. The URL should match the pattern: smtp://[username]:[password]@[host]:[port(Optional)]")
+                    ?: throw IllegalStateException("Invalid SMTP URL. The URL should match the pattern: smtp://[username]:[password]@[host]:[port]")
             }
         }
     }

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/files/FilesSettings.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/files/FilesSettings.kt
@@ -1,4 +1,5 @@
 @file:UseContextualSerialization(Duration::class)
+
 package com.lightningkite.lightningserver.files
 
 import com.lightningkite.lightningserver.auth.JwtSigner
@@ -27,15 +28,15 @@ data class FilesSettings(
     companion object : Pluggable<FilesSettings, FileSystem>() {
         init {
             register("file") {
-                val regex = Regex("""file://([^|]+)(?:\|(.+))?""")
-                regex.matchEntire(it.storageUrl)?.let { match ->
+                Regex("""file://(?<folderPath>[^|]+)(?:\|(?<servePath>.+))?""").matchEntire(it.storageUrl)?.let { match ->
                     LocalFileSystem(
-                        rootFile = File(match.groupValues[1]),
-                        serveDirectory = match.groupValues[2].takeUnless { it.isEmpty() } ?: "uploaded-files",
+                        rootFile = File(match.groups["folderPath"]!!.value),
+                        serveDirectory = match.groups["servePath"]?.value?.takeUnless { it.isEmpty() } ?: "uploaded-files",
                         signedUrlExpiration = it.signedUrlExpiration,
                         signer = it.jwtSigner
                     )
-                } ?: throw IllegalStateException("Invalid Local File storageUrl. It must follow the pattern: file:://[Path To Folder](|[Serve Directory] Optional)")
+                }
+                    ?: throw IllegalStateException("Invalid Local File storageUrl. It must follow the pattern: file:://[folderPath]|[servePath]\nServe Directory is Optional and will default to \"uploaded-files\"")
             }
         }
     }

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/settings/Pluggable.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/settings/Pluggable.kt
@@ -1,13 +1,27 @@
 package com.lightningkite.lightningserver.settings
 
 abstract class Pluggable<S, T> {
-    private val handlers = HashMap<String, (S)->T>()
+    private val handlers = HashMap<String, (S) -> T>()
     val options: Set<String> get() = handlers.keys
-    fun register(key: String, handler: (S)->T) {
+    fun register(key: String, handler: (S) -> T) {
         handlers[key] = handler
     }
+
     fun parse(key: String, setting: S): T {
-        val h = handlers[key] ?: throw IllegalArgumentException("No handler $key for ${this::class.qualifiedName} - available handlers are ${options.joinToString()}")
+        val h = handlers[key]
+            ?: throw IllegalArgumentException("No handler $key for ${this::class.qualifiedName} - available handlers are ${options.joinToString()}")
         return h(setting)
     }
+
+    fun parseParameterString(params: String): Map<String, List<String>> = params
+        .takeIf { it.isNotBlank() }
+        ?.split("&")
+        ?.filter { it.isNotBlank() }
+        ?.map {
+            val split = it.split('=')
+            split[0] to split[1]
+        }
+        ?.groupBy { it.first.lowercase() }
+        ?.mapValues { it.value.map { it.second } }
+        ?: emptyMap()
 }

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/settings/Pluggable.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/settings/Pluggable.kt
@@ -21,7 +21,7 @@ abstract class Pluggable<S, T> {
             val split = it.split('=')
             split[0] to split[1]
         }
-        ?.groupBy { it.first.lowercase() }
+        ?.groupBy { it.first }
         ?.mapValues { it.value.map { it.second } }
         ?: emptyMap()
 }

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/sms/SMSSettings.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/sms/SMSSettings.kt
@@ -14,11 +14,11 @@ data class SMSSettings(
             SMSSettings.register("console") { ConsoleSMSClient }
             SMSSettings.register("twilio") {
 
-                Regex("""mailgun://([^:]+)([^@]+)@(.+)""").matchEntire(it.url)?.let { match ->
+                Regex("""twilio://(?<user>[^:]+):(?<password>[^@]+)(?:@(?<phoneNumber>.+))?""").matchEntire(it.url)?.let { match ->
                     TwilioSMSClient(
-                        match.groupValues[1],
-                        match.groupValues[2],
-                        (it.from ?: match.groupValues[3])
+                        match.groups["user"]!!.value,
+                        match.groups["password"]!!.value,
+                        (it.from ?: match.groups["phoneNumber"]?.value ?: throw IllegalStateException("Twilio Phone Number not provided."))
                     )
                 }
                     ?: throw IllegalStateException("Invalid Twilio Url. The URL should match the pattern: twilio://[user]:[password]@[phoneNumber]")

--- a/server-dynamodb/src/main/kotlin/com/lightningkite/lightningserver/db/DynamoDbCache.kt
+++ b/server-dynamodb/src/main/kotlin/com/lightningkite/lightningserver/db/DynamoDbCache.kt
@@ -20,9 +20,9 @@ class DynamoDbCache(val makeClient: () -> DynamoDbAsyncClient, val tableName: St
     companion object {
         init {
             CacheSettings.register("dynamodb") {
-                Regex("""dynamodb://(?<access>[^:]+):(?<secret>[^@]+)@(?<region>[^/]+)/(?<tableName>.+)""").matchEntire(it.url)?.let { match ->
-                    val user = match.groups["access"]!!.value
-                    val password = match.groups["secret"]!!.value
+                Regex("""dynamodb://(?:(?<access>[^:]+):(?<secret>[^@]+)@)?(?<region>[^/]+)/(?<tableName>.+)""").matchEntire(it.url)?.let { match ->
+                    val user = match.groups["access"]?.value ?: ""
+                    val password = match.groups["secret"]?.value ?: ""
                     DynamoDbCache(
                         {
                             DynamoDbAsyncClient.builder()
@@ -40,7 +40,7 @@ class DynamoDbCache(val makeClient: () -> DynamoDbAsyncClient, val tableName: St
                         match.groups["tableName"]!!.value
                     )
                 }
-                    ?: throw IllegalStateException("Invalid S3 storageUrl. The URL should match the pattern: dynamodb://[access]:[secret]@[region]/[tableName]")
+                    ?: throw IllegalStateException("Invalid dynamodb URL. The URL should match the pattern: dynamodb://[access]:[secret]@[region]/[tableName]")
             }
         }
     }

--- a/server-postgresql/src/main/kotlin/com/lightningkite/lightningserver/db/PostgresDatabase.kt
+++ b/server-postgresql/src/main/kotlin/com/lightningkite/lightningserver/db/PostgresDatabase.kt
@@ -11,13 +11,14 @@ class PostgresDatabase(val db: Database) : com.lightningkite.lightningdb.Databas
         init {
             // postgresql://user:password@endpoint/database
             DatabaseSettings.register("postgresql") {
-                Regex("""postgresql://([^:]*)([^@]*)@(.+)""").matchEntire(it.url)?.let { match ->
-                    val user = match.groupValues[1]
-                    val password = match.groupValues[2]
+                Regex("""postgresql://(?<user>[^:]*)(?<password>[^@]*)@(?<destination>.+)""").matchEntire(it.url)?.let { match ->
+                    val user = match.groups["user"]!!.value
+                    val password = match.groups["password"]!!.value
+                    val destination = match.groups["destination"]!!.value
                     if (user.isNotBlank() && password.isNotBlank())
                         PostgresDatabase(
                             Database.connect(
-                                "jdbc:postgresql://${match.groupValues[3]}",
+                                "jdbc:postgresql://$destination",
                                 "org.postgresql.Driver",
                                 user,
                                 password
@@ -26,7 +27,7 @@ class PostgresDatabase(val db: Database) : com.lightningkite.lightningdb.Databas
                     else
                         PostgresDatabase(
                             Database.connect(
-                                "jdbc:postgresql://${match.groupValues[3]}",
+                                "jdbc:postgresql://$destination",
                                 "org.postgresql.Driver"
                             )
                         )

--- a/server-sftp/src/main/kotlin/com/lightningkite/lightningserver/files/Sftp.kt
+++ b/server-sftp/src/main/kotlin/com/lightningkite/lightningserver/files/Sftp.kt
@@ -42,7 +42,7 @@ class Sftp(
                         }
                     }
                 }
-                    ?: throw IllegalStateException("Invalid S3 storageUrl. The URL should match the pattern: sftp://[user]@[host]:[port]/[path]?[params]\nParams available are: host, identity.")
+                    ?: throw IllegalStateException("Invalid sftp storageUrl. The URL should match the pattern: sftp://[user]@[host]:[port]/[path]?[params]\nParams available are: host, identity.")
             }
         }
     }

--- a/server-sftp/src/main/kotlin/com/lightningkite/lightningserver/files/Sftp.kt
+++ b/server-sftp/src/main/kotlin/com/lightningkite/lightningserver/files/Sftp.kt
@@ -31,28 +31,26 @@ class Sftp(
     companion object {
         init {
             FilesSettings.register("sftp") { settings ->
-                val postScheme = settings.storageUrl.substringAfter("://")
-                val userAndHost = postScheme.substringBefore("/")
-                val user = userAndHost.substringBefore('@', "ubuntu")
-                val hostWithPort = userAndHost.substringAfter('@')
-                val host = hostWithPort.substringBefore(':')
-                val port = hostWithPort.substringAfter(':', "22").toInt()
-                val rootPath = postScheme.substringAfter('/').substringBefore('?')
-                val params = postScheme.substringAfter('/').substringAfter('?').split('&')
-                    .associate { it.substringBefore('=') to it.substringAfter('=', "true") }
-                Sftp(host, port, rootPath) {
-                    SSHClient().apply {
-                        params["host"]?.let { addHostKeyVerifier(it) } ?: addHostKeyVerifier(PromiscuousVerifier())
-                        connect(host, port)
-                        val id = params["identity"]!!
-                        val pk = buildString {
-                            appendLine("-----BEGIN OPENSSH PRIVATE KEY-----")
-                            id.chunked(70).forEach { l -> appendLine(l) }
-                            appendLine("-----END OPENSSH PRIVATE KEY-----")
+                Regex("""sftp://([^@]+)@([^:]+):([0-9]+)(?:/([^?]*))?(?:\?(.*))?""").matchEntire(settings.storageUrl)?.let { match ->
+                    val host = match.groupValues[2]
+                    val port = match.groupValues[3].toInt()
+                    val params: Map<String, List<String>> = FilesSettings.parseParameterString(match.groupValues[5])
+
+                    Sftp(host, port, match.groupValues[4]) {
+                        SSHClient().apply {
+                            params["host"]?.let { addHostKeyVerifier(it.first()) } ?: addHostKeyVerifier(PromiscuousVerifier())
+                            connect(host, port)
+                            val id = params["identity"]!!
+                            val pk = buildString {
+                                appendLine("-----BEGIN OPENSSH PRIVATE KEY-----")
+                                id.chunked(70).forEach { l -> appendLine(l) }
+                                appendLine("-----END OPENSSH PRIVATE KEY-----")
+                            }
+                            authPublickey(match.groupValues[1], loadKeys(pk, null, null))
                         }
-                        authPublickey(user, loadKeys(pk, null, null))
                     }
                 }
+                    ?: throw IllegalStateException("Invalid S3 storageUrl. The URL should match the pattern: sftp://[user]@[host]:[port]/[path]?[params]\nParams available are: host, identity.")
             }
         }
     }


### PR DESCRIPTION
Updated Setting URL parses to use Regex. This allows for better error handling because we know immediately if the URL format is incorrect, or have vital pieces missing and in the exception provide a proper example of how the URL should be formatted.  This also moved the complications of pulling parts out into the regex pattern, which can be complicated as well, but it's all in one place. This makes adding params to the url much easier, and I added a function to parse a param string into a easy to use map.
I was able to successfully test SesClient, S3FileSystem, SMTP, LocalFiles, DynamoDBCache, and Twilio. I DID NOT TEST MailGun, PostgresDatabase, and SFTP.