### PR TITLE
[1/12] Auth hardening: rate-limit backoff, identifier normalization, masquerade audit log

### DIFF
--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/Authentication.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/Authentication.kt
@@ -253,6 +253,11 @@ public data class Authentication<SUBJECT : HasId<*>> private constructor(
                         sessionId = null,
                         issuedAt = server.clock.now(),
                         expiration = auth.expiration,
+                        // NOTE: the masqueraded session inherits the ACTOR's scopes verbatim, not the
+                        // target's. This means a masquerade can carry more privilege than the target
+                        // normally holds. Whether that is desired (act with your own powers as the user)
+                        // or should be narrowed to a subset is an intentional, app-specific decision;
+                        // gate it in permitMasquerade if you need to restrict it.
                         scopes = auth.scopes,
                         fromMasquerade = auth,
                     )
@@ -263,8 +268,15 @@ public data class Authentication<SUBJECT : HasId<*>> private constructor(
                         throw BadRequestException(message = "Invalid masquerade id", data = mask.rawId)
                     }
 
-                    if (handler.permitMasquerade(auth, mask)) return mask
-                    else throw ForbiddenException("You are not allowed to masquerade as $masquerade")
+                    if (handler.permitMasquerade(auth, mask)) {
+                        // Audit trail: masquerade is a privilege-sensitive action, so record who
+                        // assumed whom. Logged at info because it is an authorized, expected event.
+                        server.logger.info { "AUDIT masquerade granted: ${auth.principalName}/${auth.rawId} -> $masquerade" }
+                        return mask
+                    } else {
+                        server.logger.warn { "AUDIT masquerade denied: ${auth.principalName}/${auth.rawId} attempted -> $masquerade" }
+                        throw ForbiddenException("You are not allowed to masquerade as $masquerade")
+                    }
                 }
 
                 return auth

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpoints.kt
@@ -170,14 +170,19 @@ public class BackupCodeEndpoints(
             ),
             successCode = HttpStatus.OK,
             implementation = { input: IdentificationAndPassword ->
+                val subject = input.type
+
+                val handler = serverRuntime.server.principalTypes.values.find { it.name == subject }
+                    ?: throw IllegalArgumentException("No subject $subject recognized")
+
+                // Normalize BEFORE building the rate-limit key: the key must be derived from the canonical
+                // identifier so that case/whitespace variants of the same account share one bucket. Keying on
+                // the raw value would let an attacker dodge the limiter (and its exponential backoff) simply
+                // by varying case or whitespace.
+                val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
                 cache().constrainAttemptRate(
-                    cacheKey = "backup-code-count-${input.property}-${input.value}"
+                    cacheKey = "backup-code-count-${input.property}-${normalizedValue}"
                 ) {
-                    val subject = input.type
-
-                    val handler = serverRuntime.server.principalTypes.values.find { it.name == subject }
-                        ?: throw IllegalArgumentException("No subject $subject recognized")
-
                     val subjectId = handler.fetchUserIdString(input.property, input.value)
                         ?: throw BadRequestException("Invalid Backup Code")
 

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PasswordProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PasswordProofEndpoints.kt
@@ -165,11 +165,15 @@ public class PasswordProofEndpoints(
             successCode = HttpStatus.OK,
             implementation = { input: IdentificationAndPassword ->
                 val now = now()
-                cache().constrainAttemptRate("password-${input.property}-${input.value}") {
-                    val subject = input.type
-                    val handler = serverRuntime.server.principalTypes.values.find { it.name == subject }
-                        ?: throw IllegalArgumentException("No subject $subject recognized")
-                    val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
+                val subject = input.type
+                val handler = serverRuntime.server.principalTypes.values.find { it.name == subject }
+                    ?: throw IllegalArgumentException("No subject $subject recognized")
+                // Normalize BEFORE building the rate-limit key: the key must be derived from the canonical
+                // identifier so that case/whitespace variants (e.g. "Bob@x.com" vs "bob@x.com ") of the same
+                // account share one bucket. Keying on the raw value would let an attacker dodge the limiter
+                // (and its exponential backoff) simply by varying case or whitespace.
+                val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
+                cache().constrainAttemptRate("password-${input.property}-${normalizedValue}") {
                     val subjectId = handler.fetchUserIdString(input.property, normalizedValue)
                         ?: throw BadRequestException("User ID and code do not match")
 

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/TimeBasedOTPProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/TimeBasedOTPProofEndpoints.kt
@@ -153,13 +153,17 @@ public class TimeBasedOTPProofEndpoints(
             implementation = { input: IdentificationAndPassword ->
                 val now = now()
                 val gracePeriod = now().minus(5.seconds)
+                val subject = input.type
+                val handler = serverRuntime.server.principalTypes[subject]
+                    ?: throw IllegalArgumentException("No subject $subject recognized")
+                // Normalize BEFORE building the rate-limit key: the key must be derived from the canonical
+                // identifier so that case/whitespace variants of the same account share one bucket. Keying on
+                // the raw value would let an attacker dodge the limiter (and its exponential backoff) simply
+                // by varying case or whitespace.
+                val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
                 cache().constrainAttemptRate(
-                    cacheKey = "totp-count-${input.property}-${input.value}"
+                    cacheKey = "totp-count-${input.property}-${normalizedValue}"
                 ) {
-                    val subject = input.type
-                    val handler = serverRuntime.server.principalTypes[subject]
-                        ?: throw IllegalArgumentException("No subject $subject recognized")
-                    val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
                     val subjectId = handler.fetchUserIdString(input.property, normalizedValue)
                         ?: throw BadRequestException("User ID and code do not match")
 

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
@@ -7,25 +7,11 @@ import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.now
 import com.lightningkite.services.cache.*
 import com.lightningkite.services.data.ExperimentalLightningServer
+import kotlin.math.pow
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
-
-/**
- *
- *  Tracks the number action attempts against a given [cacheKey].
- *  If more than [count] attempts occur within a [expires] time frame for the given [cacheKey],
- *  any subsequent requests for [blocked] amount of time will be denied.
- *  Subsequent requests in [blocked] time frame will reset the [blocked] time frame.
- *
- *  @param cacheKey The key you want to rate limit actions against.
- *  @param count The number of attempts that can be made in the [expires] time frame.
- *  @param expires The time frame for allowed attempts. Starts on the first attempt and resets every [expires] time passed.
- *  @param blocked The time frame the action will be blocked if too many attempts are made. Should always be greater than or equal to [expires].
- *  @param action The action you want to make against the [cacheKey]
- *
- *  @throws [BadRequestException] if attempt is denied.
- */
 
 /**
  * Atomically claims [cacheKey] for single use, returning `true` only for the very first caller.
@@ -45,15 +31,41 @@ context(server: ServerRuntime)
 public suspend fun Cache.claimOnce(cacheKey: String, ttl: Duration): Boolean =
     setIfNotExists(cacheKey, now(), ttl)
 
+/**
+ *  Tracks the number of action attempts against a given [cacheKey] and applies rate limiting with
+ *  **exponential backoff** so that repeated abuse of the same key is punished progressively harder.
+ *
+ *  If more than [count] attempts occur within an [expires] time frame for the given [cacheKey],
+ *  subsequent requests are denied for a block window. The first block lasts [blocked]; each time the
+ *  limit is hit again the block doubles (`blocked * 2^level`), capped at [maxBlocked].
+ *
+ *  The "strike level" is persisted under a separate key (`"$cacheKey-level"`) with a memory TTL far
+ *  longer than any single block window (proportional to [maxBlocked]). This is what defeats a slow
+ *  "popcorn" brute force: even after a block window lapses and the attacker returns for a fresh batch
+ *  of [count] attempts, the remembered strike level makes the next block much longer. A **successful**
+ *  action clears both the attempt counter and the strike level, so legitimate users are never
+ *  penalized for a later mistake.
+ *
+ *  @param cacheKey The key you want to rate limit actions against.
+ *  @param count The number of attempts that can be made in the [expires] time frame.
+ *  @param expires The time frame for allowed attempts. Starts on the first attempt and resets every [expires] time passed.
+ *  @param blocked The base block time frame applied the first time the limit is hit (level 0). Should be greater than or equal to [expires].
+ *  @param maxBlocked The maximum block window; the exponentially-growing block is capped here. Should be greater than or equal to [blocked].
+ *  @param action The action you want to make against the [cacheKey]
+ *
+ *  @throws [BadRequestException] if attempt is denied.
+ */
 context(server: ServerRuntime)
 public suspend inline fun <R> Cache.constrainAttemptRate(
     cacheKey: String,
     count: Int = 5,
     expires: Duration = 5.minutes,
     blocked: Duration = expires,
+    maxBlocked: Duration = 3.hours,
     action: () -> R,
 ): R {
     val startKey = "$cacheKey-start-time"
+    val levelKey = "$cacheKey-level"
 
     val ct = (this.get<Int>(cacheKey) ?: 0)
     val start = this.setIfNotExists<Instant>(startKey, now(), expires)
@@ -63,7 +75,14 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
     }
 
     if (ct >= count) {
-        val block = blocked.coerceAtLeast(expires)
+        val baseBlock = blocked.coerceAtLeast(expires)
+        // Cap the exponent so the multiplication can never overflow to Duration.INFINITE; the result
+        // is capped at maxBlocked long before level 20 anyway.
+        val level = (this.get<Int>(levelKey) ?: 0)
+        val block = (baseBlock * 2.0.pow(level.coerceAtMost(20))).coerceAtMost(maxBlocked.coerceAtLeast(baseBlock))
+        // Remember the escalated strike level well beyond this block window so a returning attacker is
+        // still treated as a repeat offender (defeats slow "popcorn" brute forcing).
+        this.add(levelKey, 1, maxBlocked * 4)
         this.add(cacheKey, 1, block)
         throw BadRequestException("Too many attempts; please wait ${block.inWholeMinutes} minutes.")
     }
@@ -71,6 +90,7 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
     return try {
         val result = action()
         remove(cacheKey)
+        remove(levelKey)
         result
     } catch (e: Throwable) {
         this.add(cacheKey, 1, blocked.coerceAtLeast(expires))

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpointsTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpointsTest.kt
@@ -590,4 +590,73 @@ class BackupCodeEndpointsTest {
             }
         }
     }
+
+    /**
+     * Security regression: the rate-limit key must be built from the NORMALIZED identifier, so that
+     * case/whitespace variants of one account share a single bucket. If the key were derived from the
+     * raw value, an attacker could dodge the limiter (and its exponential backoff) by varying case.
+     */
+    @Test
+    fun `rate limiter shares one bucket across case variants of the same identifier`() = runBlocking {
+        TestUser.users.clear()
+        val userId = Uuid.random()
+        val user = TestUser(userId, "test@example.com")
+        TestUser.users[userId] = user
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val backupCodes = path.path("auth").path("backup") include BackupCodeEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours
+            )
+        }.let { server ->
+            server.test({}) {
+                server.backupCodes.modelInfo.table().insert(
+                    listOf(
+                        BackupCodeSecret(
+                            code = "validcode",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name
+                        )
+                    )
+                )
+
+                // Five distinct case variants that all normalize to "test@example.com". The default limit
+                // is 5 attempts; five failing attempts across these variants must fill ONE shared bucket.
+                val emailVariants = listOf(
+                    "Test@example.com",
+                    "tEst@example.com",
+                    "teSt@example.com",
+                    "tesT@example.com",
+                    "TEST@example.com",
+                )
+                for (variant in emailVariants) {
+                    assertFailsWith<BadRequestException> {
+                        server.backupCodes.prove.test(
+                            null, IdentificationAndPassword("TestUser", "email", variant, "wrongcode")
+                        )
+                    }
+                }
+
+                // A sixth attempt with yet another distinct variant must be blocked by the shared limiter.
+                val blocked = assertFailsWith<BadRequestException> {
+                    server.backupCodes.prove.test(
+                        null, IdentificationAndPassword("TestUser", "email", "TesT@example.com", "wrongcode")
+                    )
+                }
+                assertTrue(
+                    blocked.message.contains("Too many attempts"),
+                    "Expected the shared rate limiter to block, but got: ${blocked.message}"
+                )
+            }
+        }
+    }
 }

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/ConstrainAttemptRateTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/ConstrainAttemptRateTest.kt
@@ -1,0 +1,156 @@
+// by Claude
+package com.lightningkite.lightningserver.sessions.proofs
+
+import com.lightningkite.lightningserver.BadRequestException
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.sessions.proofs.extensions.constrainAttemptRate
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.withClock
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.*
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+/**
+ * Tests for [constrainAttemptRate]'s exponential backoff behavior.
+ *
+ * The RAM [Cache] evaluates TTL expiry against [Clock.default], which reads the coroutine-context
+ * clock set by [withClock], while `now()` reads the [ServerRuntime] clock passed to `test`. Both are
+ * driven by the same [MutableClock] here so advancing time expires cache entries deterministically.
+ */
+class ConstrainAttemptRateTest {
+
+    object TestServer : ServerBuilder() {
+        val cache = setting("cache", Cache.Settings("ram"))
+    }
+
+    /** A clock whose [now] can be moved forward to simulate elapsed time in tests. */
+    private class MutableClock(var instant: Instant = Instant.parse("2024-01-01T00:00:00Z")) : Clock {
+        override fun now(): Instant = instant
+        fun advance(by: Duration) {
+            instant += by
+        }
+    }
+
+    /** Runs [failures] failing attempts (each below the block threshold), asserting each rethrows. */
+    context(server: ServerRuntime)
+    private suspend fun Cache.failN(key: String, count: Int, blocked: Duration, failures: Int) {
+        repeat(failures) {
+            assertFailsWith<IllegalStateException> {
+                constrainAttemptRate(key, count = count, blocked = blocked) {
+                    throw IllegalStateException("simulated failure")
+                }
+            }
+        }
+    }
+
+    /**
+     * Drives the counter to the limit and returns the block message thrown by the next (blocked)
+     * attempt. Assumes the counter starts empty for [key].
+     */
+    context(server: ServerRuntime)
+    private suspend fun Cache.hitLimit(key: String, count: Int, blocked: Duration): String {
+        failN(key, count, blocked, count)
+        val ex = assertFailsWith<BadRequestException> {
+            constrainAttemptRate(key, count = count, blocked = blocked) { /* not reached */ }
+        }
+        return ex.message
+    }
+
+    @Test
+    fun `first block matches configured blocked duration`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val message = TestServer.cache().hitLimit("first-block", count = 3, blocked = 10.minutes)
+                assertTrue(message.contains("10 minutes"), "Expected first block of 10 minutes, got: $message")
+            }
+        }
+    }
+
+    @Test
+    fun `repeat offender across block windows gets exponentially longer block`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val cache = TestServer.cache()
+                val key = "popcorn"
+
+                // Round 1: first offense -> base block (level 0).
+                val first = cache.hitLimit(key, count = 3, blocked = 10.minutes)
+                assertTrue(first.contains("10 minutes"), "Round 1 should be 10 minutes, got: $first")
+
+                // Let the block window (and attempt counter) lapse, but not the long-lived strike level.
+                clock.advance(11.minutes)
+
+                // Round 2: returning attacker gets a fresh batch of attempts, but the remembered
+                // strike level doubles the block -> 20 minutes. This is the popcorn defense.
+                val second = cache.hitLimit(key, count = 3, blocked = 10.minutes)
+                assertTrue(second.contains("20 minutes"), "Round 2 should be 20 minutes (exponential), got: $second")
+            }
+        }
+    }
+
+    @Test
+    fun `successful action resets strike level so later first offense is short again`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val cache = TestServer.cache()
+                val key = "reset"
+
+                // Escalate to level 1.
+                assertTrue(cache.hitLimit(key, count = 3, blocked = 10.minutes).contains("10 minutes"))
+                clock.advance(11.minutes)
+                assertTrue(cache.hitLimit(key, count = 3, blocked = 10.minutes).contains("20 minutes"))
+
+                // Let the block lapse, then a legitimate success clears the strike level.
+                clock.advance(21.minutes)
+                val ok = cache.constrainAttemptRate(key, count = 3, blocked = 10.minutes) { "success" }
+                assertEquals("success", ok)
+
+                // A later first offense is short again because the level was reset.
+                clock.advance(1.minutes)
+                val afterReset = cache.hitLimit(key, count = 3, blocked = 10.minutes)
+                assertTrue(afterReset.contains("10 minutes"), "After success the block should reset to 10 minutes, got: $afterReset")
+            }
+        }
+    }
+
+    @Test
+    fun `block is capped at maxBlocked`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val cache = TestServer.cache()
+                val key = "cap"
+                val count = 1
+                val blocked = 10.minutes
+                val maxBlocked = 25.minutes
+
+                // First failure fills the single allowed attempt.
+                assertFailsWith<IllegalStateException> {
+                    cache.constrainAttemptRate(key, count = count, blocked = blocked, maxBlocked = maxBlocked) {
+                        throw IllegalStateException("simulated failure")
+                    }
+                }
+
+                // Hammer past the limit; the block escalates 10 -> 20 -> capped at 25 (not 40) minutes.
+                val messages = (0 until 3).map {
+                    assertFailsWith<BadRequestException> {
+                        cache.constrainAttemptRate(key, count = count, blocked = blocked, maxBlocked = maxBlocked) { }
+                    }.message
+                }
+                assertTrue(messages[0].contains("10 minutes"), "First block should be 10 minutes, got: ${messages[0]}")
+                assertTrue(messages[1].contains("20 minutes"), "Second block should be 20 minutes, got: ${messages[1]}")
+                assertTrue(messages[2].contains("25 minutes"), "Third block should be capped at 25 minutes, got: ${messages[2]}")
+            }
+        }
+    }
+}

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/PasswordProofEndpointsTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/PasswordProofEndpointsTest.kt
@@ -433,4 +433,67 @@ class PasswordProofEndpointsTest {
             }
         }
     }
+
+    /**
+     * Security regression: the rate-limit key must be built from the NORMALIZED identifier, so that
+     * case/whitespace variants of one account share a single bucket. If the key were derived from the
+     * raw value, an attacker could dodge the limiter (and its exponential backoff) by varying case.
+     */
+    @Test
+    fun `rate limiter shares one bucket across case variants of the same identifier`() = runBlocking {
+        TestUser.users.clear()
+        val userId = Uuid.random()
+        val user = TestUser(userId, "test@example.com")
+        TestUser.users[userId] = user
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val passwordProof = path.path("auth").path("password") include PasswordProofEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours
+            )
+        }.let { server ->
+            server.test({}) {
+                server.passwordProof.establish(TestUser, userId, EstablishPassword("correctPassword"))
+
+                // Five distinct case variants that all normalize to "test@example.com". The default limit
+                // is 5 attempts; five failing attempts across these variants must fill ONE shared bucket.
+                val emailVariants = listOf(
+                    "Test@example.com",
+                    "tEst@example.com",
+                    "teSt@example.com",
+                    "tesT@example.com",
+                    "TEST@example.com",
+                )
+                for (variant in emailVariants) {
+                    assertFailsWith<BadRequestException> {
+                        server.passwordProof.prove.test(
+                            null, IdentificationAndPassword("TestUser", "email", variant, "wrongPassword")
+                        )
+                    }
+                }
+
+                // A sixth attempt with yet another distinct variant must be blocked by the shared limiter.
+                // Under the old raw-value key this variant would be an untouched bucket and fail only with
+                // the ordinary "does not match" error.
+                val blocked = assertFailsWith<BadRequestException> {
+                    server.passwordProof.prove.test(
+                        null, IdentificationAndPassword("TestUser", "email", "TesT@example.com", "wrongPassword")
+                    )
+                }
+                assertTrue(
+                    blocked.message.contains("Too many attempts"),
+                    "Expected the shared rate limiter to block, but got: ${blocked.message}"
+                )
+            }
+        }
+    }
 }

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/TimeBasedOTPProofEndpointsTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/TimeBasedOTPProofEndpointsTest.kt
@@ -526,4 +526,81 @@ class TimeBasedOTPProofEndpointsTest {
             }
         }
     }
+
+    /**
+     * Security regression: the rate-limit key must be built from the NORMALIZED identifier, so that
+     * case/whitespace variants of one account share a single bucket. If the key were derived from the
+     * raw value, an attacker could dodge the limiter (and its exponential backoff) by varying case.
+     */
+    @Test
+    fun `rate limiter shares one bucket across case variants of the same identifier`() = runBlocking {
+        TestUser.users.clear()
+        val userId = Uuid.random()
+        val user = TestUser(userId, "test@example.com")
+        TestUser.users[userId] = user
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val totpEndpoints = path.path("auth").path("totp") include TimeBasedOTPProofEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours,
+                config = testConfig
+            )
+        }.let { server ->
+            server.test({}) {
+                server.totpEndpoints.modelInfo.table().insert(
+                    listOf(
+                        TotpSecret(
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            secretBase32 = testSecretBase32,
+                            label = "test",
+                            issuer = "TestApp",
+                            period = 30.seconds,
+                            digits = 6,
+                            algorithm = TotpHashAlgorithm.SHA1,
+                            establishedAt = Clock.System.now(),
+                            lastUsedAt = Clock.System.now()
+                        )
+                    )
+                )
+
+                // Five distinct case variants that all normalize to "test@example.com". The default limit
+                // is 5 attempts; five failing attempts across these variants must fill ONE shared bucket.
+                val emailVariants = listOf(
+                    "Test@example.com",
+                    "tEst@example.com",
+                    "teSt@example.com",
+                    "tesT@example.com",
+                    "TEST@example.com",
+                )
+                for (variant in emailVariants) {
+                    assertFailsWith<BadRequestException> {
+                        server.totpEndpoints.prove.test(
+                            null, IdentificationAndPassword("TestUser", "email", variant, "000000")
+                        )
+                    }
+                }
+
+                // A sixth attempt with yet another distinct variant must be blocked by the shared limiter.
+                val blocked = assertFailsWith<BadRequestException> {
+                    server.totpEndpoints.prove.test(
+                        null, IdentificationAndPassword("TestUser", "email", "TesT@example.com", "000000")
+                    )
+                }
+                assertTrue(
+                    blocked.message.contains("Too many attempts"),
+                    "Expected the shared rate limiter to block, but got: ${blocked.message}"
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
Three related hardening changes to the auth/session layer.

- **Exponential backoff on auth attempt rate limiting**, replacing the flat window.
- **Normalize identifiers before keying the rate limiter**, so casing or
  formatting variants of the same identifier can no longer be used to multiply
  the allowed attempt budget. Applies to password, TOTP, and backup-code proofs.
- **Audit-log masquerade grants and denials**, which previously left no trace.
