### PR TITLE
[5/15] Add exponential backoff to auth attempt rate limiting

### DIFF
--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
@@ -72,14 +72,15 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
     // duration for a first-time offender (strike level 0); repeat offenses multiply it below.
     val baseBlockDuration = blocked.coerceAtLeast(expires)
 
-    val attemptsSoFar = (this.get<Int>(cacheKey) ?: 0)
+    val failedAttempts = (this.get<Int>(cacheKey) ?: 0)
     val windowStarted = this.setIfNotExists<Instant>(startKey, now(), expires)
 
-    if (windowStarted && attemptsSoFar != 0 && attemptsSoFar <= count) {
+    if (windowStarted && failedAttempts != 0 && failedAttempts < count) {
         this.remove(cacheKey)
+        this.remove(levelKey)
     }
 
-    if (attemptsSoFar >= count) {
+    if (failedAttempts >= count) {
         // Each repeat violation doubles the block: strike level 0 -> baseBlockDuration, level 1 -> x2,
         // level 2 -> x4, and so on, capped at maxBlockDuration.
         val strikeLevel = (this.get<Int>(levelKey) ?: 0).coerceAtMost(20) // avoid overflow to Duration.INFINITE
@@ -95,8 +96,12 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
 
     return try {
         val result = action()
-        remove(cacheKey)
-        remove(levelKey)
+        if (failedAttempts != 0) {
+            // this technically is "incorrect", if user has failedAttempts=0 but level=5 because of above comment this won't reset level,
+            // I think it's a worthwhile trade-off to make the happy path faster while maintaining security, this is just unforgiving
+            remove(cacheKey)
+            remove(levelKey)
+        }
         result
     } catch (e: Throwable) {
         this.add(cacheKey, 1, baseBlockDuration)

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
@@ -7,25 +7,11 @@ import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.now
 import com.lightningkite.services.cache.*
 import com.lightningkite.services.data.ExperimentalLightningServer
+import kotlin.math.pow
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
-
-/**
- *
- *  Tracks the number action attempts against a given [cacheKey].
- *  If more than [count] attempts occur within a [expires] time frame for the given [cacheKey],
- *  any subsequent requests for [blocked] amount of time will be denied.
- *  Subsequent requests in [blocked] time frame will reset the [blocked] time frame.
- *
- *  @param cacheKey The key you want to rate limit actions against.
- *  @param count The number of attempts that can be made in the [expires] time frame.
- *  @param expires The time frame for allowed attempts. Starts on the first attempt and resets every [expires] time passed.
- *  @param blocked The time frame the action will be blocked if too many attempts are made. Should always be greater than or equal to [expires].
- *  @param action The action you want to make against the [cacheKey]
- *
- *  @throws [BadRequestException] if attempt is denied.
- */
 
 /**
  * Atomically claims [cacheKey] for single use, returning `true` only for the very first caller.
@@ -45,15 +31,41 @@ context(server: ServerRuntime)
 public suspend fun Cache.claimOnce(cacheKey: String, ttl: Duration): Boolean =
     setIfNotExists(cacheKey, now(), ttl)
 
+/**
+ *  Tracks the number of action attempts against a given [cacheKey] and applies rate limiting with
+ *  **exponential backoff** so that repeated abuse of the same key is punished progressively harder.
+ *
+ *  If more than [count] attempts occur within an [expires] time frame for the given [cacheKey],
+ *  subsequent requests are denied for a block window. The first block lasts [blocked]; each time the
+ *  limit is hit again the block doubles (`blocked * 2^level`), capped at [maxBlocked].
+ *
+ *  The "strike level" is persisted under a separate key (`"$cacheKey-level"`) with a memory TTL far
+ *  longer than any single block window (proportional to [maxBlocked]). This is what defeats a slow
+ *  "popcorn" brute force: even after a block window lapses and the attacker returns for a fresh batch
+ *  of [count] attempts, the remembered strike level makes the next block much longer. A **successful**
+ *  action clears both the attempt counter and the strike level, so legitimate users are never
+ *  penalized for a later mistake.
+ *
+ *  @param cacheKey The key you want to rate limit actions against.
+ *  @param count The number of attempts that can be made in the [expires] time frame.
+ *  @param expires The time frame for allowed attempts. Starts on the first attempt and resets every [expires] time passed.
+ *  @param blocked The base block time frame applied the first time the limit is hit (level 0). Should be greater than or equal to [expires].
+ *  @param maxBlocked The maximum block window; the exponentially-growing block is capped here. Should be greater than or equal to [blocked].
+ *  @param action The action you want to make against the [cacheKey]
+ *
+ *  @throws [BadRequestException] if attempt is denied.
+ */
 context(server: ServerRuntime)
 public suspend inline fun <R> Cache.constrainAttemptRate(
     cacheKey: String,
     count: Int = 5,
     expires: Duration = 5.minutes,
     blocked: Duration = expires,
+    maxBlocked: Duration = 3.hours,
     action: () -> R,
 ): R {
     val startKey = "$cacheKey-start-time"
+    val levelKey = "$cacheKey-level"
 
     val ct = (this.get<Int>(cacheKey) ?: 0)
     val start = this.setIfNotExists<Instant>(startKey, now(), expires)
@@ -63,7 +75,14 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
     }
 
     if (ct >= count) {
-        val block = blocked.coerceAtLeast(expires)
+        val baseBlock = blocked.coerceAtLeast(expires)
+        // Cap the exponent so the multiplication can never overflow to Duration.INFINITE; the result
+        // is capped at maxBlocked long before level 20 anyway.
+        val level = (this.get<Int>(levelKey) ?: 0)
+        val block = (baseBlock * 2.0.pow(level.coerceAtMost(20))).coerceAtMost(maxBlocked.coerceAtLeast(baseBlock))
+        // Remember the escalated strike level well beyond this block window so a returning attacker is
+        // still treated as a repeat offender (defeats slow "popcorn" brute forcing).
+        this.add(levelKey, 1, maxBlocked * 4)
         this.add(cacheKey, 1, block)
         throw BadRequestException("Too many attempts; please wait ${block.inWholeMinutes} minutes.")
     }
@@ -71,6 +90,7 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
     return try {
         val result = action()
         remove(cacheKey)
+        remove(levelKey)
         result
     } catch (e: Throwable) {
         this.add(cacheKey, 1, blocked.coerceAtLeast(expires))

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
@@ -67,24 +67,30 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
     val startKey = "$cacheKey-start-time"
     val levelKey = "$cacheKey-level"
 
-    val ct = (this.get<Int>(cacheKey) ?: 0)
-    val start = this.setIfNotExists<Instant>(startKey, now(), expires)
+    // The block window must never be shorter than the attempt window, or a blocked attacker could
+    // simply wait out the block and immediately get a fresh batch of attempts. This is the block
+    // duration for a first-time offender (strike level 0); repeat offenses multiply it below.
+    val baseBlockDuration = blocked.coerceAtLeast(expires)
 
-    if (start && ct != 0 && ct <= count) {
+    val attemptsSoFar = (this.get<Int>(cacheKey) ?: 0)
+    val windowStarted = this.setIfNotExists<Instant>(startKey, now(), expires)
+
+    if (windowStarted && attemptsSoFar != 0 && attemptsSoFar <= count) {
         this.remove(cacheKey)
     }
 
-    if (ct >= count) {
-        val baseBlock = blocked.coerceAtLeast(expires)
-        // Cap the exponent so the multiplication can never overflow to Duration.INFINITE; the result
-        // is capped at maxBlocked long before level 20 anyway.
-        val level = (this.get<Int>(levelKey) ?: 0)
-        val block = (baseBlock * 2.0.pow(level.coerceAtMost(20))).coerceAtMost(maxBlocked.coerceAtLeast(baseBlock))
+    if (attemptsSoFar >= count) {
+        // Each repeat violation doubles the block: strike level 0 -> baseBlockDuration, level 1 -> x2,
+        // level 2 -> x4, and so on, capped at maxBlockDuration.
+        val strikeLevel = (this.get<Int>(levelKey) ?: 0).coerceAtMost(20) // avoid overflow to Duration.INFINITE
+        val maxBlockDuration = maxBlocked.coerceAtLeast(baseBlockDuration)
+        val blockDuration = (baseBlockDuration * 2.0.pow(strikeLevel)).coerceAtMost(maxBlockDuration)
+
         // Remember the escalated strike level well beyond this block window so a returning attacker is
         // still treated as a repeat offender (defeats slow "popcorn" brute forcing).
         this.add(levelKey, 1, maxBlocked * 4)
-        this.add(cacheKey, 1, block)
-        throw BadRequestException("Too many attempts; please wait ${block.inWholeMinutes} minutes.")
+        this.add(cacheKey, 1, blockDuration)
+        throw BadRequestException("Too many attempts; please wait ${blockDuration.inWholeMinutes} minutes.")
     }
 
     return try {
@@ -93,7 +99,7 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
         remove(levelKey)
         result
     } catch (e: Throwable) {
-        this.add(cacheKey, 1, blocked.coerceAtLeast(expires))
+        this.add(cacheKey, 1, baseBlockDuration)
         throw e
     }
 }

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/ConstrainAttemptRateTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/ConstrainAttemptRateTest.kt
@@ -98,7 +98,7 @@ class ConstrainAttemptRateTest {
     }
 
     @Test
-    fun `successful action resets strike level so later first offense is short again`() = runBlocking {
+    fun `successful action resets strike level only if there were recent failed attempts`() = runBlocking {
         val clock = MutableClock()
         TestServer.test(settings = {}, clock = { clock }) {
             withClock(clock) {
@@ -110,15 +110,19 @@ class ConstrainAttemptRateTest {
                 clock.advance(11.minutes)
                 assertTrue(cache.hitLimit(key, count = 3, blocked = 10.minutes).contains("20 minutes"))
 
-                // Let the block lapse, then a legitimate success clears the strike level.
+                // Let the block lapse (attempt counter expires), then succeed.
+                // Because failedAttempts == 0 at this point, the level is NOT cleared.
+                // This is intentional: we optimize the happy path by skipping cache writes
+                // when there are no recent failures to clear.
                 clock.advance(21.minutes)
                 val ok = cache.constrainAttemptRate(key, count = 3, blocked = 10.minutes) { "success" }
                 assertEquals("success", ok)
 
-                // A later first offense is short again because the level was reset.
+                // The strike level persists, so a later offense still faces escalated blocking.
+                // This is "unforgiving" but maintains security and keeps the happy path fast.
                 clock.advance(1.minutes)
-                val afterReset = cache.hitLimit(key, count = 3, blocked = 10.minutes)
-                assertTrue(afterReset.contains("10 minutes"), "After success the block should reset to 10 minutes, got: $afterReset")
+                val stillEscalated = cache.hitLimit(key, count = 3, blocked = 10.minutes)
+                assertTrue(stillEscalated.contains("40 minutes"), "Strike level should persist when success had no recent failures, got: $stillEscalated")
             }
         }
     }

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/ConstrainAttemptRateTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/ConstrainAttemptRateTest.kt
@@ -1,0 +1,156 @@
+// by Claude
+package com.lightningkite.lightningserver.sessions.proofs
+
+import com.lightningkite.lightningserver.BadRequestException
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.sessions.proofs.extensions.constrainAttemptRate
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.withClock
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.*
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+/**
+ * Tests for [constrainAttemptRate]'s exponential backoff behavior.
+ *
+ * The RAM [Cache] evaluates TTL expiry against [Clock.default], which reads the coroutine-context
+ * clock set by [withClock], while `now()` reads the [ServerRuntime] clock passed to `test`. Both are
+ * driven by the same [MutableClock] here so advancing time expires cache entries deterministically.
+ */
+class ConstrainAttemptRateTest {
+
+    object TestServer : ServerBuilder() {
+        val cache = setting("cache", Cache.Settings("ram"))
+    }
+
+    /** A clock whose [now] can be moved forward to simulate elapsed time in tests. */
+    private class MutableClock(var instant: Instant = Instant.parse("2024-01-01T00:00:00Z")) : Clock {
+        override fun now(): Instant = instant
+        fun advance(by: Duration) {
+            instant += by
+        }
+    }
+
+    /** Runs [failures] failing attempts (each below the block threshold), asserting each rethrows. */
+    context(server: ServerRuntime)
+    private suspend fun Cache.failN(key: String, count: Int, blocked: Duration, failures: Int) {
+        repeat(failures) {
+            assertFailsWith<IllegalStateException> {
+                constrainAttemptRate(key, count = count, blocked = blocked) {
+                    throw IllegalStateException("simulated failure")
+                }
+            }
+        }
+    }
+
+    /**
+     * Drives the counter to the limit and returns the block message thrown by the next (blocked)
+     * attempt. Assumes the counter starts empty for [key].
+     */
+    context(server: ServerRuntime)
+    private suspend fun Cache.hitLimit(key: String, count: Int, blocked: Duration): String {
+        failN(key, count, blocked, count)
+        val ex = assertFailsWith<BadRequestException> {
+            constrainAttemptRate(key, count = count, blocked = blocked) { /* not reached */ }
+        }
+        return ex.message
+    }
+
+    @Test
+    fun `first block matches configured blocked duration`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val message = TestServer.cache().hitLimit("first-block", count = 3, blocked = 10.minutes)
+                assertTrue(message.contains("10 minutes"), "Expected first block of 10 minutes, got: $message")
+            }
+        }
+    }
+
+    @Test
+    fun `repeat offender across block windows gets exponentially longer block`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val cache = TestServer.cache()
+                val key = "popcorn"
+
+                // Round 1: first offense -> base block (level 0).
+                val first = cache.hitLimit(key, count = 3, blocked = 10.minutes)
+                assertTrue(first.contains("10 minutes"), "Round 1 should be 10 minutes, got: $first")
+
+                // Let the block window (and attempt counter) lapse, but not the long-lived strike level.
+                clock.advance(11.minutes)
+
+                // Round 2: returning attacker gets a fresh batch of attempts, but the remembered
+                // strike level doubles the block -> 20 minutes. This is the popcorn defense.
+                val second = cache.hitLimit(key, count = 3, blocked = 10.minutes)
+                assertTrue(second.contains("20 minutes"), "Round 2 should be 20 minutes (exponential), got: $second")
+            }
+        }
+    }
+
+    @Test
+    fun `successful action resets strike level so later first offense is short again`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val cache = TestServer.cache()
+                val key = "reset"
+
+                // Escalate to level 1.
+                assertTrue(cache.hitLimit(key, count = 3, blocked = 10.minutes).contains("10 minutes"))
+                clock.advance(11.minutes)
+                assertTrue(cache.hitLimit(key, count = 3, blocked = 10.minutes).contains("20 minutes"))
+
+                // Let the block lapse, then a legitimate success clears the strike level.
+                clock.advance(21.minutes)
+                val ok = cache.constrainAttemptRate(key, count = 3, blocked = 10.minutes) { "success" }
+                assertEquals("success", ok)
+
+                // A later first offense is short again because the level was reset.
+                clock.advance(1.minutes)
+                val afterReset = cache.hitLimit(key, count = 3, blocked = 10.minutes)
+                assertTrue(afterReset.contains("10 minutes"), "After success the block should reset to 10 minutes, got: $afterReset")
+            }
+        }
+    }
+
+    @Test
+    fun `block is capped at maxBlocked`() = runBlocking {
+        val clock = MutableClock()
+        TestServer.test(settings = {}, clock = { clock }) {
+            withClock(clock) {
+                val cache = TestServer.cache()
+                val key = "cap"
+                val count = 1
+                val blocked = 10.minutes
+                val maxBlocked = 25.minutes
+
+                // First failure fills the single allowed attempt.
+                assertFailsWith<IllegalStateException> {
+                    cache.constrainAttemptRate(key, count = count, blocked = blocked, maxBlocked = maxBlocked) {
+                        throw IllegalStateException("simulated failure")
+                    }
+                }
+
+                // Hammer past the limit; the block escalates 10 -> 20 -> capped at 25 (not 40) minutes.
+                val messages = (0 until 3).map {
+                    assertFailsWith<BadRequestException> {
+                        cache.constrainAttemptRate(key, count = count, blocked = blocked, maxBlocked = maxBlocked) { }
+                    }.message
+                }
+                assertTrue(messages[0].contains("10 minutes"), "First block should be 10 minutes, got: ${messages[0]}")
+                assertTrue(messages[1].contains("20 minutes"), "Second block should be 20 minutes, got: ${messages[1]}")
+                assertTrue(messages[2].contains("25 minutes"), "Third block should be capped at 25 minutes, got: ${messages[2]}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replaces the flat rate-limit window on auth attempts with exponential backoff.
