### PR TITLE
Return 400 instead of 500 for malformed known-device identifiers

### DIFF
--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpoints.kt
@@ -164,7 +164,16 @@ public class KnownDeviceProofEndpoints(
             successCode = HttpStatus.OK,
             implementation = { input: String ->
                 val now = now()
-                val id = input.substringBefore('/').let { Uuid.parse(it) }
+                val id = input.substringBefore('/').let {
+                    try { Uuid.parse(it) }
+                    catch (e: IllegalArgumentException) {
+                        throw BadRequestException(
+                            message = "Invalid known device identifier. ${e.message}",
+                            data = it,
+                            cause = e
+                        )
+                    }
+                }
                 val secret = input.substringAfter('/')
                 cache().constrainAttemptRate(
                     cacheKey = "known-devices-count-${id}"

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpointsTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpointsTest.kt
@@ -220,6 +220,37 @@ class KnownDeviceProofEndpointsTest {
     }
 
     @Test
+    fun `prove rejects malformed device id with bad request`() = runBlocking {
+        TestUser.users.clear()
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val knownDevice = path.path("auth").path("known-device") include KnownDeviceProofEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours
+            )
+        }.let { server ->
+            server.test({}) {
+                // The id segment isn't a valid Uuid; this used to throw an unhandled
+                // IllegalArgumentException (surfaced as a 500) instead of a 400.
+                val malformedSecret = "not-a-uuid/${Uuid.random()}"
+
+                assertFailsWith<BadRequestException>("Malformed device id should be rejected") {
+                    server.knownDevice.prove.test(null, malformedSecret)
+                }
+            }
+        }
+    }
+
+    @Test
     fun `options returns correct configuration`() = runBlocking {
         TestUser.users.clear()
 


### PR DESCRIPTION
`Uuid.parse()` was called on a client-supplied identifier with no error
handling, so malformed input threw `IllegalArgumentException` and surfaced as a
500. It is a bad request, not a server fault.

Recovered from the stale `fixes` branch. Ships with a regression test.
