### PR TITLE
[3/15] Emit baseline security headers on every response

### DIFF
--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
@@ -63,7 +63,15 @@ public data class ServerDefinition(
 
     public val endpoints: PathSpecMap<ServerPathEndpoints> get() = flattened.endpoints
     public val httpInterceptors: List<HttpInterceptor> get() = flattened.httpInterceptors
-    public val compiledHttpInterceptors: HttpInterceptor by lazy { httpInterceptors.compileAndInstrument() }
+
+    // SecurityHeadersInterceptor is prepended (outermost) so every server emits baseline security
+    // headers by default, and so it post-processes the final response after all user interceptors
+    // (e.g. CORS) and after error responses are mapped inside the chain. Prepending here — at the
+    // single top-level composition point — guarantees exactly one instance for the whole server,
+    // rather than one per flattened module.
+    public val compiledHttpInterceptors: HttpInterceptor by lazy {
+        (listOf(SecurityHeadersInterceptor()) + httpInterceptors).compileAndInstrument()
+    }
     public val websocketInterceptors: List<WebSocketHandlerInterceptor> get() = flattened.websocketInterceptors
     public val compiledWebsocketInterceptors: WebSocketHandlerInterceptor by lazy { websocketInterceptors.compileAndInstrument() }
     public val exceptionHandler: ExceptionHttpHandler get() = flattened.exceptionHandler

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
@@ -63,15 +63,7 @@ public data class ServerDefinition(
 
     public val endpoints: PathSpecMap<ServerPathEndpoints> get() = flattened.endpoints
     public val httpInterceptors: List<HttpInterceptor> get() = flattened.httpInterceptors
-
-    // SecurityHeadersInterceptor is prepended (outermost) so every server emits baseline security
-    // headers by default, and so it post-processes the final response after all user interceptors
-    // (e.g. CORS) and after error responses are mapped inside the chain. Prepending here — at the
-    // single top-level composition point — guarantees exactly one instance for the whole server,
-    // rather than one per flattened module.
-    public val compiledHttpInterceptors: HttpInterceptor by lazy {
-        (listOf(SecurityHeadersInterceptor()) + httpInterceptors).compileAndInstrument()
-    }
+    public val compiledHttpInterceptors: HttpInterceptor by lazy { httpInterceptors.compileAndInstrument() }
     public val websocketInterceptors: List<WebSocketHandlerInterceptor> get() = flattened.websocketInterceptors
     public val compiledWebsocketInterceptors: WebSocketHandlerInterceptor by lazy { websocketInterceptors.compileAndInstrument() }
     public val exceptionHandler: ExceptionHttpHandler get() = flattened.exceptionHandler

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpHeader.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpHeader.kt
@@ -128,6 +128,9 @@ public object HttpHeader {
     public const val AccessControlExposeHeaders: String = "Access-Control-Expose-Headers"
     public const val AccessControlMaxAge: String = "Access-Control-Max-Age"
 
+    // Security headers
+    public const val XContentTypeOptions: String = "X-Content-Type-Options"
+
     // Unofficial de-facto headers
     public const val XHttpMethodOverride: String = "X-Http-Method-Override"
     public const val XForwardedHost: String = "X-Forwarded-Host"

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/SecurityHeadersInterceptor.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/SecurityHeadersInterceptor.kt
@@ -5,15 +5,21 @@ import com.lightningkite.lightningserver.runtime.ServerRuntime
 /**
  * HTTP interceptor that adds baseline security headers to every response.
  *
- * This interceptor is installed automatically for every server, so applications get safe defaults
- * without any configuration. It adds:
+ * This is **opt-in** — install it in your `ServerBuilder` to get safe defaults:
+ * ```kotlin
+ * init { install(SecurityHeadersInterceptor()) }
+ * ```
+ * Install it early (before CORS and other interceptors) so it runs outermost and post-processes the
+ * final response, including error responses mapped inside the chain. It adds:
  * - `X-Content-Type-Options: nosniff` on all responses, preventing browsers from MIME-sniffing a
  *   response away from its declared content type.
  * - `Strict-Transport-Security` only when the request arrived over https, instructing browsers to
  *   use https for future requests. Per the HSTS spec, this header is never sent over plain http.
+ *   Behind a TLS-terminating proxy this depends on the engine reporting the original scheme (e.g. from
+ *   `X-Forwarded-Proto`) as `request.protocol`; if the proxy forwards as plain http, HSTS is omitted.
  *
  * Headers a handler already set are left untouched, so an endpoint can override these defaults
- * (for example, a stricter or longer HSTS policy) without producing duplicate header values.
+ * (for example, a stricter or shorter HSTS policy) without producing duplicate header values.
  *
  * @param hstsMaxAgeSeconds The `max-age` used for the Strict-Transport-Security header.
  */
@@ -24,11 +30,13 @@ public class SecurityHeadersInterceptor(
 
     public companion object {
         /**
-         * Default `max-age` for Strict-Transport-Security, in seconds (1 hour), matching the value
-         * required by the framework's `expectations.md`. Production deployments that are confident
-         * in their https setup may prefer a longer value (e.g. 31536000, one year).
+         * Default `max-age` for Strict-Transport-Security: one year, the value browsers and the HSTS
+         * preload list expect. HSTS is only meaningful when it is long-lived — a short max-age gives
+         * an attacker a wide window to downgrade the connection — so this deliberately defaults high.
+         * Only lower it if you are not yet confident your https setup is permanent, since browsers
+         * will refuse plain http to your domain for this long once they see the header.
          */
-        public const val DEFAULT_HSTS_MAX_AGE_SECONDS: Long = 3600
+        public const val DEFAULT_HSTS_MAX_AGE_SECONDS: Long = 31_536_000
     }
 
     context(runtime: ServerRuntime)

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/SecurityHeadersInterceptor.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/SecurityHeadersInterceptor.kt
@@ -1,0 +1,54 @@
+package com.lightningkite.lightningserver.http
+
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+
+/**
+ * HTTP interceptor that adds baseline security headers to every response.
+ *
+ * This interceptor is installed automatically for every server, so applications get safe defaults
+ * without any configuration. It adds:
+ * - `X-Content-Type-Options: nosniff` on all responses, preventing browsers from MIME-sniffing a
+ *   response away from its declared content type.
+ * - `Strict-Transport-Security` only when the request arrived over https, instructing browsers to
+ *   use https for future requests. Per the HSTS spec, this header is never sent over plain http.
+ *
+ * Headers a handler already set are left untouched, so an endpoint can override these defaults
+ * (for example, a stricter or longer HSTS policy) without producing duplicate header values.
+ *
+ * @param hstsMaxAgeSeconds The `max-age` used for the Strict-Transport-Security header.
+ */
+public class SecurityHeadersInterceptor(
+    private val hstsMaxAgeSeconds: Long = DEFAULT_HSTS_MAX_AGE_SECONDS,
+) : HttpInterceptor {
+    override val name: String = "SecurityHeaders"
+
+    public companion object {
+        /**
+         * Default `max-age` for Strict-Transport-Security, in seconds (1 hour), matching the value
+         * required by the framework's `expectations.md`. Production deployments that are confident
+         * in their https setup may prefer a longer value (e.g. 31536000, one year).
+         */
+        public const val DEFAULT_HSTS_MAX_AGE_SECONDS: Long = 3600
+    }
+
+    context(runtime: ServerRuntime)
+    override suspend fun intercept(
+        request: HttpRequest<*>,
+        cont: suspend context(ServerRuntime) (HttpRequest<*>) -> HttpResponse,
+    ): HttpResponse {
+        val response = cont(request)
+        val secure = request.protocol.equals("https", ignoreCase = true)
+
+        // Nothing to add if the header is already present and HSTS doesn't apply.
+        val needsNosniff = response.headers[HttpHeader.XContentTypeOptions] == null
+        val needsHsts = secure && response.headers[HttpHeader.StrictTransportSecurity] == null
+        if (!needsNosniff && !needsHsts) return response
+
+        return response.copy(
+            headers = response.headers.copy {
+                if (needsNosniff) add(HttpHeader.XContentTypeOptions, "nosniff")
+                if (needsHsts) add(HttpHeader.StrictTransportSecurity, "max-age=$hstsMaxAgeSeconds")
+            }
+        )
+    }
+}

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
@@ -36,6 +36,9 @@ class ImplementationHelpersHandleTest {
         )
 
         init {
+            // Installed outermost so security headers apply to every response, including CORS-processed and
+            // error responses (exercised by the security-header tests below).
+            install(com.lightningkite.lightningserver.http.SecurityHeadersInterceptor())
             install(com.lightningkite.lightningserver.cors.CorsInterceptor(setting("cors", cors)))
         }
 
@@ -477,8 +480,8 @@ class ImplementationHelpersHandleTest {
 
     @Test
     fun https_response_has_security_headers() {
-        // SecurityHeadersInterceptor is installed by default for every server: an https response
-        // must carry nosniff and HSTS.
+        // TestServer explicitly installs SecurityHeadersInterceptor: an https response must carry
+        // nosniff and HSTS.
         TestServer.test(settings = {}) {
             runBlocking {
                 val resp = serverRuntime.handle(
@@ -493,7 +496,7 @@ class ImplementationHelpersHandleTest {
                 )
                 assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
                 assertEquals(
-                    "max-age=3600",
+                    "max-age=31536000",
                     resp.headers[HttpHeader.StrictTransportSecurity]?.root,
                     "https responses must carry HSTS",
                 )
@@ -544,7 +547,7 @@ class ImplementationHelpersHandleTest {
                 assertEquals(HttpStatus.NotFound, resp.status)
                 assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
                 assertEquals(
-                    "max-age=3600",
+                    "max-age=31536000",
                     resp.headers[HttpHeader.StrictTransportSecurity]?.root,
                     "error responses must carry security headers",
                 )

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
@@ -476,6 +476,83 @@ class ImplementationHelpersHandleTest {
     }
 
     @Test
+    fun https_response_has_security_headers() {
+        // SecurityHeadersInterceptor is installed by default for every server: an https response
+        // must carry nosniff and HSTS.
+        TestServer.test(settings = {}) {
+            runBlocking {
+                val resp = serverRuntime.handle(
+                    HttpRequest<PathSpec>(
+                        path = RawHttpEndpoint(asString = "/ping", method = HttpMethod.GET),
+                        queryParameters = QueryParameters.EMPTY,
+                        headers = HttpHeaders.EMPTY,
+                        domain = "example.com",
+                        protocol = "https",
+                        sourceIp = "local",
+                    )
+                )
+                assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
+                assertEquals(
+                    "max-age=3600",
+                    resp.headers[HttpHeader.StrictTransportSecurity]?.root,
+                    "https responses must carry HSTS",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun http_response_has_nosniff_but_not_hsts() {
+        // HSTS must never be sent over plain http (per the HSTS spec), but nosniff still applies.
+        TestServer.test(settings = {}) {
+            runBlocking {
+                val resp = serverRuntime.handle(
+                    HttpRequest<PathSpec>(
+                        path = RawHttpEndpoint(asString = "/ping", method = HttpMethod.GET),
+                        queryParameters = QueryParameters.EMPTY,
+                        headers = HttpHeaders.EMPTY,
+                        domain = "example.com",
+                        protocol = "http",
+                        sourceIp = "local",
+                    )
+                )
+                assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
+                assertNull(
+                    resp.headers[HttpHeader.StrictTransportSecurity],
+                    "plain http responses must NOT carry HSTS",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun error_response_has_security_headers() {
+        // Error responses are mapped inside the interceptor chain, so security headers apply to
+        // them too.
+        TestServer.test(settings = {}) {
+            runBlocking {
+                val resp = serverRuntime.handle(
+                    HttpRequest<PathSpec>(
+                        path = RawHttpEndpoint(asString = "/boom", method = HttpMethod.GET),
+                        queryParameters = QueryParameters.EMPTY,
+                        headers = HttpHeaders.EMPTY,
+                        domain = "example.com",
+                        protocol = "https",
+                        sourceIp = "local",
+                    )
+                )
+                assertEquals(HttpStatus.NotFound, resp.status)
+                assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
+                assertEquals(
+                    "max-age=3600",
+                    resp.headers[HttpHeader.StrictTransportSecurity]?.root,
+                    "error responses must carry security headers",
+                )
+            }
+        }
+    }
+
+    @Test
     fun fast_handler_completes_within_its_timeout() {
         TestServer.test(settings = {}) {
             runBlocking {

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
@@ -84,12 +84,23 @@ class HttpSpanTest {
             )
             assertEquals(200L, root.attributes.asMap().entries.first { it.key.key == "http.status_code" }.value)
 
+            // SecurityHeadersInterceptor is installed by default and is the outermost interceptor,
+            // so its span is the direct child of the route root.
+            val security = spans.singleOrNull { it.name == "lightningserver.SecurityHeaders" }
+                ?: fail("Expected a SecurityHeaders interceptor span. Got: ${spans.map { it.name }}")
+            assertEquals(
+                root.spanContext.spanId,
+                security.parentSpanContext.spanId,
+                "SecurityHeaders interceptor span should be a child of the route root span",
+            )
+
+            // The user-installed CORS interceptor nests inside the default SecurityHeaders span.
             val cors = spans.singleOrNull { it.name == "lightningserver.CORS" }
                 ?: fail("Expected a CORS interceptor span. Got: ${spans.map { it.name }}")
             assertEquals(
-                root.spanContext.spanId,
+                security.spanContext.spanId,
                 cors.parentSpanContext.spanId,
-                "CORS interceptor span should be a child of the route root span",
+                "CORS interceptor span should nest inside the default SecurityHeaders span",
             )
         }
     }

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
@@ -35,6 +35,9 @@ class HttpSpanTest {
         val cors = CorsSettings(limitToDomains = listOf("example.com"))
 
         init {
+            // Installed first so it's outermost (a parent of the CORS span below), matching how it
+            // used to be prepended automatically before this interceptor became opt-in.
+            install(SecurityHeadersInterceptor())
             install(CorsInterceptor(setting("cors", cors)))
         }
 
@@ -84,8 +87,8 @@ class HttpSpanTest {
             )
             assertEquals(200L, root.attributes.asMap().entries.first { it.key.key == "http.status_code" }.value)
 
-            // SecurityHeadersInterceptor is installed by default and is the outermost interceptor,
-            // so its span is the direct child of the route root.
+            // SecurityHeadersInterceptor is installed first above, making it the outermost
+            // interceptor, so its span is the direct child of the route root.
             val security = spans.singleOrNull { it.name == "lightningserver.SecurityHeaders" }
                 ?: fail("Expected a SecurityHeaders interceptor span. Got: ${spans.map { it.name }}")
             assertEquals(
@@ -94,13 +97,13 @@ class HttpSpanTest {
                 "SecurityHeaders interceptor span should be a child of the route root span",
             )
 
-            // The user-installed CORS interceptor nests inside the default SecurityHeaders span.
+            // The CORS interceptor was installed second, so it nests inside the SecurityHeaders span.
             val cors = spans.singleOrNull { it.name == "lightningserver.CORS" }
                 ?: fail("Expected a CORS interceptor span. Got: ${spans.map { it.name }}")
             assertEquals(
                 security.spanContext.spanId,
                 cors.parentSpanContext.spanId,
-                "CORS interceptor span should nest inside the default SecurityHeaders span",
+                "CORS interceptor span should nest inside the SecurityHeaders span",
             )
         }
     }


### PR DESCRIPTION
Adds `SecurityHeadersInterceptor`, installed by default, emitting a baseline set
of security headers on every response. Stacked on the interceptor-chain fix so
error responses carry them too.
