### PR TITLE
Fix single-EC2 Route53 AAAA record and daemon-reload ordering

### DIFF
--- a/deploy-aws-ec2/src/main/kotlin/com/lightningkite/lightningserver/terraform/aws/ec2/TerraformAwsSingleEc2Builder.kt
+++ b/deploy-aws-ec2/src/main/kotlin/com/lightningkite/lightningserver/terraform/aws/ec2/TerraformAwsSingleEc2Builder.kt
@@ -280,7 +280,7 @@ public abstract class TerraformAwsSingleEc2Builder<S : ServerBuilder>(
                         "name" - wsDomain
                         "type" - "AAAA"
                         "ttl" - 300
-                        "records" - listOf(expression("aws_instance.ubuntu.ipv6_addresses"))
+                        "records" - listOf(expression("aws_instance.ubuntu.ipv6_addresses[0]"))
                     }
             }
         }
@@ -590,6 +590,10 @@ REGION="$$applicationRegion"""",
             // language="Shell Script"
             appendLine(
                 $$"""
+
+echo "[INFO] Reloading systemd configuration..."
+systemctl daemon-reload
+
 systemctl enable $$projectPrefix
 
 # First-time deploy uses the same script that subsequent SSM-driven redeploys
@@ -599,8 +603,6 @@ echo "[INFO] Running first-time application deploy..."
 
 # === Start Services ===
 echo "[INFO] Starting services..."
-systemctl daemon-reload
-
 systemctl enable angie
 systemctl restart angie
 """


### PR DESCRIPTION
Two narrow single-EC2 deployment fixes, recovered from the stale `apple-sso`
branch where they were bundled with unrelated Apple SSO work.

- The Route53 AAAA record wrapped `ipv6_addresses` -- already a list -- in
  another `listOf(...)`. Now indexes `[0]`.
- `systemctl daemon-reload` ran *after* `systemctl enable`, so the reload could
  not see the unit it was meant to pick up. Moved before.

Terraform-only; no test coverage exists for the deploy builders, so this is
verified by compilation and review, not by tests.
