### PR TITLE
Fix AuthSetting default-scope fallback and masquerade ID decoding

### DIFF
--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AuthRequirement.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AuthRequirement.kt
@@ -178,32 +178,32 @@ public interface AuthRequirement<out SUBJECT : HasId<*>?> {
      *
      * @property default The fallback requirement if not explicitly configured
      */
-    public abstract class AuthSetting(
-        public val default: AuthRequirement<HasId<*>>? = null,
-    ) : AuthRequirement<HasId<*>>, MutableExtensions.Key<AuthRequirement<HasId<*>>> {
+    public abstract class AuthSetting<SUBJECT : HasId<*>?>(
+        public val default: AuthRequirement<SUBJECT>? = null,
+    ) : AuthRequirement<SUBJECT>, MutableExtensions.Key<AuthRequirement<SUBJECT>> {
         context(server: ServerRuntime)
-        public fun setting(): AuthRequirement<HasId<*>>? = server.server.extensions[this]
+        public fun setting(): AuthRequirement<SUBJECT>? = server.server.extensions[this]
 
-        override val requiredScopes: Runtime<Set<RequiredScope>> = Runtime { setting()?.requiredScopes() ?: emptySet() }
-        override fun subscope(subscopes: Iterable<Subscope>): Scoped = Scoped(this, subscopes)
+        override val requiredScopes: Runtime<Set<RequiredScope>> = Runtime { setting()?.requiredScopes() ?: default?.requiredScopes() ?: emptySet() }
+        override fun subscope(subscopes: Iterable<Subscope>): Scoped<SUBJECT> = Scoped(this, subscopes)
 
         context(runtime: ServerRuntime)
-        override suspend fun check(auth: Authentication<*>?): Result<HasId<*>> =
+        override suspend fun check(auth: Authentication<*>?): Result<SUBJECT> =
             setting()?.check(auth) ?: default?.check(auth)
             ?: Result.Rejected("AuthSetting $this has no set value or default")
 
-        public data class Scoped(
-            val wraps: AuthSetting,
+        public data class Scoped<SUBJECT : HasId<*>?>(
+            val wraps: AuthSetting<SUBJECT>,
             val subscopes: Iterable<Subscope>,
-        ) : AuthRequirement<HasId<*>> {
+        ) : AuthRequirement<SUBJECT> {
             override val requiredScopes: Runtime<Set<RequiredScope>> =
-                Runtime { wraps.setting()?.requiredScopes()?.subscope(subscopes) ?: emptySet() }
+                Runtime { wraps.requiredScopes().subscope(subscopes) }
 
-            override fun subscope(subscopes: Iterable<Subscope>): Scoped =
+            override fun subscope(subscopes: Iterable<Subscope>): Scoped<SUBJECT> =
                 copy(subscopes = this.subscopes + subscopes)
 
             context(runtime: ServerRuntime)
-            override suspend fun check(auth: Authentication<*>?): Result<HasId<*>> =
+            override suspend fun check(auth: Authentication<*>?): Result<SUBJECT> =
                 wraps.setting()?.subscope(subscopes)?.check(auth) ?: wraps.default?.subscope(subscopes)?.check(auth)
                 ?: Result.Rejected("AuthSetting $wraps has no set value or default")
         }
@@ -214,21 +214,21 @@ public interface AuthRequirement<out SUBJECT : HasId<*>?> {
      *
      * This represents the highest level of access and has no default fallback.
      */
-    public data object IsSuperUser : AuthSetting()
+    public data object IsSuperUser : AuthSetting<HasId<*>>()
 
     /**
      * Predefined [AuthSetting] for administrative access.
      *
      * Defaults to [IsSuperUser] if not explicitly configured.
      */
-    public data object IsAdmin : AuthSetting(default = IsSuperUser)
+    public data object IsAdmin : AuthSetting<HasId<*>>(default = IsSuperUser)
 
     /**
      * Predefined [AuthSetting] for developer/debug access.
      *
      * Defaults to [IsSuperUser] if not explicitly configured.
      */
-    public data object IsDeveloper : AuthSetting(default = IsSuperUser)
+    public data object IsDeveloper : AuthSetting<HasId<*>>(default = IsSuperUser)
 
     /**
      * Requires any valid authentication, regardless of principal type.

--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/Authentication.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/Authentication.kt
@@ -241,15 +241,48 @@ public data class Authentication<SUBJECT : HasId<*>> private constructor(
             for (reader in server.server.authReaders.sortedByDescending { it.priority }) {
                 val auth = reader.read(input) ?: continue
 
-                input.headers[HttpHeader.XMasquerade]?.root?.let { masquerade ->
-                    val principal = masquerade.substringBefore('/')
+                input.headers[HttpHeader.XMasquerade]?.let { header ->
+                    val masquerade = header.root
 
-                    val handler = server.server.principalTypes[principal] as? PrincipalType<HasId<*>, *>
-                        ?: throw BadRequestException("Principal type $principal is unrecognized for masquerade")
+                    val validEncodings = mapOf(
+                        "str-array" to server.externalSerialization.stringArrayFormat,
+                        "json" to server.externalSerialization.json
+                    )
 
-                    val mask = Authentication<HasId<*>>(
-                        principal,
-                        rawId = masquerade.substringAfter('/'),
+                    if (!masquerade.contains('/')) throw BadRequestException(
+                        """Invalid masquerade value. Expected to be in the form: <principal-name>/<subject-id> (; encoding=[${
+                            validEncodings.keys.withIndex().joinToString("|") { (idx, enc) -> 
+                                if (idx == 0) "${enc}(default)"
+                                else enc
+                            }
+                        }])"""
+                    )
+
+                    val principalName = masquerade.substringBefore('/')
+                    val principal = server.server.principalTypes[principalName] as? PrincipalType<HasId<*>, *>
+                        ?: throw BadRequestException("Principal type $principalName is unrecognized for masquerade")
+
+                    val encoding = header.parameters["encoding"]
+                        ?.let {
+                            validEncodings[it] ?: throw BadRequestException("Invalid encoding type. Supported types are ${validEncodings.keys}")
+                        }
+                        ?: validEncodings.values.first()
+
+                    val idString = masquerade.substringAfter('/')
+                    val id = try {
+                        encoding.decodeFromString(principal.idSerializer, idString)
+                    } catch (e: SerializationException) {
+                        throw BadRequestException(
+                            message = "Invalid masquerade id: ${e.message}",
+                            data = idString,
+                            cause = e
+                        )
+                    }
+
+                    val mask = Authentication(
+                        principalType = principal,
+                        id = id,
+                        rawId = idString,
                         sessionId = null,
                         issuedAt = server.clock.now(),
                         expiration = auth.expiration,
@@ -260,15 +293,10 @@ public data class Authentication<SUBJECT : HasId<*>> private constructor(
                         // gate it in permitMasquerade if you need to restrict it.
                         scopes = auth.scopes,
                         fromMasquerade = auth,
+                        cache = auth.cache,
                     )
 
-                    try {
-                        mask.untypedId
-                    } catch (_: SerializationException) {
-                        throw BadRequestException(message = "Invalid masquerade id", data = mask.rawId)
-                    }
-
-                    if (handler.permitMasquerade(auth, mask)) {
+                    if (principal.permitMasquerade(auth, mask)) {
                         // Audit trail: masquerade is a privilege-sensitive action, so record who
                         // assumed whom. Logged at info because it is an authorized, expected event.
                         server.logger.info { "AUDIT masquerade granted: ${auth.principalName}/${auth.rawId} -> $masquerade" }

--- a/auth/src/test/kotlin/com/lightningkite/lightningserver/auth/AuthRequirementTest.kt
+++ b/auth/src/test/kotlin/com/lightningkite/lightningserver/auth/AuthRequirementTest.kt
@@ -511,6 +511,40 @@ class AuthRequirementTest {
         assertEquals(AuthRequirement.IsSuperUser, scoped.wraps)
     }
 
+    @Test
+    fun `AuthSetting requiredScopes falls back to default when unconfigured`() = runBlocking {
+        // IsAdmin itself is left unconfigured; only its default (IsSuperUser) is set.
+        // requiredScopes() used to ignore `default` and report an empty set here, which
+        // fed incorrect (understated) scopes into generated docs/SDKs.
+        val customRequirement = TestUser.require(scope = RequiredScope("root-scope"))
+
+        object : ServerBuilder() {
+            init {
+                register(TestUser)
+                AuthRequirement.isSuperUser = customRequirement
+            }
+        }.test({}) {
+            val scopes = AuthRequirement.IsAdmin.requiredScopes()
+            assertTrue(scopes.contains(RequiredScope("root-scope")))
+        }
+    }
+
+    @Test
+    fun `AuthSetting Scoped requiredScopes falls back to default when unconfigured`() = runBlocking {
+        val customRequirement = TestUser.require(scope = RequiredScope("root-scope"))
+
+        object : ServerBuilder() {
+            init {
+                register(TestUser)
+                AuthRequirement.isSuperUser = customRequirement
+            }
+        }.test({}) {
+            val scoped = AuthRequirement.IsAdmin.subscope(listOf(Subscope("nested")))
+            val scopes = scoped.requiredScopes()
+            assertTrue(scopes.isNotEmpty())
+        }
+    }
+
     // ========== naturalLanguage Tests ==========
 
     @Test

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/Access.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/Access.kt
@@ -95,4 +95,4 @@ public suspend fun <SUBJECT : HasId<*>?> Request<*>.tryAuth(auth: AuthRequiremen
     auth.check(this[Authentication.CacheKey])
 
 context(server: ServerRuntime, access: Access<*, *, *>)
-public suspend operator fun AuthRequirement.AuthSetting.invoke(): Boolean = accepts(access.authOrNull)
+public suspend operator fun AuthRequirement.AuthSetting<*>.invoke(): Boolean = accepts(access.authOrNull)


### PR DESCRIPTION
**Draft: security-adjacent, with a conflict resolved by hand. Please read that
resolution before merging.** Recovered from the stale `fixes` branch.

- `AuthSetting.requiredScopes` (and `Scoped.requiredScopes`) returned an empty
  scope set whenever the setting relied on its default, so generated OpenAPI and
  SDK documentation understated the scopes actually enforced. Enforcement itself
  was correct, so this is a documentation-correctness bug, not a live authz
  bypass. `AuthSetting` becomes generic to support the fix.
- Masquerade IDs from the `X-Masquerade` header decoded with
  `internalSerialization`, which is meant for database and cache values.
  Client-supplied IDs now decode with `externalSerialization`, matching every
  other client-facing ID, with an optional `encoding=str-array|json` parameter.

**What to review.** Stacked on the auth-hardening PR because both change the
same function. The resolution keeps this branch's decode-time validation and
drops the base PR's separate `mask.untypedId` try/catch as unreachable -- the ID
is now decoded eagerly inside a try/catch, so the later catch can no longer
fire. The base PR's audit logging is preserved verbatim on both the grant and
deny paths. Both behaviours survive, but this is two changes merged by hand in
privilege-sensitive code and no test would catch a subtle mistake.

Note the error message is now `"Invalid masquerade id: ${e.message}"`.
`SerializationException` messages can name internal types; tighten it if that is
more than you want to return.

**Coverage gap.** No regression test for the serialization fix itself. Testing
it properly needs a custom ID type with diverging internal and external
serializers wired through the full auth-reader pipeline, which was judged too
involved to add safely here. The scope-fallback fix does ship with tests.
