### PR TITLE
[5/12] Docs: architecture review, files/websockets rewrite, v4-to-v5 and v5.1-to-v5.2 migration guides

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -1,115 +1,199 @@
 # File Systems
 
-**OUT OF DATE**
+Last updated July 2025 (`version-5`)
 
-Storing, serving, and using user-provided files is a common requirement, and as such, is built-in directly.
+Storing, serving, and using user-provided files is a common requirement, so Lightning Server provides a file-system
+abstraction and a set of ready-made upload endpoints. The abstraction lives in the service-abstractions library
+(`com.lightningkite.services.files`), and the HTTP endpoints that wrap it live in the `files` / `files-shared`
+modules.
 
-Valid file backends that have been built so far are Local, S3, and Azure Blob Storage. SFTP is also partially
-supported - it doesn't support public URLs.
+Available backends include a local (KotlinX-IO) file system and AWS S3. The API is modeled loosely on Kotlin's
+built-in file functions.
 
-The API is roughly based on Kotlin's built-in file functions.
+## Declaring the need for a file system
 
-## Declaring the need for a file sysstem
-
-Add a setting as follows:
+Add a setting whose value is a `PublicFileSystem`:
 
 ```kotlin
-object Server {
-    //...
-    val files = setting(name = "files", default = FilesSettings())
-    //...
+import com.lightningkite.services.files.PublicFileSystem
+
+object Server : ServerBuilder() {
+    val files = setting("files", PublicFileSystem.Settings())
 }
 ```
 
-## Accessing files
+To make additional backends available, reference them in an `init` block so their loaders register themselves:
 
 ```kotlin
-val rootFolder = Server.files().root
+import com.lightningkite.services.files.s3.S3PublicFileSystem
 
-val testFile = rootFolder.resolve("some/path/file.txt")
-
-// Files are written in terms of `HttpContent`
-// There's no mkdir.  If a folder does not exist it will be created.
-testFile.put(HttpContent.Text("Hello world!", ContentType.Text.Plain))
-
-// Files are read in terms of `HttpContent` as well
-testFile.get()!!.stream().use { it: InputStream ->
-    it.readAllBytes()
+object Server : ServerBuilder() {
+    init { S3PublicFileSystem }
+    val files = setting("files", PublicFileSystem.Settings())
 }
+```
 
-// You can just get metadata too
-testFile.head()
+Like every service, the setting resolves to a `Runtime<PublicFileSystem>`. You invoke it inside a
+`ServerRuntime` context (for example, within a handler) to get the live `PublicFileSystem`.
 
-// Generates a file reference with a large random identifier in it.
-val newFile = rootFolder.resolveRandom("test", "txt")
+## Accessing files
 
-// You can list files too.
-rootFolder.list().forEach {
-    println(it)
-}
+`FileObject` is the internal handle used to read and write files. Get one from the file system's `root` and
+navigate with `then`:
+
+```kotlin
+import com.lightningkite.services.data.TypedData
+import com.lightningkite.MediaType
+
+val root = files().root
+
+val testFile = root.then("some/path/file.txt")
+
+// Files are written and read as TypedData. Parent folders are created implicitly.
+testFile.put(TypedData.text("Hello world!", MediaType.Text.Plain))
+
+// get() returns TypedData?, null if the file does not exist.
+val text = testFile.get()?.text()
+
+// Metadata only (media type, size) without downloading the body.
+val info = testFile.head()
+
+// Remove a file.
+testFile.delete()
 ```
 
 ## Serving files
 
-These files have URLs that are signed for retrieval. Performing an HTTP GET will result in the file.
+Files can be served over signed URLs. Performing an HTTP GET against a signed URL returns the file:
 
 ```kotlin
-// Duration of the signature is determined by the file system settings
+// The signature duration is determined by the file system settings.
 println(testFile.signedUrl)
+```
+
+### `FileSystemEndpoints`
+
+`FileSystemEndpoints` exposes HEAD/GET/PUT handlers for a `PublicFileSystem`, including HTTP Range support on GET
+for partial/resumable downloads. GET streams the bytes, HEAD returns metadata, and PUT accepts an upload to a
+signed upload URL (only the local `KotlinxIoPublicFileSystem` accepts server-generated uploads this way; S3/Azure
+sign their own upload URLs).
+
+```kotlin
+val fileServing = path.path("files") include FileSystemEndpoints(files)
 ```
 
 ## Uploading files from a client
 
-You can sign an upload URL like so:
+You can sign a PUT upload URL for any file reference:
 
 ```kotlin
-// Include the expiration duration
-alt.uploadUrl(Duration.ofMinutes(10))
+import kotlin.time.Duration.Companion.minutes
+
+val uploadUrl = root.then("uploads/photo.jpg").uploadUrl(10.minutes)
 ```
 
-Performing an HTTP PUT with the file's contents will overwrite that file.
+Performing an HTTP PUT of the file's contents to that URL writes the file. Upload URLs never grant read access.
 
-## Serialization
+## `ServerFile` and serialization
 
-`FileObject` is a file-system resolve object which can be used to read and write files. They are purely internal to the
-server.
+Two types work together:
 
-`ServerFile` is a wrapper around a string that contains a public URL for an object. They are used in APIs and
-serialization.
+- `FileObject` is the internal read/write handle. It never leaves the server.
+- `ServerFile` (`com.lightningkite.services.files.ServerFile`) is a serializable wrapper around a URL string.
+  It is what you store in models and send over your API.
 
-You can switch between the two using `FileObject.serverFile` and `ServerFile.fileObject`.
+```kotlin
+import com.lightningkite.services.files.ServerFile
+
+@GenerateDataClassPaths
+@Serializable
+data class Post(
+    override val _id: Uuid = Uuid.random(),
+    val title: String,
+    @MimeType("image/*") val coverImage: ServerFile? = null,
+) : HasId<Uuid>
+```
+
+You move between the two by resolving the `ServerFile`'s location against the file system:
+
+```kotlin
+val obj = files().root.then(post.coverImage!!.location) // ServerFile -> FileObject
+val ref = ServerFile(obj.url)                            // FileObject -> ServerFile
+```
 
 ### Security
 
-When a `ServerFile` is sent to a client, the url is automatically signed for reading. Therefore, if you wish to keep a
-file in your file system secure, only serialize references to it for the people you want to read it.
+When a `ServerFile` is serialized out to a client, its URL is automatically signed for reading. Consequently, a
+file stays private as long as you only serialize references to it for people you want to be able to read it. Do not
+build a public file-sharing feature on top of this behavior by accident.
 
-## Default File Upload Endpoints
+## The `UploadEarlyEndpoint` (recommended upload flow)
 
-There is a pre-built upload endpoint for uploading files to use in subsequent requests. It requires a reference to the
-intended file system to use, a database to track whether the file has been used (if it's unused, it is garbage
-collected), and a `JwtSigner` setting to secure file reuse.
+`UploadEarlyEndpoint` is an opinionated group of endpoints for the common "upload now, reference later" pattern. It
+lets a client upload a file before the request that actually uses it, without turning your file system into an open
+file-sharing service.
 
-This endpoint prevents abuse of your file system by returning two URLs: a `uploadUrl` and a `futureCallToken`.
-
-`uploadUrl` is the URL which the client should PUT their file to.
-
-`futureCallToken` is a URL that can be used as a `ServerFile` in a subsequent request.
-
-Neither URL will allow reading of the file, and thus, you cannot abuse this endpoint as a file-sharing system.
-
-It is *strongly* recommended that you use this endpoint for handling files in your API rather than attempting to
-implement it yourself.
+Construct it with the file system, a database (used to track pending uploads for garbage collection), and a list of
+`FileScanner`s (often empty):
 
 ```kotlin
-val upload = UploadEarlyEndpoint(path("early-upload"), files, database, signer)
+import com.lightningkite.lightningserver.files.UploadEarlyEndpoint
+import com.lightningkite.lightningserver.definition.Runtime
+
+object Server : ServerBuilder() {
+    val files = setting("files", PublicFileSystem.Settings())
+    val database = setting("database", Database.Settings())
+
+    // Register ONCE. See the warning below.
+    val uploadEarly = path.path("upload") module UploadEarlyEndpoint(
+        files = files,
+        database = database,
+        fileScanner = Runtime.Constant(listOf()),
+    )
+}
 ```
+
+### The flow
+
+1. The client calls the `endpoint` (GET) to obtain an `UploadInformation`:
+    - `uploadUrl` — a presigned PUT URL to upload the bytes to.
+    - `futureCallToken` — a token that can be sent as a serialized `ServerFile` in a later request.
+2. The client PUTs the file to `uploadUrl`.
+3. The client includes `futureCallToken` as the `ServerFile` value in a subsequent API call.
+
+Neither URL grants read access, so the endpoint cannot be abused as a file host. A daily `cleanupSchedule` deletes
+uploads that were prepared but never used before their `expiration` (default one day).
+
+It is strongly recommended that you use this endpoint for API file handling rather than implementing the flow
+yourself.
+
+### Quarantine (jail) and scanning
+
+If you pass a non-empty list of `FileScanner`s (for example, the ClamAV scanner from the `files-clamav` module),
+uploads are first written to a jailed location (`jailFilePath`, default `upload-jail`) instead of the ready
+location (`filePath`, default `uploaded`). Before the
+file can be used it must be scanned and moved out of jail. The client does this by calling the `verify` (POST)
+endpoint with the token; if the file is safe it is moved to the ready location and a reusable reference is returned.
+Verifying up front also makes the subsequent request faster, since the scan has already happened.
+
+With an empty scanner list, uploads go straight to the ready location and are certified as already scanned.
+
+### ⚠️ Only one `UploadEarlyEndpoint` per server
+
+`UploadEarlyEndpoint` registers a **contextual serializer for `ServerFile`** (via its `externalSerialization`) so
+that upload tokens can be decoded as `ServerFile` values. If you instantiate `UploadEarlyEndpoint` more than once
+(for example, a separate instance created only for a test), the multiple instances register **conflicting
+`ServerFile` serializers**. This does not fail at compile time — it surfaces at runtime as serialization errors,
+typically appearing as `500 Internal Server Error` responses.
+
+**Instantiate `UploadEarlyEndpoint` exactly once in your server definition and reference that single instance
+everywhere, including from tests.**
 
 ## Available Backends
 
 ### Local
 
-Simply use a local filesystem folder.
+Use a local filesystem folder:
 
 ```json5
 // settings.json
@@ -122,9 +206,8 @@ Simply use a local filesystem folder.
 
 ```kotlin
 // Server.kt
-object Server: ServerPathGroup(ServerPath.root) {
-    // Adds S3FileSystem to the possible file system loaders
-    init { S3FileSystem }
+object Server : ServerBuilder() {
+    init { S3PublicFileSystem }
 }
 ```
 
@@ -132,22 +215,5 @@ object Server: ServerPathGroup(ServerPath.root) {
 // settings.json
 {
   "files": { "url": "s3://[user]:[password]@[bucket].[region].amazonaws.com" }
-}
-```
-
-### Azure Blob Storage
-
-```kotlin
-// Server.kt
-object Server: ServerPathGroup(ServerPath.root) {
-    // Adds AzureFileSystem to the possible file system loaders
-    init { AzureFileSystem }
-}
-```
-
-```json5
-// settings.json
-{
-  "files": { "url": "azbs://key@account/container" }
 }
 ```

--- a/docs/migration-v4-to-v5.md
+++ b/docs/migration-v4-to-v5.md
@@ -1,0 +1,200 @@
+# Migrating from v4 to v5
+
+Last updated July 2025 (`version-5`)
+
+Lightning Server 5 is a substantial reorganization of version 4. The biggest change is that the service
+abstractions (database, cache, files, email, notifications) were extracted into a separate
+`com.lightningkite.services.*` library, and the server itself was split into a **definition** phase and a
+**runtime** phase. This guide covers the server-side changes.
+
+!!! note
+    The authoritative, continually-updated migration reference — including the KiteUI 7 client-side changes — is
+    the `ls5-kui7-migration` skill. This page summarizes the server portions; consult the skill for the full
+    checklist and for client/app migration.
+
+## Overview of major changes
+
+- **Service abstractions extracted.** Database, files, cache, email, and notifications now live under
+  `com.lightningkite.services.*` instead of `com.lightningkite.lightningserver.*`.
+- **Definition vs. runtime split.** A server is now declared as a `ServerBuilder` (the definition). Services and
+  settings resolve to `Runtime<T>` values that are only realized inside a `ServerRuntime` context.
+- **Context parameters.** Kotlin context parameters are used heavily — most runtime code carries
+  `context(runtime: ServerRuntime)`. This requires the `-Xcontext-parameters` compiler flag.
+- **Standard-library types.** `com.lightningkite.UUID` → `kotlin.uuid.Uuid`, and `kotlinx.datetime.Instant` →
+  `kotlin.time.Instant`.
+- **Module split.** The single `...Shared` client artifact was split into `core-shared`, `typed-shared`,
+  `sessions-shared`, `files-shared`, and `media-shared`.
+
+## Dependencies
+
+The old single server and single shared dependencies become several targeted modules, and database/files/etc.
+come from the service-abstractions library. Representative server dependencies:
+
+```kotlin
+dependencies {
+    api(libs.comLightningKite.services.database)
+    api(libs.comLightningKite.services.database.jsonfile)
+    api(libs.comLightningKite.lightningServer.core)
+    api(libs.comLightningKite.lightningServer.typed)
+    api(libs.comLightningKite.lightningServer.files)
+    api(libs.comLightningKite.lightningServer.sessions)
+    ksp(libs.comLightningKite.services.database.processor)
+}
+
+kotlin {
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+        optIn.add("kotlin.uuid.ExperimentalUuidApi")
+        freeCompilerArgs.add("-Xcontext-parameters")
+    }
+}
+```
+
+The database KSP processor moved from `...lightningserver...Processor` to
+`com.lightningkite.services:database-processor`. See the migration skill for the full artifact-name mapping.
+
+## Imports
+
+The most common import moves:
+
+```kotlin
+// Standard-library types
+import kotlin.uuid.Uuid                                   // was com.lightningkite.UUID
+import kotlin.time.Instant                                // was kotlinx.datetime.Instant
+import com.lightningkite.lightningserver.runtime.now      // was com.lightningkite.now
+
+// Database & data (was com.lightningkite.lightningdb.*)
+import com.lightningkite.services.data.*
+import com.lightningkite.services.database.*
+import com.lightningkite.services.files.*
+
+// Services (were under com.lightningkite.lightningserver.*)
+import com.lightningkite.services.files.ServerFile        // was ...lightningserver.files.ServerFile
+import com.lightningkite.services.files.PublicFileSystem
+import com.lightningkite.services.database.Database
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.email.Email
+import com.lightningkite.services.notifications.NotificationService
+
+// Server builder (was com.lightningkite.lightningserver.core.ServerPathGroup)
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+```
+
+## Server definition: `ServerPathGroup` → `ServerBuilder`
+
+Servers and endpoint groups are now `ServerBuilder` objects. Settings use the service `Settings()` factories, and
+sub-groups are attached with `module`/`include`:
+
+```kotlin
+// OLD
+object Server : ServerPathGroup(ServerPath.root) {
+    val database = setting(name = "database", default = DatabaseSettings())
+    val files = setting(name = "files", default = FilesSettings())
+    val users = UserEndpoints(path("users"))
+}
+
+// NEW
+object Server : ServerBuilder() {
+    val database = setting("database", Database.Settings())
+    val files = setting("files", PublicFileSystem.Settings())
+    val users = path.path("users") module UserEndpoints
+}
+```
+
+Settings changed from standalone `*Settings()` constructors to nested `Service.Settings()` factories, for example
+`CacheSettings()` → `Cache.Settings()`, `FilesSettings()` → `PublicFileSystem.Settings()`,
+`NotificationSettings("console")` → `NotificationService.Settings("console")`.
+
+## Definition vs. runtime
+
+In v4, calling a setting gave you the service directly. In v5 a setting is a `Runtime<T>` in the definition, and
+you resolve it inside a `ServerRuntime` context (for example within a handler, where the context is present). Code
+that touches services must therefore carry `context(runtime: ServerRuntime)`:
+
+```kotlin
+// A helper that uses the database now declares the runtime context.
+context(runtime: ServerRuntime)
+suspend fun countUsers(): Int = database().table<User>().count()
+```
+
+This is the most pervasive source of migration compile errors: functions called from handlers, hooks, or signals
+need the `context(runtime: ServerRuntime)` receiver added.
+
+## Endpoint registration
+
+Handlers and sub-groups are attached to paths with infix operators instead of constructor-with-path:
+
+```kotlin
+// Sub-group of endpoints
+val users = path.path("users") module UserEndpoints
+
+// A single ServerBuilder component (e.g. generated REST endpoints)
+val rest = path.path("rest") include ModelRestEndpoints(info)
+
+// A single handler / task / topic
+val root = path.get bind HttpHandler { HttpResponse.plainText("Hello") }
+```
+
+## Database changes
+
+- `.collection()` → `.table()`, and `.baseCollection()` → `.baseTable()`.
+- `UUID` → `Uuid` throughout models: `HasId<UUID>` → `HasId<Uuid>`, `UUID.random()` → `Uuid.random()`.
+- Instants use `kotlin.time.Instant`; use `now()` from `com.lightningkite.lightningserver.runtime.now`.
+- `ModelInfo` signals operate on tables and take context-parameterized hooks.
+
+```kotlin
+// OLD
+info.collection().insertOne(model)
+
+// NEW
+info.table().insertOne(model)
+```
+
+## Typed endpoints
+
+Typed endpoints are declared with `ApiHttpHandler` bound to a path, taking the auth requirement as `auth` and the
+logic as `implementation`:
+
+```kotlin
+val hello = path.path("hello").get bind ApiHttpHandler(
+    summary = "Hello",
+    description = "Returns a greeting",
+    auth = noAuth,
+    implementation = { input: Unit -> "Hello" }
+)
+```
+
+See [Typed Endpoints](typed-endpoints.md) for the full API.
+
+## WebSockets
+
+The websocket package moved from `...websocket` (singular) to `...websockets` (plural), and handlers are attached
+with `bind`/`include`:
+
+```kotlin
+// OLD
+import com.lightningkite.lightningserver.websocket.MultiplexWebSocketHandler
+val multiplex = path("multiplex").websocket(MultiplexWebSocketHandler(cache))
+
+// NEW
+import com.lightningkite.lightningserver.websockets.MultiplexWebSocketHandler
+val multiplex = path.path("multiplex") bind MultiplexWebSocketHandler()
+```
+
+See [WebSockets](websockets.md) for the current API.
+
+## Common pitfalls
+
+- **Missing context parameter.** "Missing context receiver" compile errors mean a function that uses services
+  needs `context(runtime: ServerRuntime)`.
+- **`collection()` unresolved.** Replace `.collection()`/`.baseCollection()` with `.table()`/`.baseTable()`.
+- **Wrong `Instant` import.** Use `kotlin.time.Instant`, not `kotlinx.datetime.Instant`.
+- **Duplicate `UploadEarlyEndpoint`.** Instantiate it exactly once; multiple instances register conflicting
+  `ServerFile` serializers and cause runtime 500s. See [File Systems](files.md).
+
+## Client and KiteUI migration
+
+This page intentionally focuses on the server. The client SDK and KiteUI 7 changes (dependency renames, the dash →
+dot view-modifier syntax, theme derivations, `Api2` → `Api`, `OtpSecret` → `TotpSecret`, and more) are extensive
+and are documented in full in the `ls5-kui7-migration` skill.

--- a/docs/migration-v5.1-to-v5.2.md
+++ b/docs/migration-v5.1-to-v5.2.md
@@ -1,0 +1,133 @@
+# Migrating from v5.1 to v5.2
+
+Last updated July 2026 (`5.2.0`)
+
+Lightning Server 5.2 is a hardening and polish release on top of 5.1 — most of the diff is documentation,
+tests, and internal robustness work, so there is no large-scale reorganization like the
+[v4 → v5](migration-v4-to-v5.md) move. The changes below are the complete set: one dependency bump, two
+source edits, and one settings-file edit — all small and mechanical.
+
+!!! tip
+    These four items were exactly what it took to move a real, mid-sized application (auth, sessions, files,
+    AWS serverless deployment, a KiteUI web client) from 5.1 to 5.2 — nothing else was required, and the app
+    ran and served its client unchanged afterward.
+
+## 0. Bump the service-abstractions version
+
+Lightning Server 5.2 depends on a newer release of the `com.lightningkite.services:*` (service-abstractions)
+library, and the telemetry refactor below spans both libraries. If your build pins a `serviceAbstractions`
+version of its own, it **must** be raised to the version your Lightning Server 5.2 build was compiled against
+— otherwise you get a clean compile but a runtime `NoSuchMethodError` (e.g.
+`SettingContext.getOpenTelemetry()`) as mismatched classes meet on the classpath.
+
+```toml
+# gradle/libs.versions.toml
+# Match whatever your Lightning Server 5.2 release depends on. 5.2.0 uses:
+serviceAbstractions = "1.2.0-1-b2f7bd67"
+```
+
+You can confirm the exact version from the Lightning Server release's POM (the `com.lightningkite.services`
+dependency versions). This is the single most important step — do it first.
+
+## 1. `AuthEndpoints` / `SessionManager` now require a `cache`
+
+`AuthEndpoints` (and its superclass `SessionManager`) gained a required `cache: Runtime<Cache>` constructor
+parameter, positioned immediately after `database`. It backs auth-related caching (e.g. session/proof lookup
+keys and rate limiting), so it must be a **shared** cache in any multi-instance or serverless deployment — not
+the in-memory `"ram"` cache — otherwise instances will not see each other's entries.
+
+```kotlin
+// Before (5.1)
+class SessionEndpoints : AuthEndpoints<User, User.ID>(
+    principal = UserAuth,
+    database = Server.database,
+) { /* ... */ }
+
+// After (5.2)
+class SessionEndpoints : AuthEndpoints<User, User.ID>(
+    principal = UserAuth,
+    database = Server.database,
+    cache = Server.cache,
+) { /* ... */ }
+```
+
+Pass whatever `Runtime<Cache>` setting your server already defines (`Server.cache` in the example).
+
+## 2. Telemetry settings: `OpenTelemetrySettings` → `TelemetryBackend.Settings`
+
+Telemetry configuration was unified onto the service-abstractions `TelemetryBackend` SPI. Two things changed:
+
+- The `telemetrySettings` global is now the **non-nullable** type
+  `TelemetryBackend.Settings` (was a nullable `OpenTelemetrySettings?`).
+- `com.lightningkite.services.otel.OpenTelemetrySettings` is deprecated. The same URL schemes it accepted are
+  now registered directly on `TelemetryBackend.Settings` by the OpenTelemetry module.
+
+Update the import:
+
+```kotlin
+// Before
+import com.lightningkite.services.otel.OpenTelemetrySettings
+// After
+import com.lightningkite.services.telemetry.TelemetryBackend
+```
+
+Then translate the values. A configured backend becomes a `TelemetryBackend.Settings(url = ...)`, and
+"telemetry off" — previously expressed as `null` — becomes the default `TelemetryBackend.Settings()`, whose
+`url` defaults to `"noop"` (a no-op backend):
+
+```kotlin
+// Before (5.1)
+telemetrySettings.direct(OpenTelemetrySettings("console", batching = null))
+telemetrySettings.direct(null)   // disabled
+
+// After (5.2)
+telemetrySettings.direct(TelemetryBackend.Settings(url = "console"))
+telemetrySettings.direct(TelemetryBackend.Settings())   // disabled (url = "noop")
+```
+
+The URL schemes `console`, `log`, `dev`, `debounced-dev`, and `otlp-grpc` / `otlp-http` / `otlp-https` are
+registered when the OpenTelemetry module (`com.lightningkite.services:otel-jvm`) is on the classpath. Without
+it, only the built-in `noop` scheme is available. Helper extensions such as
+`telemetrySettings.otelGrafanaCloud(...)` are unaffected and continue to work.
+
+## 3. Update the `telemetry` entry in existing `settings.json` files
+
+Because `telemetrySettings` is no longer nullable (see above), the serialized form changed too. Any existing
+`settings.json` (or `settings.testing.json`, etc.) that carries `"telemetry": null` — the 5.1 way of saying
+"disabled" — will now fail to **load** at startup with a JSON parse error, since the deserializer expects a
+`TelemetryBackend.Settings` object rather than `null`.
+
+```jsonc
+// Before (5.1)
+"telemetry": null,
+
+// After (5.2) — object form; url "noop" means disabled
+"telemetry": { "url": "noop" },
+```
+
+A configured backend uses the same URL schemes as above, e.g. `"telemetry": { "url": "console" }`. This only
+affects settings files you carry across the upgrade; a freshly generated settings file already uses the new
+shape.
+
+## 4. AWS serverless deployments must declare an `applicationVpc` (AWS deployers only)
+
+If you deploy to AWS with `TerraformAwsServerlessDomainBuilder`, that builder now requires an `applicationVpc`
+override — without one the deployment object fails to compile ("is not abstract and does not implement abstract
+member: `val applicationVpc: AwsVpc`"). Deployments that don't run inside a VPC use `AwsVpc.None`:
+
+```kotlin
+object LkEnv : TerraformAwsServerlessDomainBuilder<Server>(Server) {
+    // ...existing overrides (region, handler, storageBucket, ...)
+    override val applicationVpc: AwsVpc = AwsVpc.None   // add this; import com.lightningkite.services.terraform.AwsVpc
+}
+```
+
+This is compile-time only and unrelated to local runs, but every AWS deployment object in your project needs it.
+
+## Not source-breaking, but worth knowing
+
+- **Engine reliability settings.** The JDK, Netty, and Ktor engines share a new `EngineReliabilitySettings`
+  (graceful shutdown, bounded thread pools, request size/time limits). It has sensible defaults, so no code
+  change is required; review the defaults if you tune server capacity.
+- **Docs.** The endpoint, database, authentication, files, and websockets guides were substantially rewritten
+  for 5.x — worth a re-read if you onboarded on an earlier prerelease.

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -1,5 +1,155 @@
-# Websockets
+# WebSockets
 
-**OUT OF DATE**
+Last updated July 2025 (`version-5`)
 
-TODO
+Lightning Server supports WebSockets for real-time, two-way communication. The core primitives live in
+`com.lightningkite.lightningserver.websockets`; the `typed` module adds type-safe WebSockets that participate in
+SDK generation.
+
+A key design goal is that the same handler runs identically whether the server is a single local process or a
+fleet of AWS Lambda instances behind API Gateway. To make that work, connection state and cross-connection
+delivery are modeled explicitly (serializable storage and pub/sub topics) rather than kept in local memory.
+
+## Declaring a WebSocket endpoint
+
+Bind a `WebSocketHandler` to a path with `bind`. The handler is built from lifecycle callbacks. The value returned
+by `willConnect` becomes this connection's `STORAGE` (its per-connection state); its type is inferred.
+
+```kotlin
+import com.lightningkite.lightningserver.websockets.*
+import kotlin.uuid.Uuid
+
+object ChatEndpoints : ServerBuilder() {
+    val echo = path.path("ws").path("echo") bind WebSocketHandler(
+        // Runs before the connection is accepted. Returns the initial STORAGE.
+        willConnect = { request -> "echo-${Uuid.random()}" },
+        // Runs once the connection is open. `this` is the connection.
+        didConnect = { send("Echo server ready") },
+        // Runs for each inbound frame from the client.
+        messageFromClient = { frame -> send("Echo: ${frame.text}") },
+        // Runs when the connection closes.
+        disconnect = { reason -> println("Closed: $currentState ($reason)") },
+    )
+}
+```
+
+### Connection lifecycle
+
+The callbacks receive different contexts:
+
+- `willConnect: suspend ServerRuntime.(request) -> STORAGE` — runs with a `ServerRuntime`. Return the initial
+  state. Throwing here rejects the connection.
+- `didConnect`, `messageFromClient`, `disconnect` — run with the `WebSocketConnection` as receiver, which extends
+  `ServerRuntime` and adds WebSocket-specific members.
+
+Inside those callbacks you have access to:
+
+- `currentState: STORAGE` — the current per-connection state.
+- `send(...)` — send a frame to the client. Overloads accept `String`, `ByteArray`, or a `WebSocketFrame`.
+- `subscribe(topic)` / `unsubscribe(topic)` — join or leave a pub/sub topic.
+- `updateStateImmediately { }` / `queueStateUpdate { }` — atomically update `STORAGE`.
+- `close(reason)` — close with a `WebSocketClose` code (e.g. `WebSocketClose.NORMAL`).
+
+Inbound frames are `WebSocketFrame` (`WebSocketFrame.Text` or `WebSocketFrame.Binary`). Use `frame.text` for the
+string form.
+
+## Topics and pub/sub delivery
+
+Because a connection may live on a different instance than the code that wants to message it, server-to-client
+broadcasts go through **topics**. A topic is a named, typed channel that connections subscribe to; publishing to it
+delivers the message to every subscribed connection, across all instances, via the configured pub/sub service.
+
+Declare a topic on a path with `.topic(serializer)`:
+
+```kotlin
+import com.lightningkite.lightningserver.runtime.send // topic.send(...) extension
+import kotlinx.serialization.builtins.serializer
+
+object ChatEndpoints : ServerBuilder() {
+    val chatTopic = path.path("ws").path("chat-topic").topic(ChatMessage.serializer())
+
+    val chatSocket = path.path("ws").path("chat") bind WebSocketHandler(
+        willConnect = { Uuid.random().toString() },
+        didConnect = {
+            subscribe(chatTopic)                 // start receiving topic messages
+            send("Welcome, session $currentState")
+        },
+        messageFromClient = { frame ->
+            val incoming = Json.decodeFromString(ChatMessage.serializer(), frame.text)
+            chatTopic.send(incoming)             // broadcast to all subscribers
+        },
+        // Handle messages that arrive from subscribed topics.
+        topicHandlers = {
+            chatTopic bind { message ->
+                send(Json.encodeToString(ChatMessage.serializer(), message.value))
+            }
+        },
+    )
+}
+```
+
+You can also publish to a topic from anywhere that has a `ServerRuntime` context — for example, from an HTTP
+handler — using the `send` extension (`import com.lightningkite.lightningserver.runtime.send`):
+
+```kotlin
+val announce = path.path("announce").arg<String>("text").get bind HttpHandler { request ->
+    chatTopic.send(ChatMessage(content = request.path.arg1))
+    HttpResponse.plainText("sent")
+}
+```
+
+Topics may carry path parameters, so subscriptions can be scoped to a specific resource. A single-argument topic is
+published with `topic.send(path1 = "user123", value = ...)` and subscribed to with `subscribe(topic, "user123")`.
+
+## Multiplexed connections
+
+`MultiplexWebSocketHandler` lets a client run many logical channels over a single physical WebSocket connection,
+which is useful when a client wants several simultaneous subscriptions without opening many sockets.
+
+```kotlin
+val multiplex = path.path("ws").path("multiplex") bind MultiplexWebSocketHandler()
+```
+
+`QueryParamWebSocketHandler` is a related helper that selects the underlying handler based on a query parameter.
+
+## Typed WebSockets
+
+The `typed` module provides `ApiWebsocketHandler`, which adds typed `INPUT`/`OUTPUT` messages, authentication, and
+SDK generation. Instead of raw frames, your callbacks receive already-deserialized `INPUT` values and `send` takes
+an `OUTPUT` value; content negotiation (JSON/CBOR) is handled for you.
+
+```kotlin
+import com.lightningkite.lightningserver.typed.ApiWebsocketHandler
+import com.lightningkite.lightningserver.auth.noAuth
+
+val liveFeed = path.path("ws").path("feed") bind ApiWebsocketHandler<_, Unit, User?, FeedRequest, FeedUpdate>(
+    summary = "Live Feed",
+    description = "Streams feed updates to the client.",
+    auth = noAuth,
+    willConnectType = { access -> Unit },
+    messageFromClientType = { request: FeedRequest ->
+        send(FeedUpdate(/* ... */))   // send takes a typed OUTPUT
+    },
+)
+```
+
+Inside the typed callbacks, `auth()` resolves the connection's authenticated principal, and `send`, `subscribe`,
+and the state helpers behave as they do for raw handlers.
+
+`ModelRestUpdatesWebsocket` (and the combined `ModelRestEndpoints(info) + ModelRestUpdatesWebsocket(info)`) build
+on this to push live database changes to clients — see the model REST documentation.
+
+## Local vs. AWS execution models
+
+The lifecycle above is identical across engines, but the machinery underneath differs:
+
+- **Local engines (Ktor, Netty, JDK).** Everything runs in one process. Handlers that implement
+  `DirectExecutableWebSocketHandler` are driven directly, bypassing pub/sub overhead. Per-connection state and
+  subscriptions are kept in-process.
+- **AWS (API Gateway + Lambda).** Each frame may be handled by a different Lambda instance, so nothing can rely on
+  local memory. The `STORAGE` object is serialized and stored (in DynamoDB), subscriptions are tracked there too,
+  and outbound messages are routed either directly to the API Gateway connection (via the connection's
+  `engineSocketId`) or through the pub/sub service. This is why `STORAGE` must be `@Serializable` and why
+  cross-connection messaging goes through topics rather than direct references.
+
+Writing to the lifecycle/topic API keeps your code portable between the two.

--- a/plans/architecture-review-2026-07.md
+++ b/plans/architecture-review-2026-07.md
@@ -1,0 +1,145 @@
+# Lightning Server v5 — Architecture Review & Roadmap
+
+**Date:** 2026-07-06
+**Scope:** Full-repo design review (core, typed, auth/sessions, engines, deployment, data layer boundary, peripheral modules, build/docs/test health). Complements the existing `todo.md`.
+
+---
+
+## Overall Assessment
+
+The framework's fundamentals are strong: the definition→build()→runtime lifecycle is clean and immutable-after-build, the type-safe path DSL and Condition/Modification query DSL are genuinely good, the service-abstractions boundary is unidirectional and tidy, crypto choices in auth are correct (constant-time comparisons, PBKDF2 for passwords, fast hash only for high-entropy secrets), and the recent OpenTelemetry work is solid. The weak points cluster in five places:
+
+1. **Security hardening gaps** — OAuth lacks PKCE and real state/CSRF validation; no engine emits the security headers `expectations.md` itself requires; JSON parsing is lenient with no size/depth limits.
+2. **No cross-engine conformance suite** — four engines each hand-roll request/response translation (~800 LOC duplicated) with no shared test asserting they behave identically per `expectations.md`.
+3. **AWS serverless reliability** — scheduled tasks have no distributed lock (unlike LocalEngine), async tasks are fire-and-forget Lambda invokes with no retry/DLQ, and Terraform is generated via string templating.
+4. **SDK generators are fragile** — ~900 LOC of hand-indented string building, silent skips on unmappable types, snapshot-only tests.
+5. **Repo/docs hygiene** — ~15 empty legacy `server-*` dirs, `local/` with sensitive files tracked, `files.md` documents the v4 API, `websockets.md` is a 5-line stub, coverage gate set to 0%.
+
+---
+
+## Detailed Critique by Area
+
+### Core (`core`, `core-shared`)
+
+**Good:** Immutable ServerDefinition with duplicate-endpoint detection; type-safe PathSpec0–3/Many hierarchy; settings two-phase lifecycle with circular-dependency detection; exception responses flow back through interceptors so CORS applies to errors; HEAD→GET fallback and trailing-slash redirects.
+
+**Issues:**
+- `Serialization.kt:50,63,76` — all JSON instances use `isLenient = true`; no nesting-depth or payload-size limits on deserialization (DoS surface). Provide strict instances for external input.
+- `ServerSettings.kt:91-111` — settings registry is `MapRegistry<ServerSetting<*,*>, Any?>` with unchecked casts; wrong-typed config fails deep in transformation instead of at registration. Also `goal.getOrRegister()` during `get()` is not synchronized (concurrent double-transform possible).
+- `ServerDefinition.kt:147-148` — serializersModule lambdas are evaluated lazily; a throwing module getter isn't caught until first handler use. Evaluate eagerly in `build()`.
+- `ServerDefinition.kt:175-182` — HTTP method merging on path collision is silent while websocket collision throws; asymmetric and undocumented.
+- Interceptor ordering is implicit registration order with no priority mechanism; `HttpInterceptor.compileAndInstrument()` (`HttpInterceptor.kt:102-117`) uses a fragile `reduceIndexed` idx==1 special case.
+- No typed query-parameter extraction (path args are typed, query params are stringly-typed maps).
+- Request bodies are fully buffered; no streaming request path or multipart parsing.
+- No response invariant validation (204-with-body, 3xx-without-Location).
+- `Runtime.Cached` (`ServerSetting.kt:95-114`) keys its cache on a weak reference to the runtime — cache silently evaporates under GC.
+
+### Typed endpoints & SDK generation (`typed`, `typed-shared`)
+
+**Good:** Ergonomic reified `api()` DSL; comprehensive JSON Schema/OpenAPI generation with annotation extension points; W6 warnings for undeclared thrown errors; ModelRestEndpoints generates a full CRUD surface with scoped auth.
+
+**Issues:**
+- `OpenApi.kt:223` (TODO) — declared `errorCases` never make it into OpenAPI error responses; clients can't see error schemas. Path parameters emitted as an empty list (`OpenApi.kt:~300`).
+- GET/HEAD inputs deserialize from query params with no validation that the input type is query-representable; complex inputs fail silently.
+- Both SDK generators (`TypescriptFetcherSdk.kt` ~540 LOC, `FetcherSdk.kt` ~320 LOC) are raw `Appendable` string builders with manual indent tracking; generic substitution via string `.replace()` can false-match substring type names; unmappable serializers are skipped silently (`continue`) instead of failing the build.
+- SDK tests are snapshot-only; no unit tests for type-mapping (`tsType()`, `kotlinTypeString()`, `kotlinSerializer()` spread across files with no single source of truth).
+- ModelRestEndpoints declares mostly-empty `errorCases` while actually throwing (uniqueness violations → W6 spam); no pagination metadata; bulk operations non-atomic.
+
+### Auth & sessions
+
+**Good:** Session secrets random (24 bytes), stored only hashed, constant-time comparison; lazy hash migration; single-use PIN with attempt caps and PBKDF2; Apple JWT verification validates signature/issuer/audience/expiry before trust; masquerade is default-deny with preserved auth chain.
+
+**Issues (ordered by severity):**
+- **No PKCE** anywhere in sessions-oauth (verified: zero hits for `code_challenge`).
+- **OAuth state is `Uuid.random()` generated per `/open` call and not stored/validated on callback** (`OauthProofEndpoints.kt:~105`) — no real CSRF binding.
+- No redirect-URI whitelist validation on callback.
+- Rate limiting (`Cache.ext.kt:49-78` `constrainAttemptRate`) is a flat counter+block window — no exponential backoff, no per-IP dimension; block-window resets enable slow brute-force.
+- No refresh-token rotation; every refresh writes session metadata to DB (scaling concern).
+- Masqueraded sessions inherit the full parent scope set; should be restrictable to a subset. No audit logging of masquerade or auth events generally.
+- `sessions-openid-provider` is a stub (not even in settings.gradle.kts) — delete or finish.
+- Password hashing is PBKDF2-100k; consider Argon2id longer-term.
+
+### Engines & deployment
+
+**Good:** Clean `ServerRuntime` interface; LocalEngine shares scheduling (with cache-based distributed lock + TTL), graceful shutdown with drain, websocket backpressure via bounded channels; CRaC gives Lambda ~100-200ms restores.
+
+**Issues:**
+- **No engine emits `X-Content-Type-Options: nosniff` or HSTS** despite `expectations.md` requiring both (verified — only the header-name constant exists). One `SecurityHeadersInterceptor` in core fixes all engines at once.
+- **No shared conformance test suite** run against all four engines; per-engine reliability tests exist but expectations.md compliance is untested.
+- ~800 LOC of duplicated request/response translation across Ktor/Netty/JDK/AWS adapters; no `HttpRequestAdapter`-style shared layer for path/header/body/real-IP extraction.
+- **AWS schedules have no distributed lock** (`AwsAdapterSchedule.kt`) — overlapping EventBridge fires run concurrently, unlike LocalEngine.
+- **AWS tasks are `Lambda.Invoke(Event)` fire-and-forget** — no retry, no DLQ, no queue.
+- AWS websocket state does an optimistic-lock CAS loop against DynamoDB capped at 50 attempts, with a comment acknowledging non-deterministic serialization can thrash it (`AwsAdapterWs.kt:~88`) — needs canonical serialization.
+- Terraform generation (~1,200 LOC in engine-aws-serverless, ~200 in deploy-aws-ec2) is string templating: no resource-reference safety, errors surface at `terraform apply`.
+- No standard `/health` or `/metrics` endpoint convention (each app hand-rolls).
+- Range: parsing utilities exist in `files/ranging.kt` but Range/Accept-Ranges are not honored engine-wide.
+
+### Data layer boundary (with service-abstractions)
+
+**Good:** Clean unidirectional dependency; rich Condition/Modification DSL (geo, full-text, bitwise, per-element); ModelPermissions gives row-level + field-level (mask) + update-restriction security, serializable so clients can introspect capabilities.
+
+**Issues:**
+- **No transaction API** in the public `Database` interface (acknowledged TODO at `Database.kt:408-413`); multi-table endpoint operations have no atomicity story.
+- **No migration framework** — Postgres impl explicitly punts to Flyway/Liquibase; the safe-evolution pattern (nullable-first fields) is convention, not tooling. No schema-drift detection.
+- Postgres stores models as JSONB only — no native columns, weak indexing on nested fields; "partial" is accurate.
+- Missing DSL ops: compare-and-swap (optimistic locking), list insert-at-index, collection isEmpty (old op deprecated with no replacement, `Condition.kt:393-403`), limited aggregations (no Min/Max).
+- URL-scheme service wiring validates only at runtime; a bad URL fails on first use rather than at startup.
+
+### Repo hygiene, build, docs, tests
+
+- ~15 `server-*` directories are empty v4 remnants; `server/`, `processor/`, `coroutine-websockets/` have no build files. Delete.
+- `local/` contains logs/notes/keys (e.g. `openaikey.txt`) — should be untracked; `site/` (built MkDocs) shouldn't live on the main branch.
+- `files.md` documents the v4 API (marked OUT OF DATE); `websockets.md` is a 5-line TODO stub; no v4→v5 migration guide in docs/ (only in plans/). The `docs-guide` drift-checked-examples module is excellent — extend its coverage.
+- Kover verify minBound is 0 (no gate); detekt/CVE scanning are report-only.
+- `demo/` has 20 source files but only 5 test files — weak as the reference implementation.
+- `secret-source-aws` has zero tests and 7 embedded TODOs.
+
+---
+
+## Recommended Roadmap
+
+### Phase 1 — Security & correctness (do first)
+
+1. **OAuth hardening (sessions-oauth):** implement PKCE (RFC 7636); persist `state` (cache/cookie) and validate on callback; add redirect-URI whitelist validation.
+2. **SecurityHeadersInterceptor in core:** `X-Content-Type-Options: nosniff` always, HSTS when public URL is https, wired by default; conformance-tested. (Closes expectations.md gap for all engines at once.)
+3. **JSON input hardening:** strict (non-lenient) Json for external request bodies + configurable max payload size / nesting depth; keep lenient variant for settings files.
+4. **AWS schedule locking:** port LocalEngine's cache `setIfNotExists` lock pattern to `AwsAdapterSchedule` (DynamoDB or cache-backed).
+5. **Auth audit logging:** structured events for login/failure/refresh/masquerade; masquerade scope restriction (subset of parent scopes).
+6. **Rate limiting upgrade:** exponential backoff in `constrainAttemptRate`, optional per-IP key dimension.
+7. Settings type safety: validate types at `register()` time; make `goal` map access thread-safe; eagerly evaluate serializersModule getters in `build()`.
+
+### Phase 2 — Reliability & testing infrastructure
+
+8. **EngineConformanceTest:** one shared suite (HEAD fallback, OPTIONS, CORS, security headers, timeout, body limits, trailing slash, Range on files) parameterized over Ktor/Netty/JDK/AWS-local. This is the highest-leverage test investment in the repo.
+9. **AWS task reliability:** SQS-backed task queue (or at minimum Lambda DLQ + retry policy) replacing bare `Invoke(Event)`.
+10. **Canonical serialization for AWS websocket state** to stop CAS-loop thrash.
+11. **Raise the coverage gate** from 0% to a real baseline and ratchet; add tests to `secret-source-aws` (currently zero) and demo (integration tests for the blog flows).
+12. **OpenAPI completeness:** emit declared errorCases as documented error responses (`OpenApi.kt:223` TODO); emit path parameters; fill in ModelRestEndpoints errorCases (kills W6 spam).
+13. Standard `/health` + `/metrics` meta-endpoints module.
+14. Transaction API on `Database` (`suspend fun <R> transaction(block): R`), backend-optional with clear capability signaling — the acknowledged TODO.
+
+### Phase 3 — Maintainability & DX
+
+15. **Refactor SDK generators** onto a small code-model/AST layer (or KotlinPoet for the Kotlin SDK): centralize type mapping in one `TypeMapping` unit, fail loudly on unmappable types, add unit tests per type-mapping case alongside snapshots.
+16. **Extract shared engine adapter layer** (request/response translation helpers: path, headers, real-IP, body streaming) to delete ~800 duplicated LOC across the four engines.
+17. **Repo cleanup:** delete empty `server-*`, `server/`, `processor/`, `coroutine-websockets/` dirs (or include+finish); untrack `local/` and `site/`; decide fate of `sessions-openid-provider`.
+18. **Docs sprint:** rewrite `files.md` for v5; write `websockets.md`; publish v4→v5 migration guide; extend docs-guide drift-checked examples to files/media/websockets.
+19. Typed query parameters (QuerySpec analog to PathSpec) and a typed `bodyAs<T>()` helper.
+20. Interceptor ordering: explicit priority or documented phases; simplify `compileAndInstrument`.
+21. Streaming request bodies + multipart support (unlocks large uploads without buffering).
+
+### Phase 4 — Strategic / larger bets
+
+22. **Migration tooling:** even minimal — schema fingerprint per model stored in DB, startup drift warning, and documented nullable-first evolution recipe; Flyway hook for Postgres users.
+23. **Postgres maturity:** optional native-column mapping for top-level scalar fields (indexable) with JSONB for nested structure; or explicitly position Postgres as JSONB-only and document the tradeoff prominently.
+24. **Terraform generation safety:** evaluate cdktf/Pulumi or add an HCL-validation test step; at minimum validate generated JSON with `terraform validate` in CI.
+25. Refresh-token rotation + concurrent-session limits + logout-all-devices cascade.
+26. Argon2id option for password hashing.
+27. DSL gaps: compare-and-swap modification, list insert-at-index, collection isEmpty condition, Min/Max aggregates.
+28. Optimistic locking / ETag support in ModelRestEndpoints; pagination metadata (total count / next-page hints).
+
+---
+
+## Cross-reference with existing `todo.md`
+
+The existing todo list (header parsing, ServerSetting thread safety, StartupTask circular deps, CORS per-domain, secret rotation prep, websocket rate limiting) remains valid; items 6, 7, and the auth-module suggestions there overlap Phase 1–2 above. This review adds the OAuth/PKCE, conformance-suite, AWS-reliability, and SDK-generator items as the biggest previously-untracked gaps.


### PR DESCRIPTION
Documentation only — no source changes.

- v5 architecture review and roadmap (`plans/`)
- Rewritten files and websockets guides
- v4→v5 and v5.1→v5.2 migration guides
