### PR TITLE
Version 4 reauth

### DIFF
--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/proof/WebAuthNProofEndpoints.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/proof/WebAuthNProofEndpoints.kt
@@ -18,6 +18,7 @@ import com.lightningkite.lightningdb.updateRestrictions
 import com.lightningkite.lightningserver.auth.Authentication
 import com.lightningkite.lightningserver.auth.Authentication.ProofMethod
 import com.lightningkite.lightningserver.auth.accepts
+import com.lightningkite.lightningserver.auth.anyAuth
 import com.lightningkite.lightningserver.auth.anyAuthRoot
 import com.lightningkite.lightningserver.auth.idString
 import com.lightningkite.lightningserver.auth.noAuth
@@ -67,8 +68,9 @@ import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
-class WebAuthNProofEndpoints<USER : HasId<*>>(
+class WebAuthNProofEndpoints(
     path: ServerPath,
     val database: () -> Database,
     val cache: () -> Cache,
@@ -76,8 +78,8 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
     val challengeLength: Int = 64,
     val expiration: Duration = 5.minutes,
     val rpId: String,
-    val registrationForUser: (USER, WebAuthN.GeneralPreference) -> WebAuthN.Registration.RegistrationOptions,
-    val proveOptions: (USER?) -> WebAuthN.Authentication.ProveOptions = { WebAuthN.Authentication.ProveOptions() },
+    val registrationForUser: (HasId<*>, WebAuthN.GeneralPreference) -> WebAuthN.Registration.RegistrationOptions,
+    val proveOptions: (String?) -> WebAuthN.Authentication.ProveOptions = { WebAuthN.Authentication.ProveOptions() },
 ) : ServerPathGroup(path), ProofMethod {
 
     init {
@@ -200,7 +202,7 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
         implementation = { residentKeyPreference: WebAuthN.GeneralPreference ->
 
             @Suppress("UNCHECKED_CAST")
-            val options = registrationForUser(auth.get() as USER, residentKeyPreference)
+            val options = registrationForUser(auth.get(), residentKeyPreference)
 
             val challenge = generate()
             val key = UUID.random().toString()
@@ -322,12 +324,13 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
     )
 
 
-    // At this point, the subject need not identify themselves. This is because the Public Key Credential that the client
-    // authenticator uses to sign the challenge will be used in the "prove" step to determine the subject
-    // that is signing in.
+    // The user may or may not identify themselves. If they do not, they expect their authenticator to have discoverable
+    // keys. If they do, then we must return the subjects existing credential IDs. If a user hits this endpoint WITH
+    // authentication, then they are re-authenticating, and we will return the existing credential ids regardless of
+    // identity provided.
     val start = path("start").post.api(
         belongsToInterface = proveInterface,
-        authOptions = noAuth,
+        authOptions = anyAuth + noAuth,
         summary = "Begin WebAuthN challenge",
         description = "Returns a challenge to be passed on to a client authenticator for signing.",
         errorCases = listOf(),
@@ -339,19 +342,26 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
             if (handler == null)
                 throw BadRequestException("Invalid Subject Type")
 
-            val (existingCreds: List<WebAuthN.ExistingCredential>, subject: USER?) = subjectId?.let { id ->
-                @Suppress("UNCHECKED_CAST")
-                val subject = handler.findUser("${subjectType}/_id", id) as? USER
-
-                val creds = userCredentials(subjectId = id, subjectType = subjectType)
-
-                creds to subject
+            if(authOrNull != null && subjectId != null && authOrNull.idString != subjectId){
+                return@api WebAuthN.Authentication.StartResponse(
+                    challengeId = UUID.random().toString(),
+                    options = WebAuthN.Authentication.PublicKeyCredentialRequestOptions(
+                        allowCredentials = emptyList(),
+                        challenge = generate(),
+                        extensions = WebAuthN.Authentication.RequestExtensions(),
+                        hints = emptyList(),
+                        rpId = rpId,
+                        timeout = expiration.inWholeMilliseconds.toInt(),
+                        userVerification = WebAuthN.GeneralPreference.Required,
+                    )
+                )
             }
-                ?: (emptyList<WebAuthN.ExistingCredential>() to null)
 
+            val existingCreds = (subjectId ?: authOrNull?.idString)
+                ?.let{ userCredentials(subjectId = it, subjectType = subjectType) }
+                ?: emptyList()
 
-            @Suppress("UNCHECKED_CAST")
-            val options = proveOptions(subject)
+            val options = proveOptions(subjectId)
 
             val challenge = generate()
             val key = UUID.random().toString()

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/proof/WebAuthNProofEndpoints.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/proof/WebAuthNProofEndpoints.kt
@@ -15,7 +15,6 @@ import com.lightningkite.lightningdb.modification
 import com.lightningkite.lightningdb.or
 import com.lightningkite.lightningdb.updateOneById
 import com.lightningkite.lightningdb.updateRestrictions
-import com.lightningkite.lightningserver.auth.AuthOptions
 import com.lightningkite.lightningserver.auth.Authentication
 import com.lightningkite.lightningserver.auth.Authentication.ProofMethod
 import com.lightningkite.lightningserver.auth.accepts
@@ -77,7 +76,6 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
     val challengeLength: Int = 64,
     val expiration: Duration = 5.minutes,
     val rpId: String,
-    val authOptions: AuthOptions<USER>,
     val registrationForUser: (USER, WebAuthN.GeneralPreference) -> WebAuthN.Registration.RegistrationOptions,
     val proveOptions: (USER?) -> WebAuthN.Authentication.ProveOptions = { WebAuthN.Authentication.ProveOptions() },
 ) : ServerPathGroup(path), ProofMethod {
@@ -193,7 +191,7 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
     @OptIn(ExperimentalEncodingApi::class)
     val registerStart = path("register-start").post.api(
         belongsToInterface = registerInterface,
-        authOptions = authOptions,
+        authOptions = anyAuthRoot,
         summary = "Issue WebAuthN creation challenge",
         description = "Returns a challenge to be passed on to a client authenticator for the creation of a new Public Key Credential.",
         errorCases = listOf(),
@@ -201,7 +199,8 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
         successCode = HttpStatus.OK,
         implementation = { residentKeyPreference: WebAuthN.GeneralPreference ->
 
-            val options = registrationForUser(auth.get(), residentKeyPreference)
+            @Suppress("UNCHECKED_CAST")
+            val options = registrationForUser(auth.get() as USER, residentKeyPreference)
 
             val challenge = generate()
             val key = UUID.random().toString()
@@ -243,7 +242,7 @@ class WebAuthNProofEndpoints<USER : HasId<*>>(
     @OptIn(ExperimentalEncodingApi::class)
     val registerFinish = path("register-finish").post.api(
         belongsToInterface = registerInterface,
-        authOptions = authOptions,
+        authOptions = anyAuthRoot,
         summary = "Establish WebAuthN Credential",
         description = "Validates and Accepts a public key credential created from a previously issued creation challenge.",
         errorCases = listOf(),

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/subject/AuthEndpointsForSubject.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/subject/AuthEndpointsForSubject.kt
@@ -351,26 +351,38 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
         }
     )
 
-    val availableProofs = path("available-proofs").get.api(
+    val authRequirements = path("auth-requirements").get.api(
         belongsToInterface = authInterface,
         authOptions = AuthOptions<SUBJECT>(setOf(AuthOption(handler.authType))),
         inputType = Unit.serializer(),
-        outputType = ListSerializer(ProofOption.serializer()),
-        summary = "Available Proofs",
-        description = "Returns a list of proof options for the user to use in re-authenticating.",
+        outputType = AuthRequirements.serializer(),
+        summary = "Authentication Requirements",
+        description = "Returns a required strength and a list of proof options for the user to use in re-authenticating.",
         errorCases = listOf(),
         implementation = { _: Unit ->
             val subject = auth.get()
-            handler.proofMethods
+
+            val proofMethods = handler.proofMethods
                 .filter { it.established(handler, subject) }
-                .map {
-                    ProofOption(
-                        method = it.info,
-                        value = it.info.property?.let { p ->
-                            handler.get(subject, p)
-                        }
-                    )
-                }
+
+            val maxStrengthPossible =
+                proofMethods.groupBy { it.info.property }.values.sumOf { it.maxOf { it.info.strength } }
+
+            val actStrenReq = min(handler.desiredStrengthFor(subject), maxStrengthPossible)
+
+            AuthRequirements(
+                handler.proofMethods
+                    .filter { it.established(handler, subject) }
+                    .map {
+                        ProofOption(
+                            method = it.info,
+                            value = it.info.property?.let { p ->
+                                handler.get(subject, p)
+                            }
+                        )
+                    },
+                actStrenReq
+            )
         }
     )
 

--- a/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/subject/AuthEndpointsForSubject.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningserver/auth/subject/AuthEndpointsForSubject.kt
@@ -67,7 +67,11 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
     private val sessionSerializer = Session.serializer(handler.subjectSerializer, handler.idSerializer)
     private val dataClassPath = DataClassPathSelf(sessionSerializer)
     val unauthInterface = Documentable.InterfaceInfo(path, "UserAuthClientEndpoints", listOf(handler.idSerializer))
-    val authInterface = Documentable.InterfaceInfo(path, "AuthenticatedUserAuthClientEndpoints", listOf(handler.subjectSerializer, handler.idSerializer))
+    val authInterface = Documentable.InterfaceInfo(
+        path,
+        "AuthenticatedUserAuthClientEndpoints",
+        listOf(handler.subjectSerializer, handler.idSerializer)
+    )
 
     val sessionInfo = modelInfo<HasId<*>?, Session<SUBJECT, ID>, UUID>(
         modelName = "${handler.name}Session",
@@ -132,7 +136,12 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
         // TODO: Read JWT from query params, remove and redirect
         val token =
             request.headers[HttpHeader.Authorization]?.removePrefix("bearer ")?.removePrefix("Bearer ")
-                ?: request.queryParameters.find { it.first.equals(HttpHeader.Authorization, true) }?.second?.replace(' ', '+')
+                ?: request.queryParameters.find {
+                    it.first.equals(
+                        HttpHeader.Authorization,
+                        true
+                    )
+                }?.second?.replace(' ', '+')
                 ?: request.queryParameters.find { it.first == "jwt" }?.second?.replace(' ', '+')
                 ?: request.headers.cookies[HttpHeader.Authorization]
                 ?: return null
@@ -140,28 +149,35 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
     }
 
     fun presignToken(forSession: Session<SUBJECT, ID>, requirements: RequestRequirements): String {
-        return tokenFormat().create(handler, RequestAuth(
-            subject = handler,
-            sessionId = forSession._id,
-            rawId = forSession.subjectId,
-            issuedAt = now(),
-            scopes = forSession.scopes,
-            fromMasquerade = null,
-            requirements = requirements
-        ))
+        return tokenFormat().create(
+            handler, RequestAuth(
+                subject = handler,
+                sessionId = forSession._id,
+                rawId = forSession.subjectId,
+                issuedAt = now(),
+                scopes = forSession.scopes,
+                fromMasquerade = null,
+                requirements = requirements
+            )
+        )
     }
+
     fun presignToken(forId: ID, requirements: RequestRequirements): String {
-        return tokenFormat().create(handler, RequestAuth(
-            subject = handler,
-            sessionId = null,
-            rawId = forId,
-            issuedAt = now(),
-            requirements = requirements
-        ))
+        return tokenFormat().create(
+            handler, RequestAuth(
+                subject = handler,
+                sessionId = null,
+                rawId = forId,
+                issuedAt = now(),
+                requirements = requirements
+            )
+        )
     }
+
     fun presign(request: RequestRequirements, forSession: Session<SUBJECT, ID>): String {
         return "${request.pathPlusQueryParametersAnd}${HttpHeader.Authorization}=${presignToken(forSession, request)}"
     }
+
     fun presign(request: RequestRequirements, forId: ID): String {
         return "${request.pathPlusQueryParametersAnd}${HttpHeader.Authorization}=${presignToken(forId, request)}"
     }
@@ -264,14 +280,14 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
                     id = it.id,
                     options = it.options,
                     strengthRequired = it.strengthRequired,
-                    session = if(it.readyToLogIn) newSessionPrivate(
+                    session = if (it.readyToLogIn) newSessionPrivate(
                         subjectId = it.id,
                         scopes = input.scopes,
                         label = input.label,
                         expires = run {
                             val a = it.maxExpiration
                             val b = input.expires
-                            if(a != null && b != null) minOf(a, b) else a ?: b
+                            if (a != null && b != null) minOf(a, b) else a ?: b
                         },
                     ).second.string else null
                 )
@@ -295,18 +311,26 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
             val used = proofs.map { it.via }.toSet()
             val users = proofs.mapNotNull { handler.findUser(it.property, it.value) }.distinctBy { it._id }
             val identity = proofs.filter { it.property == "email" || it.property == "phone" }.firstOrNull()
-            val subject = users.singleOrNull() ?: throw HttpStatusException(errorNoSingleUser.copy(
-                message = "No user was found with the ${identity?.property ?: "given ID"} ${identity?.value ?: ""}."
-            ))
+            val subject = users.singleOrNull() ?: throw HttpStatusException(
+                errorNoSingleUser.copy(
+                    message = "No user was found with the ${identity?.property ?: "given ID"} ${identity?.value ?: ""}."
+                )
+            )
             proofs.forEach {
-                if(handler.get(subject, it.property) != it.value) {
+                if (handler.get(subject, it.property) != it.value) {
                     throw HttpStatusException(errorIrrelevantProof.copy(data = it.via))
                 }
             }
-            val strength = proofs.groupBy { it.property }.values.sumOf { it.maxOf { it.strength } }
+
+            //TODO: Strength should account for the property as well. There could be multiple ways to
+            // prove a phone numbers ownership, sms and call. Each would have their own "via" value,
+            // but the property will be phone. We should only account for one of these. This requires
+            // modifying the proof class
+            val strength = proofs.groupBy { it.via }.values.sumOf { it.maxOf { it.strength } }
             val proofMethods = handler.proofMethods
                 .filter { it.established(handler, subject) }
-            val maxStrengthPossible = proofMethods.groupBy { it.info.property }.values.sumOf { it.maxOf { it.info.strength } }
+            val maxStrengthPossible =
+                proofMethods.groupBy { it.info.property }.values.sumOf { it.maxOf { it.info.strength } }
             val actStrenReq = min(handler.desiredStrengthFor(subject), maxStrengthPossible)
             ProofsCheckResult(
                 readyToLogIn = strength >= actStrenReq,
@@ -324,6 +348,29 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
                     },
                 strengthRequired = actStrenReq
             )
+        }
+    )
+
+    val availableProofs = path("available-proofs").get.api(
+        belongsToInterface = authInterface,
+        authOptions = AuthOptions<SUBJECT>(setOf(AuthOption(handler.authType))),
+        inputType = Unit.serializer(),
+        outputType = ListSerializer(ProofOption.serializer()),
+        summary = "Available Proofs",
+        description = "Returns a list of proof options for the user to use in re-authenticating.",
+        errorCases = listOf(),
+        implementation = { _: Unit ->
+            val subject = auth.get()
+            handler.proofMethods
+                .filter { it.established(handler, subject) }
+                .map {
+                    ProofOption(
+                        method = it.info,
+                        value = it.info.property?.let { p ->
+                            handler.get(subject, p)
+                        }
+                    )
+                }
         }
     )
 
@@ -540,27 +587,27 @@ class AuthEndpointsForSubject<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
 
     private suspend fun RefreshToken.session(request: Request?): Session<SUBJECT, ID>? {
         if (!valid) {
-            if(generalSettings().debug) println("Auth failed because !valid")
+            if (generalSettings().debug) println("Auth failed because !valid")
             return null
         }
         if (type != handler.name) {
-            if(generalSettings().debug) println("Auth failed because type != handler.name")
+            if (generalSettings().debug) println("Auth failed because type != handler.name")
             return null
         }
         val session = sessionInfo.collection().get(_id) ?: run {
-            if(generalSettings().debug) println("No such session")
+            if (generalSettings().debug) println("No such session")
             throw UnauthorizedException("No such session")
         }
         if (!plainTextSecret.checkAgainstHash(session.secretHash)) {
-            if(generalSettings().debug) println("Auth failed because !plainTextSecret.checkAgainstHash(session.secretHash) ($plainTextSecret vs ${session.secretHash})")
+            if (generalSettings().debug) println("Auth failed because !plainTextSecret.checkAgainstHash(session.secretHash) ($plainTextSecret vs ${session.secretHash})")
             throw UnauthorizedException("Incorrect hash for session")
         }
         if ((session.expires ?: Instant.DISTANT_FUTURE) < now()) {
-            if(generalSettings().debug) println("Auth failed because session.terminated != null || (session.expires ?: Instant.DISTANT_FUTURE) < now()")
+            if (generalSettings().debug) println("Auth failed because session.terminated != null || (session.expires ?: Instant.DISTANT_FUTURE) < now()")
             throw UnauthorizedException("Session has expired.")
         }
         if (session.terminated != null || (session.expires ?: Instant.DISTANT_FUTURE) < now()) {
-            if(generalSettings().debug) println("Auth failed because session.terminated != null || (session.expires ?: Instant.DISTANT_FUTURE) < now()")
+            if (generalSettings().debug) println("Auth failed because session.terminated != null || (session.expires ?: Instant.DISTANT_FUTURE) < now()")
             throw UnauthorizedException("Session has been terminated.")
         }
         sessionInfo.collection().updateOneById(_id, modification(dataClassPath) {

--- a/shared/src/commonMain/kotlin/com/lightningkite/lightningserver/auth/proof/OtpSecret.kt
+++ b/shared/src/commonMain/kotlin/com/lightningkite/lightningserver/auth/proof/OtpSecret.kt
@@ -20,9 +20,9 @@ data class OtpSecret(
     override val _id: UUID = UUID.random(),
     val subjectType: String,
     val subjectId: String,
+    val label: String,
 
     val secretBase32: String,
-    val label: String,
     val issuer: String,
     val period: Duration,
     val digits: Int,

--- a/shared/src/commonMain/kotlin/com/lightningkite/lightningserver/auth/proof/WebAuthN.kt
+++ b/shared/src/commonMain/kotlin/com/lightningkite/lightningserver/auth/proof/WebAuthN.kt
@@ -28,16 +28,19 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 @IndexSet(["subjectType", "subjectId"])
 data class WebAuthNCredential(
     override val _id: String,
-    val displayName: String,
-    val establishedAt: Instant = now(),
-    val lastUsedAt: Instant? = null,
     @Index val subjectId: String,
     @Index val subjectType: String,
+    val displayName: String,
+
     val residentKey: Boolean,
     val authenticatorAttachment: String,
     val attestationObject: String, // Base64 url-encoded
     val lastSignCount: Long,
     val transports: List<String>,
+
+    val establishedAt: Instant = now(),
+    val lastUsedAt: Instant? = null,
+    val expiresAt: Instant? = null,
     @Index val disabledAt: Instant? = null,
 ) : HasId<String>
 

--- a/shared/src/commonMain/kotlin/com/lightningkite/lightningserver/auth/proof/proofModels.kt
+++ b/shared/src/commonMain/kotlin/com/lightningkite/lightningserver/auth/proof/proofModels.kt
@@ -34,6 +34,12 @@ data class ProofOption(
 )
 
 @Serializable
+data class AuthRequirements(
+    val options: List<ProofOption>,
+    val strengthRequired: Int,
+)
+
+@Serializable
 data class Proof(
     val via: String,
     val strength: Int = 1,


### PR DESCRIPTION
Add an authenticated endpoint that returns the users login requirements. This made creating UI for re-authenticating to refresh your session to manage security items cleaner.

Also simplified the WebAuthNEndpoints by removing the Generics.