### PR TITLE
making second value case insensitive in evaluate condition

### DIFF
--- a/web-alt/src/Condition.ts
+++ b/web-alt/src/Condition.ts
@@ -86,7 +86,7 @@ export function evaluateCondition<T>(condition: Condition<T>, model: T): boolean
                 ignoreCase: boolean;
             }
             if (v.ignoreCase)
-                return ((model as unknown as string).toLowerCase().indexOf(v.value) !== -1)
+                return ((model as unknown as string).toLowerCase().indexOf(v.value.toLowerCase()) !== -1)
             else
                 return ((model as unknown as string).indexOf(v.value) !== -1)
         case "FullTextSearch":
@@ -95,7 +95,7 @@ export function evaluateCondition<T>(condition: Condition<T>, model: T): boolean
                 ignoreCase: boolean;
             }
             if (v2.ignoreCase)
-                return ((model as unknown as string).toLowerCase().indexOf(v2.value) !== -1)
+                return ((model as unknown as string).toLowerCase().indexOf(v2.value.toLowerCase()) !== -1)
             else
                 return ((model as unknown as string).indexOf(v2.value) !== -1)
         case "IntBitsClear":


### PR DESCRIPTION
When doing a case insensitive text search, it will not make what you are searching by case insensitive.

Example:



```
searchable items: ["foo", bar"]
{StringContains: {value: "FOO", ignoreCase: true}}
```
This currently returns an empty list. This pr will make it so it returns ["foo"]
