### PR TITLE
Make validation annotations on invalid types print warning but not fail

### DIFF
--- a/shared/src/commonMain/kotlin/com/lightningkite/validation/validate.kt
+++ b/shared/src/commonMain/kotlin/com/lightningkite/validation/validate.kt
@@ -13,6 +13,8 @@ import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.modules.SerializersModule
 import kotlin.reflect.KClass
 
+class ValidationInvalidType(message: String) : Exception(message)
+
 interface ShouldValidateSub<A> : KSerializer<A> {
     fun validate(value: A, existingAnnotations: List<Annotation>, defer: (Any?, List<Annotation>) -> Unit) =
         defer(value, existingAnnotations)
@@ -53,9 +55,9 @@ object Validators {
         directProcessor(T::class) { a, b ->
             if (a is T) {
                 @Suppress("UNCHECKED_CAST")
-                if(b is Collection<*>)
+                if (b is Collection<*>)
                     b.asSequence().mapNotNull { action(a, it as V) }.firstOrNull()
-                else if(b is Map<*, *>)
+                else if (b is Map<*, *>)
                     b.values.asSequence().mapNotNull { action(a, it as V) }.firstOrNull()
                 else action(a, b as V)
             } else
@@ -114,7 +116,10 @@ object Validators {
                     "Too long; got ${v.size} entries but have a maximum of ${t.size} entries."
                 ) else null
 
-                else -> throw NotImplementedError("Unknown type ${v::class}")
+                else -> {
+                    ValidationInvalidType("MaxSize applied to invalid type ${v::class}. Ignoring validation.").printStackTrace()
+                    null
+                }
             }
         }
         processor<MaxLength, Any> { t, v ->
@@ -129,7 +134,10 @@ object Validators {
                     "Too long; maximum ${t.size} characters allowed"
                 ) else null
 
-                else -> throw NotImplementedError("Unknown type ${v::class}")
+                else -> {
+                    ValidationInvalidType("MaxLength applied to invalid type ${v::class}. Ignoring validation.").printStackTrace()
+                    null
+                }
             }
         }
         processor<ExpectedPattern, Any> { t, v ->
@@ -144,7 +152,10 @@ object Validators {
                     "Does not match pattern; expected to match ${t.pattern}"
                 ) else null
 
-                else -> throw NotImplementedError("Unknown type ${v::class}")
+                else -> {
+                    ValidationInvalidType("ExpectPattern applied to invalid type ${v::class}. Ignoring validation.").printStackTrace()
+                    null
+                }
             }
         }
         processor<IntegerRange, Any> { t, v ->
@@ -189,7 +200,10 @@ object Validators {
                     "Out of range; expected to be between ${t.min} and ${t.max}"
                 ) else null
 
-                else -> throw NotImplementedError("Unknown type ${v::class}")
+                else -> {
+                    ValidationInvalidType("IntegerRange applied to invalid type ${v::class}. Ignoring validation.").printStackTrace()
+                    null
+                }
             }
         }
         processor<FloatRange, Any> { t, v ->
@@ -204,7 +218,10 @@ object Validators {
                     "Out of range; expected to be between ${t.min} and ${t.max}"
                 ) else null
 
-                else -> throw NotImplementedError("Unknown type ${v::class}")
+                else -> {
+                    ValidationInvalidType("FloatRange applied to invalid type ${v::class}. Ignoring validation.").printStackTrace()
+                    null
+                }
             }
         }
     }

--- a/shared/src/commonTest/kotlin/com/lightningkite/ValidationTest.kt
+++ b/shared/src/commonTest/kotlin/com/lightningkite/ValidationTest.kt
@@ -14,7 +14,14 @@ import kotlin.test.*
 data class Sample(
     @MaxLength(5) val x: String = "asdf",
     @IntegerRange(0, 100) val y: Int = 4,
-    @MaxLength(5) @MaxSize(5) val z: List<String> = listOf()
+    @MaxLength(5) @MaxSize(5) val z: List<String> = listOf(),
+)
+
+@Serializable
+@GenerateDataClassPaths
+data class BadSample(
+    @MaxSize(1) val a: String = "fdsa",
+    @MaxLength(5) val x: String = "asdf",
 )
 
 class ValidationTest {
@@ -59,5 +66,22 @@ class ValidationTest {
         assertPasses(Sample(z = listOf("asdf", "fdsa")))
         assertFails(Sample(z = listOf("asdf", "fdsaasdf")))
         assertFails(Sample(z = listOf("asdf", "fdsa", "asdf", "fdsa", "asdf", "fdsa")))
+    }
+
+    @Test
+    fun assertBadAnnotationIsIgnored() {
+        assertPasses(BadSample(a = "ASDFA", x = "ooui"))
+        assertPasses(modification<BadSample> { it.a assign "ASDFA" })
+        assertPasses(modification<BadSample> {
+            modifications += it.a.mapModification(
+                Modification.Chain(
+                    listOf(
+                        Modification.Assign("asdfa"),
+                        Modification.Assign("asdfab"),
+                    )
+                )
+            )
+        })
+
     }
 }


### PR DESCRIPTION
The warnings on done through error stack traces because this helps trace what model the issue is coming from.