### PR TITLE
Kotliner CLI dependency Removal.

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     api(project(":server"))
     ksp(project(":processor"))
+    implementation("com.lightningkite:kotliner-cli:1.0.3")
     implementation("io.ktor:ktor-server-call-logging:2.1.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
     testImplementation(project(":client"))

--- a/server-core/build.gradle.kts
+++ b/server-core/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
 
     implementation("ch.qos.logback:logback-classic:$logBack")
 
-    api("com.lightningkite:kotliner-cli:1.0.3")
     implementation("com.lightningkite.khrysalis:jvm-runtime:$khrysalisVersion")
 
     api("io.ktor:ktor-client-content-negotiation:$ktorVersion")

--- a/server-core/src/main/kotlin/com/lightningkite/lightningdb/Flow.ext.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningdb/Flow.ext.kt
@@ -18,5 +18,5 @@ suspend inline fun <Model> Flow<Model>.collectChunked(chunkSize: Int, crossinlin
             list.clear()
         }
     }
-    action(list)
+    if(list.isNotEmpty()) action(list)
 }

--- a/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/SimpleSignals.kt
+++ b/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/SimpleSignals.kt
@@ -13,7 +13,7 @@ import kotlin.test.fail
 
 class SimpleSignals {
 
-    lateinit var collection: FieldCollection<TempThing>
+    lateinit var collection: InMemoryFieldCollection<TempThing>
     val thing1 = TempThing(1)
     val thing2 = TempThing(2)
     val thing3 = TempThing(3)
@@ -27,7 +27,8 @@ class SimpleSignals {
     fun setup() {
         prepareModels()
         com.lightningkite.lightningserver.db.testmodels.prepareModels()
-        collection = TestSettings.database().collection<TempThing>()
+        collection = TestSettings.database().collection<TempThing>() as InMemoryFieldCollection
+        collection.drop()
     }
 
     @Test

--- a/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestAbstractSignalFieldCollection.kt
+++ b/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestAbstractSignalFieldCollection.kt
@@ -23,6 +23,7 @@ class TestAbstractSignalFieldCollection {
         prepareModels()
         com.lightningkite.lightningserver.db.testmodels.prepareModels()
         collection = TestSettings.database().collection<TempThing>() as InMemoryFieldCollection
+        collection.drop()
         collection.signals.clear()
     }
 

--- a/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestAbstractSignalFieldCollection.kt
+++ b/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestAbstractSignalFieldCollection.kt
@@ -4,14 +4,13 @@ import com.lightningkite.lightningdb.*
 import com.lightningkite.lightningserver.TestSettings
 import com.lightningkite.lightningserver.db.testmodels.TempThing
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.Serializable
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class AbstractSignalFieldCollectionTest {
+class TestAbstractSignalFieldCollection {
 
     lateinit var collection: InMemoryFieldCollection<TempThing>
     val thing1 = TempThing(1)

--- a/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestFieldCollectionExtensions.kt
+++ b/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestFieldCollectionExtensions.kt
@@ -1,0 +1,42 @@
+package com.lightningkite.lightningserver.db
+
+import com.lightningkite.lightningdb.*
+import com.lightningkite.lightningserver.TestSettings
+import com.lightningkite.lightningserver.db.testmodels.TempThing
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestFieldCollectionExtensions {
+
+    lateinit var collection: FieldCollection<TempThing>
+
+    @Before
+    fun setup() {
+        prepareModels()
+        com.lightningkite.lightningserver.db.testmodels.prepareModels()
+        collection = TestSettings.database().collection<TempThing>()
+    }
+
+    @Test
+    fun testAll():Unit = runBlocking {
+
+        collection.insertMany(0.until(100).toList().map { TempThing(it) })
+
+        assertEquals(100, collection.all().count())
+
+        var results = collection.all().toList()
+        repeat(100){
+            assertEquals(it, results[it]._id)
+        }
+
+        collection.insertOne(TempThing(1))
+        assertEquals(101, collection.all().count())
+        results = collection.all().toList()
+        assertEquals(1, results[100]._id)
+    }
+
+}

--- a/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestFieldCollectionExtensions.kt
+++ b/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestFieldCollectionExtensions.kt
@@ -12,19 +12,20 @@ import kotlin.test.assertEquals
 
 class TestFieldCollectionExtensions {
 
-    lateinit var collection: FieldCollection<TempThing>
+    lateinit var collection: InMemoryFieldCollection<TempThing>
 
     @Before
     fun setup() {
         prepareModels()
         com.lightningkite.lightningserver.db.testmodels.prepareModels()
-        collection = TestSettings.database().collection<TempThing>()
+        collection = TestSettings.database().collection<TempThing>() as InMemoryFieldCollection
+        collection.drop()
     }
 
     @Test
     fun testAll():Unit = runBlocking {
 
-        collection.insertMany(0.until(100).toList().map { TempThing(it) })
+        collection.insertMany((0 until 100).toList().map { TempThing(it) })
 
         assertEquals(100, collection.all().count())
 

--- a/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestFlowExtensions.kt
+++ b/server-core/src/test/kotlin/com/lightningkite/lightningserver/db/TestFlowExtensions.kt
@@ -1,0 +1,43 @@
+package com.lightningkite.lightningserver.db
+
+import com.lightningkite.lightningdb.collectChunked
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestFlowExtensions {
+
+    @Test
+    fun testCollectChunked():Unit = runBlocking {
+
+        var flow: Flow<Int> = flowOf(*0.until(100).toList().toTypedArray())
+
+        var count = 0
+        var emmitted = mutableListOf<Int>()
+
+        flow.collectChunked(10){items ->
+            count++
+            assertEquals(10, items.size)
+            emmitted.addAll(items)
+        }
+        assertEquals(10, count)
+        repeat(100){
+            assertEquals(it, emmitted[it])
+        }
+
+        flow = flowOf(1,2,3)
+        count = 0
+        emmitted = mutableListOf()
+        flow.collectChunked(10){items ->
+            count++
+            assertEquals(3, items.size)
+            emmitted.addAll(items)
+        }
+        assertEquals(1, count)
+        assertEquals(listOf(1,2,3), emmitted)
+    }
+
+
+}


### PR DESCRIPTION
Few tests added. Removed KotlinerCli from core dependencies.

This will likely break all projects relying on LightningServer. The projects will need to import KotlinerCli themselves