### PR TITLE
Mask Count

### DIFF
--- a/server-core/src/main/kotlin/com/lightningkite/lightningdb/ModelPermissionsFieldCollection.kt
+++ b/server-core/src/main/kotlin/com/lightningkite/lightningdb/ModelPermissionsFieldCollection.kt
@@ -64,7 +64,7 @@ open class ModelPermissionsFieldCollection<Model : Any>(
         return wraps.insertMany(passingModels).map { permissions.mask(it) }
     }
 
-    override suspend fun count(condition: Condition<Model>): Int = wraps.count(condition and permissions.read)
+    override suspend fun count(condition: Condition<Model>): Int = wraps.count(condition and permissions.read and permissions.readMask(condition, textIndexPaths))
 
     override suspend fun <Key> groupCount(
         condition: Condition<Model>,

--- a/shared/src/commonMain/kotlin/com/lightningkite/lightningdb/Mask.kt
+++ b/shared/src/commonMain/kotlin/com/lightningkite/lightningdb/Mask.kt
@@ -277,6 +277,10 @@ fun <T> Condition<T>.readsResultOf(modification: Modification<T>, tableTextPaths
             }
         }
 
+        is Condition.Not -> {
+            this.condition.readsResultOf(modification, tableTextPaths)
+        }
+
         else -> true
     }
 }


### PR DESCRIPTION
- Apply masking condition to "Count" so that you can't count based off of a field that is masked
- Add `Not` condition to masked condition. Previously this was disallowing reading conditions that have `Not` in them. In this scenario, "Not" should behave the same as `And` or `Or`