### PR TITLE
[3/12] Lock AWS scheduled-task execution to prevent concurrent runs

### DIFF
--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapter.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapter.kt
@@ -14,6 +14,7 @@ import com.lightningkite.lightningserver.settings.*
 import com.lightningkite.lightningserver.websockets.*
 import com.lightningkite.services.Service
 import com.lightningkite.services.aws.AwsConnections
+import com.lightningkite.services.cache.Cache
 import com.lightningkite.services.get
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -41,14 +42,37 @@ import kotlin.time.Duration.Companion.milliseconds
 
 private val awsApiGatewayWsEndpointSetting = ServerSetting("awsApiGatewayWsEndpointSetting", "", String.serializer())
 
+/**
+ * Cache used by the AWS engine for distributed locking of scheduled-task execution
+ * (see [AwsAdapterSchedule]). EventBridge can deliver a scheduled trigger more than once and to
+ * overlapping Lambda invocations; the lock ensures only one invocation runs a given tick.
+ *
+ * For this to coordinate across concurrent Lambda instances (separate processes) it must point at a
+ * shared cache such as DynamoDB or Redis. The default "ram" cache only deduplicates within a single
+ * process, mirroring [com.lightningkite.lightningserver.engine.local.LocalEngine]'s engine cache.
+ *
+ * Optional so existing deployments whose settings.json predates this setting still start.
+ */
+public val awsEngineCache: ServerSetting<Cache.Settings, Cache> =
+    ServerSetting(
+        "engine-cache",
+        Cache.Settings(),
+        Cache.Settings.serializer(),
+        instructions = "Shared cache (e.g. DynamoDB) used to coordinate scheduled tasks across Lambda invocations.",
+        optional = true,
+    )
+
 public open class AwsAdapter(server: ServerDefinition) : ServerRuntimeBase(server), RequestStreamHandler, Resource {
 
     internal val logger: KLogger = KotlinLogging.logger("com.lightningkite.lightningserver.engine.awsserverless")
     internal var preventLambdaTimeoutReuse: Boolean = false
 
-    override val settings: ServerSettings = super.settings + awsApiGatewayWsEndpointSetting
+    override val settings: ServerSettings = super.settings + awsApiGatewayWsEndpointSetting + awsEngineCache
 
     override val websocketHandlersRunOnSameMachine: Boolean get() = false
+
+    /** Cache used for scheduled-task distributed locking; see [awsEngineCache]. */
+    internal val cache: Cache by lazy { with(this) { awsEngineCache() } }
 
     init {
         logger.info { "Initializing AwsAdapter..." }

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterSchedule.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterSchedule.kt
@@ -2,12 +2,25 @@ package com.lightningkite.lightningserver.engine.awsserverless
 
 import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.runtime.executeWithMetrics
+import com.lightningkite.services.cache.setIfNotExists
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 
 internal class AwsAdapterSchedule(val root: AwsAdapter) {
 
     @Serializable
     data class Scheduled(val scheduled: String) : AwsLambdaInput
+
+    /**
+     * TTL of the per-tick lock. Matches [com.lightningkite.lightningserver.engine.local.LocalEngine]'s
+     * default so scheduled-task behavior is consistent across engines. The lock is released in the
+     * `finally` below as soon as the tick finishes, so this only matters as a backstop after a hard
+     * crash (a Lambda killed mid-tick would otherwise leave the lock held until it expires).
+     */
+    private val scheduleLockTtl: Duration = 1.hours
 
     suspend fun handleSchedule(parsed: Scheduled): APIGatewayV2HTTPResponse {
         val p = PathSpec0.fromString(parsed.scheduled)
@@ -16,6 +29,15 @@ internal class AwsAdapterSchedule(val root: AwsAdapter) {
                 statusCode = 404,
                 body = "No schedule '${parsed.scheduled}' found"
             )
+        // EventBridge can fire a scheduled trigger more than once and to overlapping Lambda invocations.
+        // Acquire a distributed lock (same key scheme and TTL as LocalEngine) so only one invocation runs
+        // the tick; a losing invocation simply reports the same benign success and does no work. AWS
+        // schedules are stateless per invocation, so the lock is the only coordination needed here — there
+        // is no next-run persistence like the local engine keeps.
+        val lockKey = "$p-lock"
+        if (!root.cache.setIfNotExists(lockKey, true, scheduleLockTtl)) {
+            return APIGatewayV2HTTPResponse(statusCode = 200)
+        }
         try {
             with(root) {
                 schedule.executeWithMetrics(p)
@@ -23,6 +45,10 @@ internal class AwsAdapterSchedule(val root: AwsAdapter) {
             return APIGatewayV2HTTPResponse(statusCode = 200)
         } catch (e: Exception) {
             return APIGatewayV2HTTPResponse(statusCode = 500)
+        } finally {
+            // Always release the lock, even on cancellation (e.g. Lambda timeout), so a mid-tick failure
+            // can't leave the lock stuck until its TTL expires. NonCancellable guards only this fast cleanup.
+            withContext(NonCancellable) { root.cache.remove(lockKey) }
         }
     }
 }

--- a/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterScheduleTest.kt
+++ b/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterScheduleTest.kt
@@ -1,0 +1,51 @@
+package com.lightningkite.lightningserver.engine.awsserverless
+
+import com.lightningkite.lightningserver.definition.ScheduledTask
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.services.cache.get
+import com.lightningkite.services.cache.set
+import com.lightningkite.services.cache.setIfNotExists
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.minutes
+
+class AwsAdapterScheduleTest {
+    companion object {
+        val runCount = AtomicInteger(0)
+    }
+
+    object SampleServer : ServerBuilder() {
+        val tick = path.path("tick") bind ScheduledTask(frequency = 1.minutes) {
+            runCount.incrementAndGet()
+        }
+    }
+
+    @Test
+    fun normalInvocationRunsAndReleasesLock() = runBlocking {
+        runCount.set(0)
+        val adapter = TestAwsAdapter(SampleServer.build())
+        val input = adapter.server.schedules.entries.single().key.toString()
+        val response = adapter.schedules.handleSchedule(AwsAdapterSchedule.Scheduled(input))
+        assertEquals(200, response.statusCode)
+        assertEquals(1, runCount.get(), "The scheduled task should have run exactly once")
+        // Lock must be released after the tick so the next trigger can run.
+        assertNull(adapter.cache.get<Boolean>("$input-lock"), "Lock should be released after execution")
+    }
+
+    @Test
+    fun heldLockSkipsExecution() = runBlocking {
+        runCount.set(0)
+        val adapter = TestAwsAdapter(SampleServer.build())
+        val input = adapter.server.schedules.entries.single().key.toString()
+        // Simulate a concurrent invocation already holding the lock.
+        assertEquals(true, adapter.cache.setIfNotExists("$input-lock", true))
+        val response = adapter.schedules.handleSchedule(AwsAdapterSchedule.Scheduled(input))
+        assertEquals(200, response.statusCode, "A skipped tick still reports benign success")
+        assertEquals(0, runCount.get(), "The scheduled task must not run while the lock is held")
+        // The pre-existing lock must not be cleared by the skipped invocation.
+        assertEquals(true, adapter.cache.get<Boolean>("$input-lock"))
+    }
+}


### PR DESCRIPTION
Takes a lock around AWS scheduled-task execution. EventBridge can deliver the
same schedule to more than one Lambda invocation, which meant scheduled tasks
could run concurrently with themselves.
