### PR TITLE
[6/12] Core request handling: interceptor-chain errors, serializer fail-fast, thread-safe settings

### DIFF
--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
@@ -113,7 +113,12 @@ public data class ServerDefinition(
      * Flattening is **not** sealed or cached to prevent unnecessary intermediate allocations.
      * */
     private fun flatten(): Module {
-        if (modules.isEmpty()) return thisLayer
+        // Even a single-module server routes its serializers module getter through the naming guard so a
+        // throwing getter fails fast with a clear, module-identified error rather than an opaque lazy failure.
+        if (modules.isEmpty()) return thisLayer.copy(
+            internalSerializersModule = thisLayer.internalSerializersModule.namedSerializers("internal", "/"),
+            externalSerializersModule = thisLayer.externalSerializersModule.namedSerializers("external", "/"),
+        )
 
         val flattenedModules = modules.mapItems { it.flatten() }
         // Cache this to avoid repeated list creation in serializers module lambdas
@@ -144,8 +149,19 @@ public data class ServerDefinition(
 
         return Module(
             moduleId = Uuid.NIL,    // When flattening module identification loses meaning
-            internalSerializersModule = { flattenedModuleItems.fold(thisLayer.internalSerializersModule()) { acc, module -> acc + module.internalSerializersModule() } },
-            externalSerializersModule = { flattenedModuleItems.fold(thisLayer.externalSerializersModule()) { acc, module -> acc + module.externalSerializersModule() } },
+            // Each module's serializers module getter is routed through [namedSerializers] so that a getter
+            // which throws fails fast with the offending module's location named, rather than surfacing an
+            // opaque error the first time a request touches serialization.
+            internalSerializersModule = {
+                var acc = thisLayer.internalSerializersModule.namedSerializers("internal", "/")()
+                for ((modPath, module) in flattenedModules) acc += module.internalSerializersModule.namedSerializers("internal", "/$modPath")()
+                acc
+            },
+            externalSerializersModule = {
+                var acc = thisLayer.externalSerializersModule.namedSerializers("external", "/")()
+                for ((modPath, module) in flattenedModules) acc += module.externalSerializersModule.namedSerializers("external", "/$modPath")()
+                acc
+            },
             annotationValidators = { flattenedModuleItems.fold(thisLayer.annotationValidators()) { acc, module -> acc + module.annotationValidators() } },
             httpInterceptors = flattenList { it.httpInterceptors },
             websocketInterceptors = flattenList { it.websocketInterceptors },
@@ -215,6 +231,26 @@ public data class ServerDefinition(
         )
     }
 
+
+    /**
+     * Wraps a module's serializers module [Runtime] so that, when evaluated, any failure is rethrown with the
+     * module's [location] and [kind] ("internal"/"external") named — making the offending module immediately
+     * identifiable instead of surfacing an opaque error the first time a request touches serialization.
+     */
+    private fun Runtime<SerializersModule>.namedSerializers(kind: String, location: String): Runtime<SerializersModule> {
+        val wrapped = this
+        return Runtime {
+            try {
+                wrapped()
+            } catch (e: Exception) {
+                throw IllegalStateException(
+                    "Failed to build the $kind serializers module for the module at '$location'. " +
+                        "Check that module's serializer registration (internalSerialization/externalSerialization).",
+                    e,
+                )
+            }
+        }
+    }
 
     private val reverseLookupHttpHandler: Map<HttpHandler<*>, HttpEndpoint<*>> by lazy {
         endpoints.entries.flatMap { (path, group) ->

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
@@ -60,9 +60,28 @@ private val errorType = TelemetryKey.OfString("error.type")
  */
 public suspend fun ServerRuntime.handle(request: HttpRequest<PathSpec>): HttpResponse = instrumentHttpRequest(request) {
     var errorType: String? = null
+
+    // Turns a thrown error into an HTTP response via the configured exception handler,
+    // recording the error type for instrumentation; falls back to a bare 500 if the handler
+    // itself throws. Applied INSIDE the interceptor chain (below) so error responses still
+    // pass back through the interceptors — most importantly CORS. Otherwise error responses
+    // ship without CORS headers and browsers misreport every 4xx/5xx as a CORS failure.
+    suspend fun handleError(e: Exception, label: String? = e::class.simpleName): HttpResponse {
+        errorType = label
+        return try {
+            instrument("exceptionHandler") { server.exceptionHandler.handle(request, e) }
+        } catch (_: Exception) {
+            errorType = "unhandled_exception"
+            HttpResponse(status = HttpStatus.InternalServerError)
+        }
+    }
+
     val response = try {
         server.compiledHttpInterceptors.intercept(request) { req ->
             this.logger.info { "${request.path} accessed by ${request.sourceIp}" }
+            // Map handler/route/compression exceptions to responses in-place so the surrounding
+            // interceptors (CORS, etc.) still post-process error responses.
+            try {
             val result = try {
                 // Route resolution must live inside this try so that a RouteNotFoundException (e.g. a HEAD
                 // request with no HEAD handler, or a missing trailing slash) is caught below and recovered
@@ -173,37 +192,30 @@ public suspend fun ServerRuntime.handle(request: HttpRequest<PathSpec>): HttpRes
                 } else result.headers,
                 body = TypedData(newData, result.body.mediaType)
             )
-        }
-    } catch (timeout: TimeoutCancellationException) {
-        // A handler exceeded its HttpHandler.timeout. Map to 408 through the normal exception handler so the
-        // error body is formatted consistently. (Other CancellationExceptions — e.g. client disconnect — are
-        // NOT caught here and fall through unchanged.)
-        errorType = "timeout"
-        this.logger.warn { "Request to ${request.path} exceeded its handler timeout." }
-        instrument("exceptionHandler") {
-            server.exceptionHandler.handle(
-                request,
-                HttpStatusException(
-                    status = HttpStatus.RequestTimeout,
-                    detail = "timeout",
-                    message = "The request handler exceeded its timeout.",
-                ),
-            )
+            } catch (timeout: TimeoutCancellationException) {
+                // A handler exceeded its HttpHandler.timeout. Map to 408 through the normal exception handler so
+                // the error body is formatted consistently. (Other CancellationExceptions — e.g. client
+                // disconnect — are handled by the generic catch below, matching prior behavior.)
+                this.logger.warn { "Request to ${request.path} exceeded its handler timeout." }
+                handleError(
+                    HttpStatusException(
+                        status = HttpStatus.RequestTimeout,
+                        detail = "timeout",
+                        message = "The request handler exceeded its timeout.",
+                    ),
+                    label = "timeout",
+                )
+            } catch (e: Exception) {
+                this.logger.error(e) { "Exception in HTTP" }
+                handleError(e)
+            }
         }
     } catch (e: Exception) {
-        errorType = e::class.simpleName
-        try {
-            this.logger.error(e) { "Exception in HTTP" }
-            instrument("exceptionHandler") {
-                server.exceptionHandler.handle(
-                    request,
-                    e
-                )
-            }
-        } catch (_: Exception) {
-            errorType = "unhandled_exception"
-            HttpResponse(status = HttpStatus.InternalServerError)
-        }
+        // Safety net for exceptions thrown by an interceptor itself (outside the handler), which
+        // never reach the in-chain handling above and so may lack interceptor-applied headers
+        // (e.g. CORS) — acceptable for this rare failure mode.
+        this.logger.error(e) { "Exception in HTTP interceptor chain" }
+        handleError(e)
     }
     HttpInstrumentationResult(response, response.status.code, errorType)
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/settings/ServerSettings.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/settings/ServerSettings.kt
@@ -5,6 +5,7 @@ import com.lightningkite.lightningserver.definition.builder.*
 import com.lightningkite.lightningserver.logger
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.services.otel.applyToLogback
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.contracts.*
 
 /**
@@ -89,7 +90,18 @@ public class ServerSettings private constructor(
     private var usingDefaults: Boolean = false
 
     private val serializable: MapRegistry<ServerSetting<*, *>, Any?> = MapRegistry()
-    private val goal: MapRegistry<ServerSetting<*, *>, Any?> = MapRegistry()
+
+    // Transformed results, keyed by setting. Backed by a ConcurrentHashMap so a fully-resolved value can be
+    // read on the hot path without locking. ConcurrentHashMap forbids null values, so a null result is stored
+    // as [NULL_RESULT] and unwrapped on read.
+    private val goal = ConcurrentHashMap<ServerSetting<*, *>, Any>()
+
+    // A single lock guarding transformation in [get]. A single (reentrant) lock — rather than per-setting
+    // locks — is used deliberately: a setting's getter may resolve its dependencies by calling get() again on
+    // the same thread, which re-enters this lock harmlessly, whereas per-setting locks could produce a
+    // cross-thread lock-ordering deadlock between two mutually-dependent settings. Correctness (transform once)
+    // is preserved because the only concurrent writers to [goal] go through this lock.
+    private val resolveLock = Any()
 
     // Track settings currently being resolved to detect circular dependencies at runtime
     private val resolving: ThreadLocal<MutableSet<ServerSetting<*, *>>>? =
@@ -137,7 +149,7 @@ public class ServerSettings private constructor(
      */
     public infix fun <RESULT> ServerSetting<*, RESULT>.setStatic(value: RESULT) {
         if (ready) throw IllegalStateException("Settings are marked as ready.")
-        goal.register(this, value as Any?)
+        goal[this] = value ?: NULL_RESULT
     }
 
     /**
@@ -250,7 +262,16 @@ public class ServerSettings private constructor(
     public fun <SERIALIZABLE, RESULT> get(key: ServerSetting<SERIALIZABLE, RESULT>): RESULT {
         if (!ready) throw IllegalStateException("Settings not ready yet.")
 
-        return goal.getOrRegister(key) {
+        // Lock-free fast path: once resolved, the value is published in [goal] and read without locking.
+        goal[key]?.let { return it.unwrapResult() as RESULT }
+
+        // Slow path: resolve under [resolveLock] so each setting is transformed at most once, even when
+        // multiple threads request it for the first time concurrently. The per-thread [resolving] set (checked
+        // inside the lock) still detects circular dependencies.
+        val resolved: Any? = synchronized(resolveLock) {
+            // Re-check now that we hold the lock; another thread may have resolved it while we waited.
+            goal[key]?.let { return it.unwrapResult() as RESULT }
+
             // Check for circular dependency during resolution
             val currentlyResolving = resolving?.get()
             if (currentlyResolving != null && key in currentlyResolving) {
@@ -258,7 +279,7 @@ public class ServerSettings private constructor(
             }
 
             currentlyResolving?.add(key)
-            try {
+            val result = try {
                 overrides[key]?.let { defer ->
                     serializable[key]
                         ?.let { key.get(it as SERIALIZABLE) } // specified in settings file
@@ -282,8 +303,14 @@ public class ServerSettings private constructor(
             } finally {
                 currentlyResolving?.remove(key)
             }
-        } as RESULT
+            goal[key] = result ?: NULL_RESULT
+            result
+        }
+        return resolved as RESULT
     }
+
+    /** Unwraps the [NULL_RESULT] sentinel used to store null results in the null-hostile [goal] map. */
+    private fun Any.unwrapResult(): Any? = if (this === NULL_RESULT) null else this
 
     // For some dumb fucking reason kotlin made this internal, and it's what getOrElse should do in the first place!
     @OptIn(ExperimentalContracts::class)
@@ -328,7 +355,7 @@ public class ServerSettings private constructor(
         overrides: Map<ServerSetting<*, *>, Runtime<*>> = this.overrides,
     ) = ServerSettings(settings, overrides).also {
         it.serializable.include(this.serializable)
-        it.goal.include(this.goal)
+        it.goal.putAll(this.goal)
     }
 
     public operator fun plus(requirement: ServerSetting<*, *>): ServerSettings = copy(settings + requirement)
@@ -336,6 +363,11 @@ public class ServerSettings private constructor(
         copy(settings + requirements)
 
     public data class Override<S, R>(val override: ServerSetting<S, R>, val deferTo: Runtime<R>)
+
+    private companion object {
+        /** Sentinel stored in [goal] to represent a resolved-but-null result (ConcurrentHashMap forbids null values). */
+        private val NULL_RESULT = Any()
+    }
 }
 
 /*
@@ -347,9 +379,6 @@ public class ServerSettings private constructor(
  * 2. The missing settings check in `ready()` doesn't distinguish between truly required settings
  *    and optional settings with no default. The error message could be more helpful.
  *
- * 3. The `get()` function performs lazy transformation but the caching isn't thread-safe.
- *    If called concurrently during initial ready phase, could transform the same setting twice.
- *    (Though this is documented in ServerSetting.kt TODO, worth noting here too.)
  *
  * 4. `readyUsingDefaults()` bypasses all validation with a warning, but doesn't actually
  *    enforce that defaults exist for all settings. Could still throw during get().

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerDefinitionSerializersModuleTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerDefinitionSerializersModuleTest.kt
@@ -1,0 +1,44 @@
+package com.lightningkite.lightningserver.definition
+
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.*
+import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.plainText
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import kotlinx.serialization.modules.SerializersModule
+import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that a module whose serializers module getter throws fails fast with a clear error that names the
+ * offending module, rather than surfacing an opaque error deep inside a later request.
+ */
+class ServerDefinitionSerializersModuleTest {
+
+    object BadExternalSerializerServer : ServerBuilder() {
+        override val externalSerialization: Runtime<SerializersModule>
+            get() = Runtime { throw IllegalArgumentException("serializer registration blew up") }
+
+        val root = path.get bind HttpHandler<PathSpec0> { HttpResponse.plainText("ok") }
+    }
+
+    @Test
+    fun `throwing external serializers module getter fails fast naming the module`() {
+        BadExternalSerializerServer.test(settings = {}) {
+            val failure = assertFailsWith<IllegalStateException> {
+                // Materializing serialization folds every module's serializers module getter; the bad one throws.
+                serverRuntime.externalSerialization
+            }
+            assertTrue(
+                failure.message?.contains("external serializers module") == true,
+                "Error should identify which serializers module failed. Was: ${failure.message}",
+            )
+            assertTrue(
+                failure.cause?.message?.contains("serializer registration blew up") == true,
+                "Original failure should be preserved as the cause. Was: ${failure.cause?.message}",
+            )
+        }
+    }
+}

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
@@ -1,6 +1,9 @@
 package com.lightningkite.lightningserver.definition
 
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.settings.ServerSettings
 import kotlinx.coroutines.*
+import kotlinx.serialization.builtins.serializer
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -58,5 +61,53 @@ class ServerSettingThreadSafetyTest {
 
         // The computation should only happen once despite 100 concurrent accesses
         assertEquals(1, executionCount.get(), "Runtime should only execute once, got ${executionCount.get()}")
+    }
+
+    /**
+     * Hammers [ServerSettings.get] from many threads for several settings simultaneously and asserts that
+     * each setting's transformer runs exactly once. Guards against the double-transform race that existed
+     * when the goal registry was populated without synchronization.
+     */
+    @Test
+    fun `ServerSettings get transforms each setting exactly once under concurrent first-access`() = runBlocking {
+        val counters = (0 until 8).map { AtomicInteger(0) }
+        val settings = counters.mapIndexed { i, counter ->
+            ServerSetting("setting$i", 0, Int.serializer()) {
+                counter.incrementAndGet()
+                Thread.sleep(20) // Widen the race window so an unsynchronized cache would double-transform.
+                "result-$i"
+            }
+        }
+        val serverSettings = ServerSettings(settings)
+        serverSettings.readyUsingDefaults()
+
+        val runtime = stubRuntime()
+
+        // Every coroutine resolves every setting; without per-setting synchronization the transformers race.
+        (1..100).map {
+            async(Dispatchers.Default) {
+                with(runtime) { settings.map { serverSettings.get(it) } }
+            }
+        }.awaitAll()
+
+        counters.forEachIndexed { i, counter ->
+            assertEquals(1, counter.get(), "Transformer for setting$i should run exactly once, got ${counter.get()}")
+        }
+    }
+
+    /** Minimal [ServerRuntime] stub whose only usable capability is acting as the settings/transformation context. */
+    private fun stubRuntime(): ServerRuntime = object : ServerRuntime {
+        override val server get() = throw NotImplementedError()
+        override val settings get() = throw NotImplementedError()
+        override val internalSerialization get() = throw NotImplementedError()
+        override val externalSerialization get() = throw NotImplementedError()
+        override val serverId get() = ""
+        override val serverVersion get() = ""
+        override val projectName get() = ""
+        override val sharedResources get() = throw NotImplementedError()
+        override suspend fun <T> Task<T>.invoke(input: T) = throw NotImplementedError()
+        override suspend fun <PATH : com.lightningkite.lightningserver.pathing.PathSpec, T> sendWebSocketSubscriptionMessage(
+            event: com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage<PATH, T>,
+        ) = throw NotImplementedError()
     }
 }

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
@@ -1,6 +1,7 @@
 package com.lightningkite.lightningserver.runtime
 
 import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.NotFoundException
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.definition.loggingSettings
 import com.lightningkite.lightningserver.http.*
@@ -86,6 +87,11 @@ class ImplementationHelpersHandleTest {
         // Fast handler with the same short timeout to confirm normal completion is unaffected.
         val fast = path.path("fast").get bind HttpHandler<PathSpec0>(timeout = 100.milliseconds) {
             HttpResponse.plainText("quick")
+        }
+
+        // Always throws, to prove error responses still receive interceptor post-processing.
+        val boom = path.path("boom").get bind HttpHandler<PathSpec0> {
+            throw NotFoundException(detail = "boom", message = "Boom.")
         }
 
         init {
@@ -386,6 +392,34 @@ class ImplementationHelpersHandleTest {
                     )
                 )
                 assertEquals(HttpStatus.RequestTimeout, resp.status)
+            }
+        }
+    }
+
+    @Test
+    fun error_response_still_receives_cors_headers() {
+        // Regression: a handler that throws must still get CORS headers. The exception is now
+        // mapped to a response INSIDE the interceptor chain, so CORS post-processes it. Without
+        // this, the browser masks every 4xx/5xx as a CORS failure and the real error (here, a
+        // 404) is invisible to client JS.
+        TestServer.test(settings = {}) {
+            runBlocking {
+                val resp = serverRuntime.handle(
+                    HttpRequest<PathSpec>(
+                        path = RawHttpEndpoint(asString = "/boom", method = HttpMethod.GET),
+                        queryParameters = QueryParameters.EMPTY,
+                        headers = HttpHeaders { add(HttpHeader.Origin, "https://example.com") },
+                        domain = "example.com",
+                        protocol = "https",
+                        sourceIp = "local",
+                    )
+                )
+                assertEquals(HttpStatus.NotFound, resp.status)
+                assertEquals(
+                    "https://example.com",
+                    resp.headers[HttpHeader.AccessControlAllowOrigin]?.root,
+                    "error responses must carry the CORS allow-origin header",
+                )
             }
         }
     }


### PR DESCRIPTION
Three independent core fixes that everything else in this stack builds on.

- **Route error responses back through the interceptor chain.** Previously an
  exception short-circuited the interceptors, so responses produced from errors
  skipped everything downstream (logging, headers, CORS).
- **Fail fast with a named error when a module's serializers throw.** A throwing
  `serializersModule` used to surface as an opaque failure with no indication of
  which module was at fault.
- **Make settings resolution thread-safe.** Concurrent first-touch of a setting
  could resolve it more than once.

Each change ships with a test.
