### PR TITLE
[12/15] Log every request through an access-log interceptor

### DIFF
--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AccessLogInterceptor.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AccessLogInterceptor.kt
@@ -1,0 +1,46 @@
+package com.lightningkite.lightningserver.auth
+
+import com.lightningkite.lightningserver.data.get
+import com.lightningkite.lightningserver.http.HttpInterceptor
+import com.lightningkite.lightningserver.http.HttpRequest
+import com.lightningkite.lightningserver.http.HttpResponse
+import com.lightningkite.lightningserver.logger
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import kotlinx.coroutines.CancellationException
+
+/**
+ * HTTP interceptor that writes one access-log line per request, naming the resolved principal.
+ *
+ * Install it in your `ServerBuilder` (typically outermost, so every request is logged):
+ * ```kotlin
+ * init { install(AccessLogInterceptor()) }
+ * ```
+ * It logs at INFO in the form `<path> accessed by <principal> (<ip>)`, where `<principal>` is the
+ * request's resolved [Authentication] — rendered including masquerade as "actor masquerading as
+ * target" — or `anonymous` when the request carries no credentials. This is the v4-style access log.
+ *
+ * Auth resolution is cached per request, so this adds no work when a handler also resolves auth, and
+ * it is skipped entirely when INFO logging is off. A resolution failure (e.g. a malformed token) is
+ * swallowed here so logging never breaks a request; the handler surfaces the real error itself.
+ */
+public class AccessLogInterceptor : HttpInterceptor {
+    override val name: String = "AccessLog"
+
+    context(runtime: ServerRuntime)
+    override suspend fun intercept(
+        request: HttpRequest<*>,
+        cont: suspend context(ServerRuntime) (HttpRequest<*>) -> HttpResponse,
+    ): HttpResponse {
+        if (runtime.logger.isInfoEnabled()) {
+            val accessedBy = try {
+                request[Authentication.CacheKey]
+            } catch (e: CancellationException) {
+                throw e // never swallow cancellation — it would break structured concurrency
+            } catch (_: Exception) {
+                null
+            }
+            runtime.logger.info { "${request.path} accessed by ${accessedBy ?: "anonymous"} (${request.sourceIp})" }
+        }
+        return cont(request)
+    }
+}

--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/Authentication.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/Authentication.kt
@@ -264,7 +264,10 @@ public data class Authentication<SUBJECT : HasId<*>> private constructor(
                     }
 
                     if (handler.permitMasquerade(auth, mask)) return mask
-                    else throw ForbiddenException("You are not allowed to masquerade as $masquerade")
+                    else {
+                        server.logger.warn { "$auth denied masquerade as $masquerade" }
+                        throw ForbiddenException("You are not allowed to masquerade as $masquerade")
+                    }
                 }
 
                 return auth

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
@@ -61,11 +61,6 @@ private val errorType = TelemetryKey.OfString("error.type")
 public suspend fun ServerRuntime.handle(request: HttpRequest<PathSpec>): HttpResponse = instrumentHttpRequest(request) {
     var errorType: String? = null
 
-    // Turns a thrown error into an HTTP response via the configured exception handler,
-    // recording the error type for instrumentation; falls back to a bare 500 if the handler
-    // itself throws. Applied INSIDE the interceptor chain (below) so error responses still
-    // pass back through the interceptors — most importantly CORS. Otherwise error responses
-    // ship without CORS headers and browsers misreport every 4xx/5xx as a CORS failure.
     suspend fun handleError(e: Exception, label: String? = e::class.simpleName): HttpResponse {
         errorType = label
         return try {
@@ -78,128 +73,131 @@ public suspend fun ServerRuntime.handle(request: HttpRequest<PathSpec>): HttpRes
 
     val response = try {
         server.compiledHttpInterceptors.intercept(request) { req ->
-            this.logger.info { "${request.path} accessed by ${request.sourceIp}" }
+            // Access logging (with the resolved principal) is provided by the opt-in AccessLogInterceptor in
+            // the auth module, not hardcoded here — so it can name the principal without core depending on auth.
             // Map handler/route/compression exceptions to responses in-place so the surrounding
             // interceptors (CORS, etc.) still post-process error responses.
             try {
-            val result = try {
-                // Route resolution must live inside this try so that a RouteNotFoundException (e.g. a HEAD
-                // request with no HEAD handler, or a missing trailing slash) is caught below and recovered
-                // via the HEAD->GET fallback / slash-redirect logic rather than escaping as a bare 404.
-                @Suppress("UNCHECKED_CAST")
-                val handler = req.path.match.value as HttpHandler<PathSpec>
-                instrument("handler") {
-                    // Per-handler request timeout (HttpHandler.timeout, default 30s), enforced at this single
-                    // choke point shared by every engine instead of being duplicated (and high-risk) in each
-                    // engine adapter. Cooperative cancellation: only interrupts at suspension points.
-                    withTimeout(handler.timeout) {
-                        handler.handle(req as HttpRequest<PathSpec>)
+                val result = try {
+                    // Route resolution must live inside this try so that a RouteNotFoundException (e.g. a HEAD
+                    // request with no HEAD handler, or a missing trailing slash) is caught below and recovered
+                    // via the HEAD->GET fallback / slash-redirect logic rather than escaping as a bare 404.
+                    @Suppress("UNCHECKED_CAST")
+                    val handler = req.path.match.value as HttpHandler<PathSpec>
+                    instrument("handler") {
+                        // Per-handler request timeout (HttpHandler.timeout, default 30s), enforced at this single
+                        // choke point shared by every engine instead of being duplicated (and high-risk) in each
+                        // engine adapter. Cooperative cancellation: only interrupts at suspension points.
+                        withTimeout(handler.timeout) {
+                            handler.handle(req as HttpRequest<PathSpec>)
+                        }
+                    }
+                } catch (notFound: RouteNotFoundException) {
+                    when (req.path.method) {
+                        HttpMethod.HEAD -> {
+                            // OK, we'll do a get and remove the body.
+                            val getRequest = req.copyWithNewPathType(path = req.path.copy(method = HttpMethod.GET))
+
+                            @Suppress("UNCHECKED_CAST")
+                            val headHandler = getRequest.path.match.value as HttpHandler<PathSpec>
+                            val getResult = instrument("handler") {
+                                withTimeout(headHandler.timeout) { headHandler.handle(getRequest) }
+                            }
+                            getResult.copy(
+                                body = null,
+                                status = if (getResult.status.success) HttpStatus.NoContent else getResult.status,
+                            )
+                        }
+
+                        else -> {
+                            this.logger.debug {
+                                "Not found: ${req.path.pathSegments.segments.map { "'$it'" }}, looking for slashes"
+                            }
+                            if (request.path.pathSegments.isNotEmpty()) {
+                                // Let's see if they just got their ending slash wrong.
+                                val altSlashEndpoint = req.path.copy(pathSegments = req.path.pathSegments.segments.let {
+                                    if (it.lastOrNull() == "") it.dropLast(1) else it + ""
+                                }.let(::PathSegments))
+                                try {
+                                    altSlashEndpoint.match
+                                    HttpResponse.pathMoved(to = "/" + altSlashEndpoint.pathSegments.toString())
+                                } catch (_: RouteNotFoundException) {
+                                    throw notFound
+                                }
+                            } else throw notFound
+                        }
                     }
                 }
-            } catch (notFound: RouteNotFoundException) {
-                when (req.path.method) {
-                    HttpMethod.HEAD -> {
-                        // OK, we'll do a get and remove the body.
-                        val getRequest = req.copyWithNewPathType(path = req.path.copy(method = HttpMethod.GET))
+                if (result.body == null || request.headers[HttpHeader.AcceptEncoding] == null) return@intercept result
 
-                        @Suppress("UNCHECKED_CAST")
-                        val headHandler = getRequest.path.match.value as HttpHandler<PathSpec>
-                        val getResult = instrument("handler") {
-                            withTimeout(headHandler.timeout) { headHandler.handle(getRequest) }
-                        }
-                        getResult.copy(
-                            body = null,
-                            status = if (getResult.status.success) HttpStatus.NoContent else getResult.status,
-                        )
+                val acceptedEncodings = request.headers.getMany(HttpHeader.AcceptEncoding)
+                if (acceptedEncodings.isEmpty()) return@intercept result
+
+                val accepts = acceptedEncodings
+                    .map { it.root.lowercase().substringBefore(';').trim() }
+
+                // Accept-Encoding negotiation (gzip only for now)
+                if (!accepts.contains("gzip")) return@intercept result
+
+                // Content-Type denylist (skip already-compressed types)
+                if (result.body.mediaType.type in setOf("image", "audio", "video") ||
+                    (result.body.mediaType.type == "application" &&
+                            result.body.mediaType.subtype in
+                            setOf("zip", "gzip", "x-gzip", "x-7z-compressed", "x-bzip2", "x-tar", "pdf")
+                            ) ||
+                    (result.body.mediaType.type == "font" && result.body.mediaType.subtype in setOf("woff", "woff2"))
+                ) return@intercept result
+
+                // Lower compress limit. Either not worth the effort, or likely will inflate a little.
+                if (result.body.data.size?.let { it < 256 } == true) return@intercept result
+
+                val (newData, compressed) = when (val data = result.body.data) {
+                    is Data.Sink -> {
+                        Data.Sink { outSink ->
+                            GZIPOutputStream(outSink.asOutputStream()).asSink().buffered().use { gzOut ->
+                                data.write(gzOut)
+                            }
+                        } to true
+                    }
+
+                    is Data.Source -> {
+                        Data.Sink { outSink ->
+                            GZIPOutputStream(outSink.asOutputStream()).asSink().buffered().use { gzOut ->
+                                data.write(gzOut)
+                            }
+                        } to true
                     }
 
                     else -> {
-                        this.logger.debug {
-                            "Not found: ${req.path.pathSegments.segments.map { "'$it'" }}, looking for slashes"
-                        }
-                        if (request.path.pathSegments.isNotEmpty()) {
-                            // Let's see if they just got their ending slash wrong.
-                            val altSlashEndpoint = req.path.copy(pathSegments = req.path.pathSegments.segments.let {
-                                if (it.lastOrNull() == "") it.dropLast(1) else it + ""
-                            }.let(::PathSegments))
-                            try {
-                                altSlashEndpoint.match
-                                HttpResponse.pathMoved(to = "/" + altSlashEndpoint.pathSegments.toString())
-                            } catch (_: RouteNotFoundException) {
-                                throw notFound
-                            }
-                        } else throw notFound
+                        // 1024 Grey area. It likely will compress fine, but if not send the original
+                        val s = data.size
+                        if (s?.let { it <= 1024 } == true) {
+                            val og = data.bytes()
+                            val gz = og.gzip()
+                            if (gz.size < s)
+                                Data.Bytes(gz) to true
+                            else
+                                Data.Bytes(og) to false
+                        } else
+                            Data.Bytes(data.bytes().gzip()) to true
                     }
                 }
-            }
-            if (result.body == null || request.headers[HttpHeader.AcceptEncoding] == null) return@intercept result
-
-            val acceptedEncodings = request.headers.getMany(HttpHeader.AcceptEncoding)
-            if (acceptedEncodings.isEmpty()) return@intercept result
-
-            val accepts = acceptedEncodings
-                .map { it.root.lowercase().substringBefore(';').trim() }
-
-            // Accept-Encoding negotiation (gzip only for now)
-            if (!accepts.contains("gzip")) return@intercept result
-
-            // Content-Type denylist (skip already-compressed types)
-            if (result.body.mediaType.type in setOf("image", "audio", "video") ||
-                (result.body.mediaType.type == "application" &&
-                        result.body.mediaType.subtype in
-                        setOf("zip", "gzip", "x-gzip", "x-7z-compressed", "x-bzip2", "x-tar", "pdf")
-                        ) ||
-                (result.body.mediaType.type == "font" && result.body.mediaType.subtype in setOf("woff", "woff2"))
-            ) return@intercept result
-
-            // Lower compress limit. Either not worth the effort, or likely will inflate a little.
-            if (result.body.data.size?.let { it < 256 } == true) return@intercept result
-
-            val (newData, compressed) = when (val data = result.body.data) {
-                is Data.Sink -> {
-                    Data.Sink { outSink ->
-                        GZIPOutputStream(outSink.asOutputStream()).asSink().buffered().use { gzOut ->
-                            data.write(gzOut)
-                        }
-                    } to true
-                }
-
-                is Data.Source -> {
-                    Data.Sink { outSink ->
-                        GZIPOutputStream(outSink.asOutputStream()).asSink().buffered().use { gzOut ->
-                            data.write(gzOut)
-                        }
-                    } to true
-                }
-
-                else -> {
-                    // 1024 Grey area. It likely will compress fine, but if not send the original
-                    val s = data.size
-                    if (s?.let { it <= 1024 } == true) {
-                        val og = data.bytes()
-                        val gz = og.gzip()
-                        if (gz.size < s)
-                            Data.Bytes(gz) to true
-                        else
-                            Data.Bytes(og) to false
-                    } else
-                        Data.Bytes(data.bytes().gzip()) to true
-                }
-            }
-            result.copy(
-                headers = if (compressed) result.headers.copy {
-                    add(HttpHeader.ContentEncoding, "gzip")
-                } else result.headers,
-                body = TypedData(newData, result.body.mediaType)
-            )
+                result.copy(
+                    headers = if (compressed) result.headers.copy {
+                        add(HttpHeader.ContentEncoding, "gzip")
+                    } else result.headers,
+                    body = TypedData(newData, result.body.mediaType)
+                )
             } catch (timeout: TimeoutCancellationException) {
-                // A handler exceeded its HttpHandler.timeout. Map to 408 through the normal exception handler so
-                // the error body is formatted consistently. (Other CancellationExceptions — e.g. client
-                // disconnect — are handled by the generic catch below, matching prior behavior.)
+                // A handler exceeded its HttpHandler.timeout. This is a server-side condition (the server
+                // couldn't finish in time), so it maps to 503 Service Unavailable — NOT 408, which per
+                // RFC 7231 means the client was too slow sending its request. Routed through the normal
+                // exception handler so the error body is formatted consistently. (Other
+                // CancellationExceptions — e.g. client disconnect — are handled by the generic catch below.)
                 this.logger.warn { "Request to ${request.path} exceeded its handler timeout." }
                 handleError(
                     HttpStatusException(
-                        status = HttpStatus.RequestTimeout,
+                        status = HttpStatus.ServiceUnavailable,
                         detail = "timeout",
                         message = "The request handler exceeded its timeout.",
                     ),
@@ -285,14 +283,18 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
         instrument("messageFromClient", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, request.sourceIp)
-            put(wsFrameType, when (frame) {
-                is WebSocketFrame.Text -> "text"
-                is WebSocketFrame.Binary -> "binary"
-            })
-            put(wsFrameSize, when (frame) {
-                is WebSocketFrame.Text -> frame.content.length.toLong()
-                is WebSocketFrame.Binary -> frame.content.size.toLong()
-            })
+            put(
+                wsFrameType, when (frame) {
+                    is WebSocketFrame.Text -> "text"
+                    is WebSocketFrame.Binary -> "binary"
+                }
+            )
+            put(
+                wsFrameSize, when (frame) {
+                    is WebSocketFrame.Text -> frame.content.length.toLong()
+                    is WebSocketFrame.Binary -> frame.content.size.toLong()
+                }
+            )
         }) {
             messageFromClient(frame)
         }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/settings/ServerSettings.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/settings/ServerSettings.kt
@@ -89,7 +89,20 @@ public class ServerSettings private constructor(
     private var usingDefaults: Boolean = false
 
     private val serializable: MapRegistry<ServerSetting<*, *>, Any?> = MapRegistry()
-    private val goal: MapRegistry<ServerSetting<*, *>, Any?> = MapRegistry()
+
+    // Transformed results, published as an immutable snapshot. Reads are lock-free: once a setting is resolved,
+    // its value is visible here for good (the @Volatile guarantees other threads see the new snapshot). Writes
+    // replace the whole map under [resolveLock] (copy-on-write) — cheap because each setting is resolved at most
+    // once, and in production every setting is pre-resolved single-threaded during ready(). An immutable Map
+    // (not a ConcurrentHashMap) is used so a null result is stored naturally, with no sentinel.
+    @Volatile
+    private var goal: Map<ServerSetting<*, *>, Any?> = emptyMap()
+
+    // Guards resolution so each setting is transformed exactly once, even if several threads first request it
+    // at once. A single reentrant lock — not per-setting — is deliberate: a setting's getter may resolve its
+    // dependencies by calling get() again on the same thread, which re-enters this lock harmlessly, whereas
+    // per-setting locks could deadlock between two mutually-dependent settings.
+    private val resolveLock = Any()
 
     // Track settings currently being resolved to detect circular dependencies at runtime
     private val resolving: ThreadLocal<MutableSet<ServerSetting<*, *>>>? =
@@ -137,7 +150,8 @@ public class ServerSettings private constructor(
      */
     public infix fun <RESULT> ServerSetting<*, RESULT>.setStatic(value: RESULT) {
         if (ready) throw IllegalStateException("Settings are marked as ready.")
-        goal.register(this, value as Any?)
+        // Pre-ready configuration is single-threaded, so a plain copy-on-write assignment is enough.
+        goal = goal + (this to value)
     }
 
     /**
@@ -250,7 +264,16 @@ public class ServerSettings private constructor(
     public fun <SERIALIZABLE, RESULT> get(key: ServerSetting<SERIALIZABLE, RESULT>): RESULT {
         if (!ready) throw IllegalStateException("Settings not ready yet.")
 
-        return goal.getOrRegister(key) {
+        // Lock-free fast path: once a setting is resolved its value lives in [goal] forever, read without locking.
+        // containsKey (not a null check) because a resolved value may legitimately be null.
+        goal.let { if (it.containsKey(key)) return it[key] as RESULT }
+
+        // Slow path: resolve under [resolveLock] so each setting is transformed at most once, even when several
+        // threads first request it concurrently. The per-thread [resolving] set still detects circular deps.
+        synchronized(resolveLock) {
+            // Re-check now that we hold the lock; another thread may have resolved it while we waited.
+            goal.let { if (it.containsKey(key)) return it[key] as RESULT }
+
             // Check for circular dependency during resolution
             val currentlyResolving = resolving?.get()
             if (currentlyResolving != null && key in currentlyResolving) {
@@ -258,7 +281,7 @@ public class ServerSettings private constructor(
             }
 
             currentlyResolving?.add(key)
-            try {
+            val result = try {
                 overrides[key]?.let { defer ->
                     serializable[key]
                         ?.let { key.get(it as SERIALIZABLE) } // specified in settings file
@@ -282,7 +305,11 @@ public class ServerSettings private constructor(
             } finally {
                 currentlyResolving?.remove(key)
             }
-        } as RESULT
+            // Publish by re-reading [goal] (never a snapshot captured before resolution): the getter above may
+            // have recursively resolved dependencies and published them, and those additions must be preserved.
+            goal = goal + (key to result)
+            return result as RESULT
+        }
     }
 
     // For some dumb fucking reason kotlin made this internal, and it's what getOrElse should do in the first place!
@@ -328,7 +355,8 @@ public class ServerSettings private constructor(
         overrides: Map<ServerSetting<*, *>, Runtime<*>> = this.overrides,
     ) = ServerSettings(settings, overrides).also {
         it.serializable.include(this.serializable)
-        it.goal.include(this.goal)
+        // Safe to share the reference: [goal] is immutable, and copy-on-write writes replace it rather than mutate.
+        it.goal = this.goal
     }
 
     public operator fun plus(requirement: ServerSetting<*, *>): ServerSettings = copy(settings + requirement)
@@ -347,9 +375,6 @@ public class ServerSettings private constructor(
  * 2. The missing settings check in `ready()` doesn't distinguish between truly required settings
  *    and optional settings with no default. The error message could be more helpful.
  *
- * 3. The `get()` function performs lazy transformation but the caching isn't thread-safe.
- *    If called concurrently during initial ready phase, could transform the same setting twice.
- *    (Though this is documented in ServerSetting.kt TODO, worth noting here too.)
  *
  * 4. `readyUsingDefaults()` bypasses all validation with a warning, but doesn't actually
  *    enforce that defaults exist for all settings. Could still throw during get().

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
@@ -1,6 +1,9 @@
 package com.lightningkite.lightningserver.definition
 
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.settings.ServerSettings
 import kotlinx.coroutines.*
+import kotlinx.serialization.builtins.serializer
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -58,5 +61,53 @@ class ServerSettingThreadSafetyTest {
 
         // The computation should only happen once despite 100 concurrent accesses
         assertEquals(1, executionCount.get(), "Runtime should only execute once, got ${executionCount.get()}")
+    }
+
+    /**
+     * Hammers [ServerSettings.get] from many threads for several settings simultaneously and asserts that
+     * each setting's transformer runs exactly once. Guards against the double-transform race that existed
+     * when the goal registry was populated without synchronization.
+     */
+    @Test
+    fun `ServerSettings get transforms each setting exactly once under concurrent first-access`() = runBlocking {
+        val counters = (0 until 8).map { AtomicInteger(0) }
+        val settings = counters.mapIndexed { i, counter ->
+            ServerSetting("setting$i", 0, Int.serializer()) {
+                counter.incrementAndGet()
+                Thread.sleep(20) // Widen the race window so an unsynchronized cache would double-transform.
+                "result-$i"
+            }
+        }
+        val serverSettings = ServerSettings(settings)
+        serverSettings.readyUsingDefaults()
+
+        val runtime = stubRuntime()
+
+        // Every coroutine resolves every setting; without per-setting synchronization the transformers race.
+        (1..100).map {
+            async(Dispatchers.Default) {
+                with(runtime) { settings.map { serverSettings.get(it) } }
+            }
+        }.awaitAll()
+
+        counters.forEachIndexed { i, counter ->
+            assertEquals(1, counter.get(), "Transformer for setting$i should run exactly once, got ${counter.get()}")
+        }
+    }
+
+    /** Minimal [ServerRuntime] stub whose only usable capability is acting as the settings/transformation context. */
+    private fun stubRuntime(): ServerRuntime = object : ServerRuntime {
+        override val server get() = throw NotImplementedError()
+        override val settings get() = throw NotImplementedError()
+        override val internalSerialization get() = throw NotImplementedError()
+        override val externalSerialization get() = throw NotImplementedError()
+        override val serverId get() = ""
+        override val serverVersion get() = ""
+        override val projectName get() = ""
+        override val sharedResources get() = throw NotImplementedError()
+        override suspend fun <T> Task<T>.invoke(input: T) = throw NotImplementedError()
+        override suspend fun <PATH : com.lightningkite.lightningserver.pathing.PathSpec, T> sendWebSocketSubscriptionMessage(
+            event: com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage<PATH, T>,
+        ) = throw NotImplementedError()
     }
 }

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
@@ -380,9 +380,10 @@ class ImplementationHelpersHandleTest {
     }
 
     @Test
-    fun handler_exceeding_its_timeout_returns_408() {
+    fun handler_exceeding_its_timeout_returns_503() {
         // The timeout now lives in core: ServerRuntime.handle enforces HttpHandler.timeout and maps an
-        // exceeded handler to 408, regardless of which engine runs it.
+        // exceeded handler to 503 (a server-side condition — not 408, which means a slow client),
+        // regardless of which engine runs it.
         TestServer.test(settings = {}) {
             runBlocking {
                 val resp = serverRuntime.handle(
@@ -395,7 +396,7 @@ class ImplementationHelpersHandleTest {
                         sourceIp = "local",
                     )
                 )
-                assertEquals(HttpStatus.RequestTimeout, resp.status)
+                assertEquals(HttpStatus.ServiceUnavailable, resp.status)
             }
         }
     }
@@ -480,8 +481,7 @@ class ImplementationHelpersHandleTest {
 
     @Test
     fun https_response_has_security_headers() {
-        // TestServer explicitly installs SecurityHeadersInterceptor: an https response must carry
-        // nosniff and HSTS.
+        // This test server installs SecurityHeadersInterceptor: an https response must carry nosniff and HSTS.
         TestServer.test(settings = {}) {
             runBlocking {
                 val resp = serverRuntime.handle(

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/settings/ServerSettingsTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/settings/ServerSettingsTest.kt
@@ -172,4 +172,25 @@ class ServerSettingsTest {
             assertEquals("A", b()) // should defer to 'a' as configured in the server
         }
     }
+
+    @Test
+    fun `resolving a setting caches its reentrantly-resolved dependencies`() {
+        // Guards get()'s copy-on-write publish: resolving `derived` reentrantly resolves `base`, and publishing
+        // derived must not clobber base's freshly-cached entry. If it did, `base` would be transformed twice.
+        val baseTransforms = java.util.concurrent.atomic.AtomicInteger(0)
+        object : ServerBuilder() {
+            val base = setting("base", "x", getter = { baseTransforms.incrementAndGet(); it })
+            val derived = setting("derived", "y")
+
+            init {
+                derived bind base
+            }
+        }.let { server ->
+            server.test({}) {
+                assertEquals("x", server.derived()) // reentrantly resolves and caches base
+                assertEquals("x", server.base())    // must hit the cache, not re-transform
+                assertEquals(1, baseTransforms.get(), "base should be transformed exactly once")
+            }
+        }
+    }
 }

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
@@ -35,8 +35,7 @@ class HttpSpanTest {
         val cors = CorsSettings(limitToDomains = listOf("example.com"))
 
         init {
-            // Installed first so it's outermost (a parent of the CORS span below), matching how it
-            // used to be prepended automatically before this interceptor became opt-in.
+            // Installed outermost (before CORS) so its span is the direct child of the route root.
             install(SecurityHeadersInterceptor())
             install(CorsInterceptor(setting("cors", cors)))
         }
@@ -87,8 +86,8 @@ class HttpSpanTest {
             )
             assertEquals(200L, root.attributes.asMap().entries.first { it.key.key == "http.status_code" }.value)
 
-            // SecurityHeadersInterceptor is installed first above, making it the outermost
-            // interceptor, so its span is the direct child of the route root.
+            // This test server installs SecurityHeadersInterceptor outermost, so its span is the direct
+            // child of the route root.
             val security = spans.singleOrNull { it.name == "lightningserver.SecurityHeaders" }
                 ?: fail("Expected a SecurityHeaders interceptor span. Got: ${spans.map { it.name }}")
             assertEquals(
@@ -97,7 +96,7 @@ class HttpSpanTest {
                 "SecurityHeaders interceptor span should be a child of the route root span",
             )
 
-            // The CORS interceptor was installed second, so it nests inside the SecurityHeaders span.
+            // The CORS interceptor, installed after it, nests inside the SecurityHeaders span.
             val cors = spans.singleOrNull { it.name == "lightningserver.CORS" }
                 ?: fail("Expected a CORS interceptor span. Got: ${spans.map { it.name }}")
             assertEquals(

--- a/demo/src/main/kotlin/com/lightningkite/lightningserver/demo/Server.kt
+++ b/demo/src/main/kotlin/com/lightningkite/lightningserver/demo/Server.kt
@@ -84,6 +84,11 @@ object Server : ServerBuilder() {
     val newSecret = setting("someSecret", "???", instructions = "This can be whatever you dream, you madman.")
     val githubOauth = setting("githubOauth", OauthProviderCredentials("", ""))
 
+    // Baseline security headers (X-Content-Type-Options, and HSTS over https). Installed first so it runs
+    // outermost and applies to every response, including CORS-processed and error responses.
+    val securityHeaders = install(SecurityHeadersInterceptor())
+    // v4-style access log: one line per request naming the resolved principal (or "anonymous") and IP.
+    val accessLog = install(AccessLogInterceptor())
     val corsInterceptor = install(CorsInterceptor(cors))
 
     init {

--- a/engine-jdk-server/src/test/kotlin/com/lightningkite/lightningserver/engine/jdk/JdkReliabilityTest.kt
+++ b/engine-jdk-server/src/test/kotlin/com/lightningkite/lightningserver/engine/jdk/JdkReliabilityTest.kt
@@ -107,14 +107,6 @@ class JdkReliabilityTest {
         .build()
 
     @Test
-    fun slow_handler_returns_408() {
-        startServer()
-        client().newCall(Request.Builder().url("http://127.0.0.1:$port/slow").build()).execute().use { resp ->
-            assertEquals(HttpStatus.RequestTimeout.code, resp.code)
-        }
-    }
-
-    @Test
     fun oversized_body_by_content_length_returns_413() {
         startServer()
         val body = ByteArray((maxBody + 1).toInt()) { 'x'.code.toByte() }.toRequestBody()

--- a/engine-ktor/src/test/kotlin/com/lightningkite/lightningserver/engine/ktor/KtorReliabilityTest.kt
+++ b/engine-ktor/src/test/kotlin/com/lightningkite/lightningserver/engine/ktor/KtorReliabilityTest.kt
@@ -98,11 +98,14 @@ class KtorReliabilityTest {
     private fun httpClient(): HttpClient = HttpClient(ClientCIO)
 
     @Test
-    fun slow_handler_returns_408() = runBlocking {
+    fun slow_handler_returns_503() = runBlocking {
+        // A handler that exceeds its own timeout is a server-side failure to respond in time, which per RFC 7231 is
+        // 503 Service Unavailable — NOT 408 (that means the *client* was too slow sending its request). The interceptor
+        // maps the handler-timeout TimeoutCancellationException accordingly; KtorHttpConformanceTest pins the same.
         startServer()
         httpClient().use { client ->
             val resp = client.get("http://127.0.0.1:$port/slow")
-            assertEquals(HttpStatusCode.RequestTimeout.value, resp.status.value)
+            assertEquals(HttpStatusCode.ServiceUnavailable.value, resp.status.value)
         }
     }
 

--- a/engine-local/src/testFixtures/kotlin/com/lightningkite/lightningserver/engine/conformance/EngineHttpConformanceSuite.kt
+++ b/engine-local/src/testFixtures/kotlin/com/lightningkite/lightningserver/engine/conformance/EngineHttpConformanceSuite.kt
@@ -245,16 +245,17 @@ public abstract class EngineHttpConformanceSuite {
     }
 
     @Test
-    public fun handler_timeout_returns_408() {
+    public fun handler_timeout_returns_503() {
         startEngine(freePort(), maxBodySize).use { running ->
             val resp = client().send(
                 request(running.port, "/slow").GET().build(),
                 BodyHandlers.ofString(),
             )
             assertEquals(
-                HttpStatus.RequestTimeout.code,
+                HttpStatus.ServiceUnavailable.code,
                 resp.statusCode(),
-                "A handler that exceeds its timeout should yield 408 (enforced centrally in ServerRuntime.handle)",
+                "A handler that exceeds its timeout is a server-side condition, so it should yield 503 " +
+                    "(enforced centrally in ServerRuntime.handle) — not 408, which means a slow client.",
             )
         }
     }
@@ -294,7 +295,7 @@ public abstract class EngineHttpConformanceSuite {
         )
 
         init {
-            // Needed so the central 408/error bodies can be serialized by the default exception handler.
+            // Needed so the central timeout/error bodies can be serialized by the default exception handler.
             registerBasicMediaTypeCoders()
             // Installed first (outermost) so security headers apply to every response — including CORS-processed
             // and error responses — which the nosniff_* tests verify end-to-end through each engine.

--- a/expectations.md
+++ b/expectations.md
@@ -1,7 +1,9 @@
 # Expectations for Engines
 
-- X-Content-Type-Options: nosniff
-- (if public URL has https) Strict-Transport-Security: max-age=3600
+- Security headers — provided by the opt-in `SecurityHeadersInterceptor` (install it in your `ServerBuilder`),
+  not emitted automatically by engines:
+    - X-Content-Type-Options: nosniff
+    - (if the request arrived over https) Strict-Transport-Security: max-age=31536000 (one year, configurable)
 - HEAD - if undefined, perform get and ignore body
 - Range - respected, ideally abuses extra options to do proper file partial fetch
 - OPTIONS

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpoints.kt
@@ -164,7 +164,16 @@ public class KnownDeviceProofEndpoints(
             successCode = HttpStatus.OK,
             implementation = { input: String ->
                 val now = now()
-                val id = input.substringBefore('/').let { Uuid.parse(it) }
+                val id = input.substringBefore('/').let {
+                    try { Uuid.parse(it) }
+                    catch (e: IllegalArgumentException) {
+                        throw BadRequestException(
+                            message = "Invalid known device identifier. ${e.message}",
+                            data = it,
+                            cause = e
+                        )
+                    }
+                }
                 val secret = input.substringAfter('/')
                 cache().constrainAttemptRate(
                     cacheKey = "known-devices-count-${id}"

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
@@ -2,11 +2,22 @@
 package com.lightningkite.lightningserver.sessions
 
 import com.lightningkite.lightningserver.ForbiddenException
+import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.auth.*
 import com.lightningkite.lightningserver.definition.Runtime
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.*
+import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.plainText
 import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.handle
+import com.lightningkite.lightningserver.runtime.serverRuntime
 import com.lightningkite.lightningserver.runtime.test.test
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.slf4j.LoggerFactory
 import com.lightningkite.lightningserver.sessions.token.PrivateTinyTokenFormat
 import com.lightningkite.lightningserver.typed.test
 import com.lightningkite.services.database.Database
@@ -92,6 +103,60 @@ class SessionManagerTest {
                 assertNotNull(refreshToken.string)
                 assertEquals("SessionTestUser", refreshToken.type)
                 assertEquals(session._id, refreshToken._id)
+            }
+        }
+    }
+
+    @Test
+    fun `access-log interceptor names the authenticated principal`() = runBlocking {
+        // v4-style access log via an opt-in interceptor: it resolves the request's Authentication (whose
+        // toString also renders masquerade, covered by AuthenticationExtTest) and logs it. We capture the
+        // emitted line to prove the principal, not just the IP, is recorded.
+        SessionTestUser.users.clear()
+        val userId = Uuid.random()
+        SessionTestUser.users[userId] = SessionTestUser(userId, "test@example.com")
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+
+            init { install(AccessLogInterceptor()) }
+
+            val sessions = path.path("auth") include TestSessionManager(database = database)
+            val ping = path.path("ping").get bind HttpHandler<PathSpec0> { HttpResponse.plainText("pong") }
+        }.let { server ->
+            server.test({}) {
+                val (_, refreshToken) = server.sessions.newSession(userId)
+                val accessToken = server.sessions.tokenSimple.test(null, refreshToken.string)
+
+                // Attach the log capture after settings are applied, so the framework's logback setup can't
+                // wipe it. Scoped to this logger and detached in finally.
+                val logbackLogger = LoggerFactory.getLogger("com.lightningkite.lightningserver") as Logger
+                val appender = ListAppender<ILoggingEvent>().apply { start() }
+                logbackLogger.level = Level.INFO
+                logbackLogger.addAppender(appender)
+                try {
+                    runBlocking {
+                        serverRuntime.handle(
+                            HttpRequest<PathSpec>(
+                                path = RawHttpEndpoint(asString = "/ping", method = HttpMethod.GET),
+                                queryParameters = QueryParameters.EMPTY,
+                                headers = HttpHeaders { add(HttpHeader.Authorization, "Bearer $accessToken") },
+                                domain = "example.com",
+                                protocol = "https",
+                                sourceIp = "local",
+                            )
+                        )
+                    }
+                } finally {
+                    logbackLogger.detachAppender(appender)
+                }
+
+                val accessLine = appender.list.map { it.formattedMessage }.singleOrNull { it.contains("accessed by") }
+                    ?: fail("Expected an access-log line; got: ${appender.list.map { it.formattedMessage }}")
+                assertTrue(
+                    accessLine.contains("SessionTestUser") && accessLine.contains(userId.toString()),
+                    "access log should name the authenticated principal; was: $accessLine",
+                )
             }
         }
     }

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpointsTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpointsTest.kt
@@ -220,6 +220,37 @@ class KnownDeviceProofEndpointsTest {
     }
 
     @Test
+    fun `prove rejects malformed device id with bad request`() = runBlocking {
+        TestUser.users.clear()
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val knownDevice = path.path("auth").path("known-device") include KnownDeviceProofEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours
+            )
+        }.let { server ->
+            server.test({}) {
+                // The id segment isn't a valid Uuid; this used to throw an unhandled
+                // IllegalArgumentException (surfaced as a 500) instead of a 400.
+                val malformedSecret = "not-a-uuid/${Uuid.random()}"
+
+                assertFailsWith<BadRequestException>("Malformed device id should be rejected") {
+                    server.knownDevice.prove.test(null, malformedSecret)
+                }
+            }
+        }
+    }
+
+    @Test
     fun `options returns correct configuration`() = runBlocking {
         TestUser.users.clear()
 


### PR DESCRIPTION
Replaces logging scattered through request handling with a single
`AccessLogInterceptor`.

**Read this before merging.** Two things here are not a plain replay of history:

- This squashes two commits (both titled "One more step"). The first added
  `RequestLogDescriber.kt`; the second deleted it again in favour of
  `AccessLogInterceptor`. Split across two PRs that is pure churn -- one PR
  proposing a file the next one removes -- so they are combined.
- `Authentication.kt` had a conflict resolved by hand. The masquerade *denial*
  log is kept, in the simpler form this commit introduces
  (`"$auth denied masquerade as $masquerade"`). The separate `AUDIT`-prefixed
  grant/denial logging from an earlier commit is deliberately gone: it was
  superseded by this interceptor, and shipping it would have meant reviewing an
  approach already abandoned.

This PR also refines the request pipeline, session manager and settings around
the interceptor, which is why it touches more than the new file.
