### PR TITLE
Update aws terraform provider versions

### DIFF
--- a/server-aws/src/main/kotlin/com/lightningkite/lightningserver/aws/terraform/TerraformProvider.kt
+++ b/server-aws/src/main/kotlin/com/lightningkite/lightningserver/aws/terraform/TerraformProvider.kt
@@ -6,11 +6,11 @@ internal data class TerraformProvider(
     val version: String,
 ) {
     companion object {
-        val aws = TerraformProvider("aws", "hashicorp/aws", "~> 4.30")
-        val random = TerraformProvider("random", "hashicorp/random", "~> 3.1.0")
-        val archive = TerraformProvider("archive", "hashicorp/archive", "~> 2.2.0")
-        val mongodbatlas = TerraformProvider("mongodbatlas", "mongodb/mongodbatlas", "~> 1.4")
-        val local = TerraformProvider("local", "hashicorp/local", "~> 2.2")
-        val nullProvider = TerraformProvider("null", "hashicorp/null", "~> 3.2")
+        val aws = TerraformProvider("aws", "hashicorp/aws", "~> 5.89.0")
+        val random = TerraformProvider("random", "hashicorp/random", "~> 3.7.1")
+        val archive = TerraformProvider("archive", "hashicorp/archive", "~> 2.7.0")
+        val mongodbatlas = TerraformProvider("mongodbatlas", "mongodb/mongodbatlas", "~> 1.28.0")
+        val local = TerraformProvider("local", "hashicorp/local", "~> 2.5.2")
+        val nullProvider = TerraformProvider("null", "hashicorp/null", "~> 3.2.3")
     }
 }


### PR DESCRIPTION
Updated the providers to the most recent versions. I have confirmed there are no breaks to the current terraform, and deploying an existing project with the new providers will also work without issue. You will need to run "init --upgrade" to an existing project after this update.