### PR TITLE
Request ids become Uuid, and the socket leaves ServerRuntime

### DIFF
--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AccessLogInterceptor.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AccessLogInterceptor.kt
@@ -7,13 +7,13 @@ import com.lightningkite.lightningserver.http.HttpLogicalInterceptor
 import com.lightningkite.lightningserver.logger
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.websockets.DelegatingWebSocketHandler
 import com.lightningkite.lightningserver.websockets.WebSocketClose
 import com.lightningkite.lightningserver.websockets.WebSocketConnectRequest
 import com.lightningkite.lightningserver.websockets.WebSocketConnection
 import com.lightningkite.lightningserver.websockets.WebSocketHandler
 import com.lightningkite.lightningserver.websockets.WebSocketLogicalInterceptor
 import kotlinx.coroutines.CancellationException
-import kotlinx.serialization.KSerializer
 import kotlin.time.TimeSource
 
 /**
@@ -73,9 +73,7 @@ public class AccessLogInterceptor : HttpLogicalInterceptor, WebSocketLogicalInte
     }
 
     override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> =
-        object : WebSocketHandler<PATH, T> {
-            override val storageSerializer: KSerializer<T> get() = handler.storageSerializer
-
+        object : DelegatingWebSocketHandler<PATH, T>(handler) {
             context(serverRuntime: ServerRuntime)
             override suspend fun willConnect(request: WebSocketConnectRequest<PATH>): T {
                 if (serverRuntime.logger.isInfoEnabled()) {
@@ -85,31 +83,20 @@ public class AccessLogInterceptor : HttpLogicalInterceptor, WebSocketLogicalInte
                             request.idSuffix(idLabel = "conn")
                     }
                 }
-                return handler.willConnect(request)
+                return wrapped.willConnect(request)
             }
 
-            context(connection: WebSocketConnection<PATH, T>)
-            override suspend fun didConnect(): Unit = handler.didConnect()
-
-            context(connection: WebSocketConnection<PATH, T>)
-            override suspend fun messageFromClient(frame: com.lightningkite.lightningserver.websockets.WebSocketFrame): Unit =
-                handler.messageFromClient(frame)
-
-            context(connection: WebSocketConnection<PATH, T>)
-            override suspend fun messageFromSubscription(topic: com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage<*, *>): Unit =
-                handler.messageFromSubscription(topic)
-
-            context(connection: WebSocketConnection<PATH, T>)
-            override suspend fun disconnect(reason: WebSocketClose) {
-                if (connection.logger.isInfoEnabled()) {
+            context(serverRuntime: ServerRuntime)
+            override suspend fun disconnect(connection: WebSocketConnection<PATH, T>, reason: WebSocketClose) {
+                if (serverRuntime.logger.isInfoEnabled()) {
                     val request = connection.request
-                    val principal = with(connection as ServerRuntime) { request.principalName() }
-                    connection.logger.info {
+                    val principal = request.principalName()
+                    serverRuntime.logger.info {
                         "ws ${request.path} closed by $principal (${request.sourceIp}) " +
                             "-> $reason ${request.idSuffix(idLabel = "conn")}"
                     }
                 }
-                handler.disconnect(reason)
+                wrapped.disconnect(connection, reason)
             }
         }
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/data/Request.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/data/Request.kt
@@ -4,6 +4,7 @@ import com.lightningkite.lightningserver.http.HttpHeaders
 import com.lightningkite.lightningserver.http.QueryParameters
 import com.lightningkite.lightningserver.pathing.*
 import com.lightningkite.lightningserver.runtime.ServerRuntime
+import kotlin.uuid.Uuid
 
 /**
  * Base class for HTTP requests in Lightning Server.
@@ -40,19 +41,27 @@ public abstract class Request<out PATH : PathSpec> : HasContextualPath<PATH>, Ca
      * Never derived from an untrusted caller — see
      * [com.lightningkite.lightningserver.http.requestIdentity] for how engines resolve it.
      */
-    public abstract val requestId: String
+    public abstract val requestId: Uuid
 
     /**
      * The [requestId] of the request that dispatched this one, for sub-requests of a multiplexed
      * request, or null for a request that arrived directly from a client.
      */
-    public abstract val parentRequestId: String?
+    public abstract val parentRequestId: Uuid?
 
     /**
      * An identifier the caller supplied that was not trusted, kept for diagnostics only.
      * Never used for correlation.
      */
     public abstract val upstreamRequestId: String?
+
+    /**
+     * The identifier the gateway or proxy in front of the server minted for this request, or null
+     * when the engine has none. Trusted — it comes from our own infrastructure rather than the
+     * caller — and kept only so a record can be joined back to that gateway's own access log, which
+     * is why it is a `String`: it is the gateway's identifier, in whatever shape the gateway uses.
+     */
+    public abstract val engineRequestId: String?
 
     context(serverRuntime: ServerRuntime)
     override val pathInContext: ResolvedPath<PATH>

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpRequest.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpRequest.kt
@@ -7,6 +7,7 @@ import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
 import com.lightningkite.services.data.TypedData
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import kotlin.uuid.Uuid
 
 /**
  * Represents an HTTP request with all associated data.
@@ -43,9 +44,10 @@ public data class HttpRequest<PATH : PathSpec>(
     override val domain: String,
     override val protocol: String,
     override val sourceIp: String,
-    override val requestId: String,
-    override val parentRequestId: String? = null,
+    override val requestId: Uuid,
+    override val parentRequestId: Uuid? = null,
     override val upstreamRequestId: String? = null,
+    override val engineRequestId: String? = null,
     override val cache: SerializableCache = SerializableCache(),
     @Transient public val body: TypedData? = null,
 ) : Request<PATH>() {
@@ -66,9 +68,10 @@ public data class HttpRequest<PATH : PathSpec>(
         domain: String = this.domain,
         protocol: String = this.protocol,
         sourceIp: String = this.sourceIp,
-        requestId: String = this.requestId,
-        parentRequestId: String? = this.parentRequestId,
+        requestId: Uuid = this.requestId,
+        parentRequestId: Uuid? = this.parentRequestId,
         upstreamRequestId: String? = this.upstreamRequestId,
+        engineRequestId: String? = this.engineRequestId,
         cache: SerializableCache = this.cache,
         body: TypedData? = this.body,
     ): HttpRequest<PATH2> = HttpRequest(
@@ -81,6 +84,7 @@ public data class HttpRequest<PATH : PathSpec>(
         requestId = requestId,
         parentRequestId = parentRequestId,
         upstreamRequestId = upstreamRequestId,
+        engineRequestId = engineRequestId,
         cache = cache,
         body = body,
     )

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/RequestIdentity.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/RequestIdentity.kt
@@ -1,7 +1,5 @@
 package com.lightningkite.lightningserver.http
 
-import java.security.SecureRandom
-import kotlin.io.encoding.Base64
 import kotlin.uuid.Uuid
 
 /**
@@ -10,19 +8,16 @@ import kotlin.uuid.Uuid
  * @property requestId The authoritative identifier. Always server-controlled: either generated here
  *   or adopted from a reverse proxy the deployment has explicitly declared trustworthy.
  * @property upstreamRequestId Any identifier the caller supplied that was *not* trusted, kept for
- *   diagnostics only. Never used to correlate.
+ *   diagnostics only. Never used to correlate. It stays a `String` because it is a wire-level fact
+ *   about what the caller sent, not an identifier of ours.
  */
 public data class RequestIdentity(
-    val requestId: String,
+    val requestId: Uuid,
     val upstreamRequestId: String? = null,
 )
 
 /** Generates a fresh authoritative request identifier. */
-public fun generateRequestId(): String {
-    val ba = ByteArray(16)
-    SecureRandom.getInstanceStrong().nextBytes(ba)
-    return Base64.UrlSafe.encode(ba)
-}
+public fun generateRequestId(): Uuid = Uuid.random()
 
 /**
  * Determines the [RequestIdentity] for an incoming request.
@@ -39,8 +34,9 @@ public fun generateRequestId(): String {
  * share an identifier with no correlation step.
  *
  * @param onTrustedHeaderMissing Invoked when [trustedRequestIdHeader] is configured but the header is
- *   absent, which means the request did not arrive through the expected proxy. A fresh ID is
- *   generated in that case, so correlation degrades rather than failing.
+ *   absent or does not hold a UUID, which means the request did not arrive through the expected
+ *   proxy, or that proxy does not stamp UUIDs. A fresh ID is generated in that case, so correlation
+ *   degrades rather than failing.
  */
 public fun HttpHeaders.requestIdentity(
     trustedRequestIdHeader: String?,
@@ -49,7 +45,13 @@ public fun HttpHeaders.requestIdentity(
     val claimed = get(HttpHeader.XRequestId)?.root
     if (trustedRequestIdHeader == null) return RequestIdentity(generateRequestId(), claimed)
 
-    val trusted = get(trustedRequestIdHeader)?.root
+    val trusted = get(trustedRequestIdHeader)?.root?.let {
+        try {
+            Uuid.parse(it)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
     if (trusted == null) {
         onTrustedHeaderMissing()
         return RequestIdentity(generateRequestId(), claimed)

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
@@ -230,18 +230,20 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.wi
  * Wraps a WebSocket didConnect handler invocation with telemetry metrics.
  *
  * @param location The path specification for this WebSocket endpoint
+ * @param serverRuntime The runtime this phase runs on
  * @param connection The established WebSocket connection
  */
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.didConnectWithMetrics(
     location: PATH,
+    serverRuntime: ServerRuntime,
     connection: WebSocketConnection<PATH, STORAGE>,
 ) {
-    return with(connection) {
+    return with(serverRuntime) {
         instrument("didConnect", TelemetryAttributes {
             put(wsRoute, location.toString())
-            put(TelemetryKeys.Net.peerIp, request.sourceIp)
+            put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
         }) {
-            didConnect()
+            didConnect(connection)
         }
     }
 }
@@ -252,18 +254,20 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.di
  * Records the frame type (text/binary) and size in telemetry.
  *
  * @param location The path specification for this WebSocket endpoint
+ * @param serverRuntime The runtime this phase runs on
  * @param connection The WebSocket connection
  * @param frame The frame received from the client
  */
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.messageFromClientWithMetrics(
     location: PATH,
+    serverRuntime: ServerRuntime,
     connection: WebSocketConnection<PATH, STORAGE>,
     frame: WebSocketFrame,
 ) {
-    return with(connection) {
+    return with(serverRuntime) {
         instrument("messageFromClient", TelemetryAttributes {
             put(wsRoute, location.toString())
-            put(TelemetryKeys.Net.peerIp, request.sourceIp)
+            put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
             put(
                 wsFrameType, when (frame) {
                     is WebSocketFrame.Text -> "text"
@@ -277,7 +281,7 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
                 }
             )
         }) {
-            messageFromClient(frame)
+            messageFromClient(connection, frame)
         }
     }
 }
@@ -286,21 +290,23 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
  * Wraps a WebSocket messageFromSubscription handler invocation with telemetry metrics.
  *
  * @param location The path specification for this WebSocket endpoint
+ * @param serverRuntime The runtime this phase runs on
  * @param connection The WebSocket connection
  * @param topic The subscription message received
  */
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.messageFromSubscriptionWithMetrics(
     location: PATH,
+    serverRuntime: ServerRuntime,
     connection: WebSocketConnection<PATH, STORAGE>,
     topic: WebSocketSubscriptionMessage<*, *>,
 ) {
-    return with(connection) {
+    return with(serverRuntime) {
         instrument("messageFromSubscription", TelemetryAttributes {
             put(wsRoute, location.toString())
-            put(TelemetryKeys.Net.peerIp, request.sourceIp)
+            put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
             put(wsSubscriptionTopic, topic.topic.location.toString())
         }) {
-            messageFromSubscription(topic)
+            messageFromSubscription(connection, topic)
         }
     }
 }
@@ -309,22 +315,24 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
  * Wraps a WebSocket disconnect handler invocation with telemetry metrics.
  *
  * @param location The path specification for this WebSocket endpoint
+ * @param serverRuntime The runtime this phase runs on
  * @param connection The WebSocket connection being closed
  * @param reason The close reason and code
  */
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.disconnectWithMetrics(
     location: PATH,
+    serverRuntime: ServerRuntime,
     connection: WebSocketConnection<PATH, STORAGE>,
     reason: WebSocketClose,
 ) {
-    return with(connection) {
+    return with(serverRuntime) {
         instrument("disconnect", TelemetryAttributes {
             put(wsRoute, location.toString())
-            put(TelemetryKeys.Net.peerIp, request.sourceIp)
+            put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
             put(wsDisconnectCode, reason.code.toLong())
             put(wsDisconnectReason, reason.name)
         }) {
-            disconnect(reason)
+            disconnect(connection, reason)
         }
     }
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.ext.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.ext.kt
@@ -7,6 +7,7 @@ import com.lightningkite.lightningserver.runtime.handle
 import com.lightningkite.lightningserver.runtime.location
 import com.lightningkite.lightningserver.websockets.*
 import com.lightningkite.services.data.TypedData
+import kotlin.uuid.Uuid
 
 /**
  * Testing extensions for HTTP handlers and WebSocket handlers.
@@ -34,7 +35,7 @@ public suspend fun <STORAGE> WebSocketHandler<PathSpec0, STORAGE>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec0, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -48,7 +49,7 @@ public suspend fun <STORAGE> WebSocketHandler<PathSpec0, STORAGE>.test(
     )
     val storage = intercepted.willConnect(request)
     return test.TestWebSocket(intercepted, request, storage).also {
-        with(it.server) { intercepted.didConnect() }
+        with(test) { intercepted.didConnect(it.server) }
     }
 }
 
@@ -61,7 +62,7 @@ public suspend fun <STORAGE, A> WebSocketHandler<PathSpec1<A>, STORAGE>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec1<A>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -75,7 +76,7 @@ public suspend fun <STORAGE, A> WebSocketHandler<PathSpec1<A>, STORAGE>.test(
     )
     val storage = intercepted.willConnect(request)
     return test.TestWebSocket(intercepted, request, storage).also {
-        with(it.server) { intercepted.didConnect() }
+        with(test) { intercepted.didConnect(it.server) }
     }
 }
 
@@ -89,7 +90,7 @@ public suspend fun <STORAGE, A, B> WebSocketHandler<PathSpec2<A, B>, STORAGE>.te
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec2<A, B>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -103,7 +104,7 @@ public suspend fun <STORAGE, A, B> WebSocketHandler<PathSpec2<A, B>, STORAGE>.te
     )
     val storage = with(test) { intercepted.willConnect(request) }
     return test.TestWebSocket(intercepted, request, storage).also {
-        with(it.server) { intercepted.didConnect() }
+        with(test) { intercepted.didConnect(it.server) }
     }
 }
 
@@ -118,7 +119,7 @@ public suspend fun <STORAGE, A, B, C> WebSocketHandler<PathSpec3<A, B, C>, STORA
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec3<A, B, C>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -132,7 +133,7 @@ public suspend fun <STORAGE, A, B, C> WebSocketHandler<PathSpec3<A, B, C>, STORA
     )
     val storage = with(test) { intercepted.willConnect(request) }
     return test.TestWebSocket(this, request, storage).also {
-        with(it.server) { intercepted.didConnect() }
+        with(test) { intercepted.didConnect(it.server) }
     }
 }
 
@@ -144,7 +145,7 @@ public suspend fun HttpHandler<PathSpec0>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
     return test.handle(
@@ -170,7 +171,7 @@ public suspend fun <A> HttpHandler<PathSpec1<A>>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
     return test.handle(
@@ -197,7 +198,7 @@ public suspend fun <A, B> HttpHandler<PathSpec2<A, B>>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
     return test.handle(
@@ -225,7 +226,7 @@ public suspend fun <A, B, C> HttpHandler<PathSpec3<A, B, C>>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: String = generateRequestId(),
+    requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
     return test.handle(

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
@@ -125,18 +125,17 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
 
         public suspend fun send(frame: WebSocketFrame) {
             /*logger.debug*/run { "$name --> '$frame'" }.let(::println)
-            with(server) {
-                handler.messageFromClient(frame)
-                flush()
-            }
+            val connection = this@TestWebSocket.server
+            with(this@TestRunner) { handler.messageFromClient(connection, frame) }
+            connection.flush()
         }
 
         public val server: ServerSide = ServerSide()
 
-        public inner class ServerSide() : WebSocketConnection<PATH, STORAGE>, ServerRuntime by this@TestRunner {
+        public inner class ServerSide() : WebSocketConnection<PATH, STORAGE> {
             private val changeQueue = ArrayList<(STORAGE) -> STORAGE>()
             private val sub: suspend (WebSocketSubscriptionMessage<*, *>) -> Unit = {
-                handler.messageFromSubscription(it)
+                with(this@TestRunner) { handler.messageFromSubscription(this@ServerSide, it) }
                 flush()
             }
 
@@ -185,7 +184,7 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
 
             override suspend fun close(reason: WebSocketClose) {
                 /*logger.debug*/run { "$name <-- <close>" }.let(::println)
-                handler.disconnect(reason)
+                with(this@TestRunner) { handler.disconnect(this@ServerSide, reason) }
             }
 
             internal fun clean() {

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/CoroutineWebsocketHandler.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/CoroutineWebsocketHandler.kt
@@ -177,8 +177,8 @@ public abstract class CoroutineWebSocketHandler : ServerBuilder() {
             // --- Standard WebSocketHandler implementation ---
             // Used by distributed engines (AWS Lambda) that need pub/sub
 
-            context(connection: WebSocketConnection<PathSpec0, Storage>)
-            override suspend fun didConnect() {
+            context(serverRuntime: ServerRuntime)
+            override suspend fun didConnect(connection: WebSocketConnection<PathSpec0, Storage>) {
                 // Only subscribe to outbound topic if direct send is not available
                 // This avoids unnecessary DynamoDB subscription when using direct API Gateway
                 if (connection.currentState.request.engineSocketId == null) {
@@ -230,20 +230,29 @@ public abstract class CoroutineWebSocketHandler : ServerBuilder() {
                 return@coroutineScope s
             }
 
-            context(connection: WebSocketConnection<PathSpec0, Storage>)
-            override suspend fun messageFromClient(frame: WebSocketFrame) {
+            context(serverRuntime: ServerRuntime)
+            override suspend fun messageFromClient(
+                connection: WebSocketConnection<PathSpec0, Storage>,
+                frame: WebSocketFrame,
+            ) {
                 connection.currentState.inbound().emit(frame.serializable())
             }
 
-            context(connection: WebSocketConnection<PathSpec0, Storage>)
-            override suspend fun messageFromSubscription(topic: WebSocketSubscriptionMessage<*, *>) {
+            context(serverRuntime: ServerRuntime)
+            override suspend fun messageFromSubscription(
+                connection: WebSocketConnection<PathSpec0, Storage>,
+                topic: WebSocketSubscriptionMessage<*, *>,
+            ) {
                 if (topic.topic == outboundTopic) {
                     connection.send((topic.value as SerializableWebSocketFrame).standard())
                 }
             }
 
-            context(connection: WebSocketConnection<PathSpec0, Storage>)
-            override suspend fun disconnect(reason: WebSocketClose) {
+            context(serverRuntime: ServerRuntime)
+            override suspend fun disconnect(
+                connection: WebSocketConnection<PathSpec0, Storage>,
+                reason: WebSocketClose,
+            ) {
                 connection.currentState.inbound().emit(SerializableWebSocketFrame(close = true))
             }
         })

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/DelegatingWebSocketHandler.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/DelegatingWebSocketHandler.kt
@@ -1,0 +1,46 @@
+package com.lightningkite.lightningserver.websockets
+
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import kotlinx.serialization.KSerializer
+
+/**
+ * A handler that passes every phase through to [wrapped], so a subclass overrides only the phases it
+ * actually has something to say about.
+ *
+ * Wrapping a socket almost always means acting on one or two of the five phases — an interceptor that
+ * logs the open and the close has nothing to add to the three in between — and hand-writing the rest
+ * as pass-throughs both buries the interesting override and makes every wrapper a place a future
+ * phase can be forgotten.
+ */
+public abstract class DelegatingWebSocketHandler<PATH : PathSpec, STORAGE>(
+    protected val wrapped: WebSocketHandler<PATH, STORAGE>,
+) : WebSocketHandler<PATH, STORAGE> {
+    override val storageSerializer: KSerializer<STORAGE> get() = wrapped.storageSerializer
+
+    context(serverRuntime: ServerRuntime)
+    override suspend fun willConnect(request: WebSocketConnectRequest<PATH>): STORAGE =
+        wrapped.willConnect(request)
+
+    context(serverRuntime: ServerRuntime)
+    override suspend fun didConnect(connection: WebSocketConnection<PATH, STORAGE>): Unit =
+        wrapped.didConnect(connection)
+
+    context(serverRuntime: ServerRuntime)
+    override suspend fun messageFromClient(
+        connection: WebSocketConnection<PATH, STORAGE>,
+        frame: WebSocketFrame,
+    ): Unit = wrapped.messageFromClient(connection, frame)
+
+    context(serverRuntime: ServerRuntime)
+    override suspend fun messageFromSubscription(
+        connection: WebSocketConnection<PATH, STORAGE>,
+        topic: WebSocketSubscriptionMessage<*, *>,
+    ): Unit = wrapped.messageFromSubscription(connection, topic)
+
+    context(serverRuntime: ServerRuntime)
+    override suspend fun disconnect(
+        connection: WebSocketConnection<PATH, STORAGE>,
+        reason: WebSocketClose,
+    ): Unit = wrapped.disconnect(connection, reason)
+}

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/MultiplexWebSocketHandler.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/MultiplexWebSocketHandler.kt
@@ -40,21 +40,22 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
     override val storageSerializer: KSerializer<MultiplexWebSocketHandlerState> get() = serializer()
 
     private inner class WrappedConnection<T>(
+        val runtime: ServerRuntime,
         val wrapped: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>,
         val channel: String,
         val handler: WebSocketHandler<PathSpec, T>,
-    ) : WebSocketConnection<PathSpec, T>, ServerRuntime by wrapped {
+    ) : WebSocketConnection<PathSpec, T> {
         @Suppress("UNCHECKED_CAST")
         override val request: WebSocketConnectRequest<PathSpec> get() = wrapped.currentState.map.getValue(channel).request as WebSocketConnectRequest<PathSpec>
         override var currentState: T = wrapped.currentState.map.getValue(channel).storage.value(
-            wrapped.internalSerialization.kotlinBytesFormat,
+            runtime.internalSerialization.kotlinBytesFormat,
             handler.storageSerializer
         )
             private set
 
         override suspend fun close(reason: WebSocketClose) = wrapped.close(reason)
         override suspend fun send(frame: WebSocketFrame) = wrapped.send(
-            externalSerialization.json.encodeToString(
+            runtime.externalSerialization.json.encodeToString(
                 MultiplexMessage(
                     channel = channel,
                     data = frame.text
@@ -67,20 +68,21 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                 val info = wrapped.repullState().map[channel]
                     ?: throw IllegalStateException("Multiplex channel $channel was closed while it was being handled.")
                 info.storage.value(
-                    this.internalSerialization.kotlinBytesFormat,
+                    runtime.internalSerialization.kotlinBytesFormat,
                     handler.storageSerializer
                 )
             }
 
         override suspend fun subscribe(topic: WebSocketSubscriptionRequest<*, *>) {
-            if (topic.path() !in wrapped.currentState) wrapped.subscribe(topic)
+            val asString = with(runtime) { topic.path() }
+            if (asString !in wrapped.currentState) wrapped.subscribe(topic)
             wrapped.updateStateImmediately { data ->
-                data.updateChannel(channel) { it.copy(topics = it.topics + topic.path()) }
+                data.updateChannel(channel) { it.copy(topics = it.topics + asString) }
             }
         }
 
         override suspend fun unsubscribe(topic: WebSocketSubscriptionRequest<*, *>) {
-            val asString = topic.path()
+            val asString = with(runtime) { topic.path() }
             val newstate = wrapped.updateStateImmediately { data ->
                 data.updateChannel(channel) { it.copy(topics = it.topics - asString) }
             }
@@ -92,12 +94,12 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
             wrapped.queueStateUpdate { data ->
                 data.updateChannel(channel) { info ->
                     val underlying = info.storage.value(
-                        this.internalSerialization.kotlinBytesFormat,
+                        runtime.internalSerialization.kotlinBytesFormat,
                         handler.storageSerializer
                     )
                     info.copy(
                         storage = AnonType(
-                            this.internalSerialization.kotlinBytesFormat,
+                            runtime.internalSerialization.kotlinBytesFormat,
                             modification(underlying),
                             handler.storageSerializer
                         )
@@ -110,12 +112,12 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
             wrapped.updateStateImmediately { data ->
                 data.updateChannel(channel) { info ->
                     val underlying = info.storage.value(
-                        this.internalSerialization.kotlinBytesFormat,
+                        runtime.internalSerialization.kotlinBytesFormat,
                         handler.storageSerializer
                     )
                     info.copy(
                         storage = AnonType(
-                            this.internalSerialization.kotlinBytesFormat,
+                            runtime.internalSerialization.kotlinBytesFormat,
                             modification(underlying).also {
                                 currentState = it
                             },
@@ -138,11 +140,12 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
     }
 
     private suspend inline fun <T> WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>.withWrapped(
+        runtime: ServerRuntime,
         handler: WebSocketHandler<PathSpec, T>,
         channel: String,
         action: suspend (WrappedConnection<T>) -> Unit,
     ): WebSocketConnection<PathSpec, T> {
-        val wrapped = WrappedConnection(this, channel, handler)
+        val wrapped = WrappedConnection(runtime, this, channel, handler)
         action(wrapped)
         wrapped.finalize()
         return wrapped
@@ -154,11 +157,13 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
             map = mapOf(),
         )
 
-    context(connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>)
-    override suspend fun didConnect(): Unit = Unit
+    context(serverRuntime: ServerRuntime)
+    override suspend fun didConnect(connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>): Unit =
+        Unit
 
-    context(connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>)
+    context(serverRuntime: ServerRuntime)
     override suspend fun messageFromClient(
+        connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>,
         frame: WebSocketFrame,
     ) {
         if ((frame as? WebSocketFrame.Text)?.content?.isBlank() == true) {
@@ -166,48 +171,49 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
             return
         }
         val message =
-            connection.externalSerialization.json.decodeFromString<MultiplexMessage>((frame as WebSocketFrame.Text).content)
+            serverRuntime.externalSerialization.json.decodeFromString<MultiplexMessage>((frame as WebSocketFrame.Text).content)
         val channel = message.channel
         try {
             when {
                 message.start -> {
-                    val match = connection.server.endpoints.match(
-                        connection.externalSerialization.stringArrayFormat,
+                    val match = serverRuntime.server.endpoints.match(
+                        serverRuntime.externalSerialization.stringArrayFormat,
                         message.path!!
                     ) { it.webSocket } ?: throw NotFoundException()
                     // A virtual socket is a logical connection in its own right, so it must go through the webSocket
                     // interceptor chain. Taking the raw handler let every multiplexed socket bypass access logging and
                     // rate limiting, exactly as bulk sub-requests once bypassed the HTTP chain.
                     @Suppress("UNCHECKED_CAST")
-                    val otherHandler = connection.server.compiledWebSocketLogicalInterceptors
+                    val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
                         .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
                     val r = connection.request.subConnection<PathSpec>(
                         path = RawWebSocketPath<PathSpec>(PathSegments.parse(message.path!!), match),
                         queryParameters = QueryParameters(connection.request.queryParameters + (message.queryParams?.entries?.flatMap { it.value.map { v -> it.key to v } }
                             ?: listOf())),
                     )
-                    val storage = otherHandler.willConnectWithMetrics(match.path.pathSpec, connection, r)
+                    val storage = otherHandler.willConnectWithMetrics(match.path.pathSpec, serverRuntime, r)
                     connection.updateStateImmediately {
                         it.copy(
                             map = it.map + (channel to MultiplexWebSocketHandlerConnectionInfo(
                                 request = r,
                                 storage = AnonType(
-                                    connection.internalSerialization.kotlinBytesFormat,
+                                    serverRuntime.internalSerialization.kotlinBytesFormat,
                                     storage,
                                     otherHandler.storageSerializer
                                 ),
                             ))
                         )
                     }
-                    connection.withWrapped(otherHandler, channel) {
+                    connection.withWrapped(serverRuntime, otherHandler, channel) {
                         otherHandler.didConnectWithMetrics(
                             match.pathSpec,
+                            serverRuntime,
                             it
                         )
                     }
                     connection.send(
                         WebSocketFrame(
-                            connection.externalSerialization.json.encodeToString(
+                            serverRuntime.externalSerialization.json.encodeToString(
                                 MultiplexMessage(
                                     channel = channel,
                                     start = true
@@ -220,13 +226,14 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                 message.end -> {
                     val info = connection.currentState.map[message.channel]
                         ?: throw NotFoundException("No open multiplex channel ${message.channel} to end.")
-                    val match = with(connection) { info.request.path.match }
+                    val match = info.request.path.match
                     @Suppress("UNCHECKED_CAST")
-                    val otherHandler = connection.server.compiledWebSocketLogicalInterceptors
+                    val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
                         .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
-                    connection.withWrapped(otherHandler, channel) {
+                    connection.withWrapped(serverRuntime, otherHandler, channel) {
                         otherHandler.disconnectWithMetrics(
                             match.pathSpec,
+                            serverRuntime,
                             it,
                             WebSocketClose.NORMAL
                         )
@@ -234,7 +241,7 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                     connection.updateStateImmediately { it.copy(map = it.map - channel) }
                     connection.send(
                         WebSocketFrame(
-                            connection.externalSerialization.json.encodeToString(
+                            serverRuntime.externalSerialization.json.encodeToString(
                                 MultiplexMessage(
                                     channel = channel,
                                     end = true
@@ -247,20 +254,21 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                 message.data != null -> {
                     val info = connection.currentState.map[message.channel]
                         ?: throw NotFoundException("No open multiplex channel ${message.channel} to deliver data to.")
-                    val match = with(connection) { info.request.path.match }
+                    val match = info.request.path.match
                     @Suppress("UNCHECKED_CAST")
-                    val otherHandler = connection.server.compiledWebSocketLogicalInterceptors
+                    val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
                         .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
                     val textFrame = WebSocketFrame.Text(message.data!!)
                     connection.withWrapped(
+                        serverRuntime,
                         otherHandler,
                         channel
-                    ) { otherHandler.messageFromClientWithMetrics(match.pathSpec, it, textFrame) }
+                    ) { otherHandler.messageFromClientWithMetrics(match.pathSpec, serverRuntime, it, textFrame) }
                 }
             }
         } catch (e: Exception) {
             connection.send(
-                connection.externalSerialization.json.encodeToString(
+                serverRuntime.externalSerialization.json.encodeToString(
                     MultiplexMessage(
                         channel,
                         end = true,
@@ -269,13 +277,14 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                 )
             )
             connection.currentState.map[channel]?.let { info ->
-                val match = with(connection) { info.request.path.match }
+                val match = info.request.path.match
                 @Suppress("UNCHECKED_CAST")
-                val otherHandler = connection.server.compiledWebSocketLogicalInterceptors
+                val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
                     .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
-                connection.withWrapped(otherHandler, channel) {
+                connection.withWrapped(serverRuntime, otherHandler, channel) {
                     otherHandler.disconnectWithMetrics(
                         match.pathSpec,
+                        serverRuntime,
                         it,
                         ((e as? HttpStatusException)?.status ?: HttpStatus.InternalServerError).bestWebSocketCloseCode
                     )
@@ -285,34 +294,37 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
         }
     }
 
-    context(connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>)
+    context(serverRuntime: ServerRuntime)
     override suspend fun messageFromSubscription(
+        connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>,
         topic: WebSocketSubscriptionMessage<*, *>,
-    ): Unit = with(connection) {
-        for ((channel, info) in currentState.map) {
+    ) {
+        for ((channel, info) in connection.currentState.map) {
             if (info.topics.contains(topic.path())) {
-                val match = with(connection) { info.request.path.match }
+                val match = info.request.path.match
                 @Suppress("UNCHECKED_CAST")
-                val otherHandler = connection.server.compiledWebSocketLogicalInterceptors
+                val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
                     .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
-                connection.withWrapped(otherHandler, channel) {
-                    otherHandler.messageFromSubscriptionWithMetrics(match.pathSpec, it, topic)
+                connection.withWrapped(serverRuntime, otherHandler, channel) {
+                    otherHandler.messageFromSubscriptionWithMetrics(match.pathSpec, serverRuntime, it, topic)
                 }
             }
         }
     }
 
-    context(connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>)
-    override suspend fun disconnect(reason: WebSocketClose): Unit =
-        with(connection) {
-            currentState.map.entries.forEach { (channel, info) ->
-                val match = with(connection) { info.request.path.match }
-                @Suppress("UNCHECKED_CAST")
-                val otherHandler = connection.server.compiledWebSocketLogicalInterceptors
-                    .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
-                connection.withWrapped(otherHandler, channel) {
-                    otherHandler.disconnectWithMetrics(match.pathSpec, it, reason)
-                }
+    context(serverRuntime: ServerRuntime)
+    override suspend fun disconnect(
+        connection: WebSocketConnection<PathSpec0, MultiplexWebSocketHandlerState>,
+        reason: WebSocketClose,
+    ) {
+        connection.currentState.map.entries.forEach { (channel, info) ->
+            val match = info.request.path.match
+            @Suppress("UNCHECKED_CAST")
+            val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
+                .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
+            connection.withWrapped(serverRuntime, otherHandler, channel) {
+                otherHandler.disconnectWithMetrics(match.pathSpec, serverRuntime, it, reason)
             }
         }
+    }
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/QueryParamWebSocketHandler.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/QueryParamWebSocketHandler.kt
@@ -21,14 +21,15 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
         QueryParamWebSocketHandlerData.serializer()
 
     private class ConnectionWrapped<T>(
+        val runtime: ServerRuntime,
         val wrapped: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>,
         val handler: WebSocketHandler<PathSpec, T>,
-    ) : WebSocketConnection<PathSpec, T>, ServerRuntime by wrapped {
+    ) : WebSocketConnection<PathSpec, T> {
         @Suppress("UNCHECKED_CAST")
         override val request: WebSocketConnectRequest<PathSpec>
             get() = wrapped.currentState.request as WebSocketConnectRequest<PathSpec>
         override var currentState: T = wrapped.currentState.underlyingData.value(
-            wrapped.internalSerialization.kotlinBytesFormat,
+            runtime.internalSerialization.kotlinBytesFormat,
             handler.storageSerializer
         )
             private set
@@ -37,7 +38,7 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
         override suspend fun send(frame: WebSocketFrame) = wrapped.send(frame)
         override suspend fun repullState(): T =
             wrapped.repullState().underlyingData.value(
-                wrapped.internalSerialization.kotlinBytesFormat,
+                runtime.internalSerialization.kotlinBytesFormat,
                 handler.storageSerializer
             )
 
@@ -45,12 +46,12 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
             wrapped.queueStateUpdate { data ->
                 val underlying =
                     data.underlyingData.value(
-                        wrapped.internalSerialization.kotlinBytesFormat,
+                        runtime.internalSerialization.kotlinBytesFormat,
                         handler.storageSerializer
                     )
                 data.copy(
                     underlyingData = AnonType(
-                        wrapped.internalSerialization.kotlinBytesFormat,
+                        runtime.internalSerialization.kotlinBytesFormat,
                         modification(underlying),
                         handler.storageSerializer
                     )
@@ -62,12 +63,12 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
             wrapped.updateStateImmediately { data ->
                 val underlying =
                     data.underlyingData.value(
-                        wrapped.internalSerialization.kotlinBytesFormat,
+                        runtime.internalSerialization.kotlinBytesFormat,
                         handler.storageSerializer
                     )
                 data.copy(
                     underlyingData = AnonType(
-                        wrapped.internalSerialization.kotlinBytesFormat,
+                        runtime.internalSerialization.kotlinBytesFormat,
                         modification(underlying).also { currentState = it },
                         handler.storageSerializer
                     )
@@ -91,10 +92,11 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
     }
 
     private suspend inline fun <T> WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>.withWrapped(
+        runtime: ServerRuntime,
         handler: WebSocketHandler<PathSpec, T>,
         action: suspend (ConnectionWrapped<T>) -> Unit,
     ): WebSocketConnection<PathSpec, T> {
-        val wrapped = ConnectionWrapped(this, handler)
+        val wrapped = ConnectionWrapped(runtime, this, handler)
         action(wrapped)
         wrapped.finalize()
         return wrapped
@@ -165,60 +167,58 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
         )
     }
 
-    context(connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>)
-    override suspend fun didConnect(
-    ) {
-        val innerRequest = connection.currentState.request
-        val match = with(connection) { innerRequest.path.match }
+    /**
+     * Resolves the handler the socket was actually opened against, which is stored on the connection
+     * rather than the path because every AWS socket arrives at "/".
+     */
+    context(serverRuntime: ServerRuntime)
+    private fun WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>.inner(): Pair<PathSpec, WebSocketHandler<PathSpec, Any?>> {
+        val innerRequest = currentState.request
+        val match = innerRequest.path.match
         val otherHandler = match.value
-            ?: throw com.lightningkite.lightningserver.NotFoundException("No web socket handler found for '${innerRequest.path}'")
+            ?: throw NotFoundException("No web socket handler found for '${innerRequest.path}'")
         @Suppress("UNCHECKED_CAST")
-        otherHandler as WebSocketHandler<PathSpec, Any?>
-        connection.withWrapped(otherHandler) { otherHandler.didConnectWithMetrics(match.pathSpec, it) }
+        return match.pathSpec to (otherHandler as WebSocketHandler<PathSpec, Any?>)
     }
 
-    context(connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>)
-    override suspend fun messageFromClient(
-        frame: WebSocketFrame,
-    ) {
-        val innerRequest = connection.currentState.request
-        val match = with(connection) { innerRequest.path.match }
-        val otherHandler = match.value
-            ?: throw com.lightningkite.lightningserver.NotFoundException("No web socket handler found for '${innerRequest.path}'")
-        @Suppress("UNCHECKED_CAST")
-        otherHandler as WebSocketHandler<PathSpec, Any?>
-        connection.withWrapped(otherHandler) { otherHandler.messageFromClientWithMetrics(match.pathSpec, it, frame) }
-    }
-
-    context(connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>)
-    override suspend fun messageFromSubscription(
-        topic: WebSocketSubscriptionMessage<*, *>,
-    ) {
-        val innerRequest = connection.currentState.request
-        val match = with(connection) { innerRequest.path.match }
-        val otherHandler = match.value
-            ?: throw com.lightningkite.lightningserver.NotFoundException("No web socket handler found for '${innerRequest.path}'")
-        @Suppress("UNCHECKED_CAST")
-        otherHandler as WebSocketHandler<PathSpec, Any?>
-        connection.withWrapped(otherHandler) {
-            otherHandler.messageFromSubscriptionWithMetrics(
-                match.pathSpec,
-                it,
-                topic
-            )
+    context(serverRuntime: ServerRuntime)
+    override suspend fun didConnect(connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>) {
+        val (pathSpec, otherHandler) = connection.inner()
+        connection.withWrapped(serverRuntime, otherHandler) {
+            otherHandler.didConnectWithMetrics(pathSpec, serverRuntime, it)
         }
     }
 
-    context(connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>)
+    context(serverRuntime: ServerRuntime)
+    override suspend fun messageFromClient(
+        connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>,
+        frame: WebSocketFrame,
+    ) {
+        val (pathSpec, otherHandler) = connection.inner()
+        connection.withWrapped(serverRuntime, otherHandler) {
+            otherHandler.messageFromClientWithMetrics(pathSpec, serverRuntime, it, frame)
+        }
+    }
+
+    context(serverRuntime: ServerRuntime)
+    override suspend fun messageFromSubscription(
+        connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>,
+        topic: WebSocketSubscriptionMessage<*, *>,
+    ) {
+        val (pathSpec, otherHandler) = connection.inner()
+        connection.withWrapped(serverRuntime, otherHandler) {
+            otherHandler.messageFromSubscriptionWithMetrics(pathSpec, serverRuntime, it, topic)
+        }
+    }
+
+    context(serverRuntime: ServerRuntime)
     override suspend fun disconnect(
+        connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>,
         reason: WebSocketClose,
     ) {
-        val innerRequest = connection.currentState.request
-        val match = with(connection) { innerRequest.path.match }
-        val otherHandler = match.value
-            ?: throw com.lightningkite.lightningserver.NotFoundException("No web socket handler found for '${innerRequest.path}'")
-        @Suppress("UNCHECKED_CAST")
-        otherHandler as WebSocketHandler<PathSpec, Any?>
-        connection.withWrapped(otherHandler) { otherHandler.disconnectWithMetrics(match.pathSpec, it, reason) }
+        val (pathSpec, otherHandler) = connection.inner()
+        connection.withWrapped(serverRuntime, otherHandler) {
+            otherHandler.disconnectWithMetrics(pathSpec, serverRuntime, it, reason)
+        }
     }
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocket.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocket.kt
@@ -10,6 +10,7 @@ import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.location
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
 
 
 /**
@@ -90,8 +91,8 @@ public data class WebSocketConnectRequest<PATH : PathSpec>(
      * this connection correlates back to it, since a long-lived socket is one logical session rather
      * than one request.
      */
-    override val requestId: String,
-    override val parentRequestId: String? = null,
+    override val requestId: Uuid,
+    override val parentRequestId: Uuid? = null,
     override val upstreamRequestId: String? = null,
     override val cache: SerializableCache = SerializableCache(),
     /**
@@ -101,6 +102,9 @@ public data class WebSocketConnectRequest<PATH : PathSpec>(
      */
     val engineSocketId: String? = null,
 ) : Request<PATH>() {
+    /** The gateway's identifier for a socket is the socket itself, so there is nothing else to hold. */
+    override val engineRequestId: String? get() = engineSocketId
+
     /**
      * Derives a logical sub-connection of this one, as multiplexing carries several logical sockets
      * over a single physical connection.
@@ -131,8 +135,8 @@ public data class WebSocketConnectRequest<PATH : PathSpec>(
 /**
  * Represents an active WebSocket connection with stateful lifecycle management.
  *
- * This interface extends [ServerRuntime] to provide access to server services and adds
- * WebSocket-specific functionality for managing connection state, subscriptions, and messaging.
+ * This is the socket alone: connection state, subscriptions, and messaging. The server it runs on is
+ * a separate concern, supplied to every [WebSocketHandler] method as a [ServerRuntime] context.
  *
  * **State Management:**
  * Each connection maintains a STORAGE object that can be updated in two ways:
@@ -149,7 +153,7 @@ public data class WebSocketConnectRequest<PATH : PathSpec>(
  * @param PATH The PathSpec type for this WebSocket endpoint
  * @param STORAGE The type of state object maintained for this connection
  */
-public interface WebSocketConnection<PATH : PathSpec, STORAGE> : ServerRuntime {
+public interface WebSocketConnection<PATH : PathSpec, STORAGE> {
     /** The original connection request */
     public val request: WebSocketConnectRequest<PATH>
 
@@ -210,8 +214,8 @@ public interface WebSocketConnection<PATH : PathSpec, STORAGE> : ServerRuntime {
  * 3. No way to query current subscriptions for a connection. Adding a `val subscriptions: Set<WebSocketSubscriptionRequest<*, *>>`
  *    would be useful for debugging and state inspection.
  *
- * 4. WebSocketConnection extends ServerRuntime which means every connection has its own runtime context.
- *    Document how this relates to the parent server runtime and if there are any scoping implications.
+ * 4. No way to identify a connection from the connection itself; callers reach for
+ *    `request.requestId`. Consider exposing the socket's identity directly.
  *
  * 5. The subscribe/unsubscribe operations don't return success/failure. If a topic doesn't exist or
  *    subscription fails, how does the caller know? Consider returning Boolean or throwing exceptions.

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocketHandler.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocketHandler.kt
@@ -10,18 +10,28 @@ import com.lightningkite.lightningserver.serialization.serializerOrContextual
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.serialization.KSerializer
 
+/**
+ * The five phases of a WebSocket's life, as the server sees them.
+ *
+ * The server is the context and the socket is an argument, because they have different lifetimes: on
+ * a serverless engine each phase below is a separate invocation with its own runtime, while the
+ * connection is the one thing that persists across all of them.
+ */
 public interface WebSocketHandler<PATH : PathSpec, STORAGE> {
     public val storageSerializer: KSerializer<STORAGE>
     public context(serverRuntime: ServerRuntime)
     suspend fun willConnect(request: WebSocketConnectRequest<PATH>): STORAGE
-    public context(connection: WebSocketConnection<PATH, STORAGE>)
-    suspend fun didConnect()
-    public context(connection: WebSocketConnection<PATH, STORAGE>)
-    suspend fun messageFromClient(frame: WebSocketFrame)
-    public context(connection: WebSocketConnection<PATH, STORAGE>)
-    suspend fun messageFromSubscription(topic: WebSocketSubscriptionMessage<*, *>)
-    public context(connection: WebSocketConnection<PATH, STORAGE>)
-    suspend fun disconnect(reason: WebSocketClose)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun didConnect(connection: WebSocketConnection<PATH, STORAGE>)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun messageFromClient(connection: WebSocketConnection<PATH, STORAGE>, frame: WebSocketFrame)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun messageFromSubscription(
+        connection: WebSocketConnection<PATH, STORAGE>,
+        topic: WebSocketSubscriptionMessage<*, *>,
+    )
+    public context(serverRuntime: ServerRuntime)
+    suspend fun disconnect(connection: WebSocketConnection<PATH, STORAGE>, reason: WebSocketClose)
 }
 
 /**
@@ -60,60 +70,59 @@ public interface DirectExecutableWebSocketHandler<PATH : PathSpec> {
 
 // BUILDER
 
-@InternalLightningServerApi
-public suspend fun <PATH : PathSpec, STORAGE> WebSocketConnection<PATH, STORAGE>.didConnectNoOp(): Unit = Unit
-
-@InternalLightningServerApi
-public suspend fun <PATH : PathSpec, STORAGE> WebSocketConnection<PATH, STORAGE>.messageFromClientNoOp(frame: WebSocketFrame): Unit =
-    Unit
-
-@InternalLightningServerApi
-public suspend fun <PATH : PathSpec, STORAGE> WebSocketConnection<PATH, STORAGE>.disconnectNoOp(reason: WebSocketClose): Unit =
-    Unit
-
+/**
+ * Builds a handler from one lambda per lifecycle phase.
+ *
+ * The connection is the lambdas' receiver and the [ServerRuntime] their context, which is the
+ * opposite of how [WebSocketHandler] declares them. A socket body spends most of its lines on the
+ * socket — `send`, `currentState`, `subscribe` — so that is what `this` should be, while the runtime
+ * is what the settings and service accessors want and they take it as a context anyway.
+ */
 public inline fun <PATH : PathSpec, reified STORAGE> WebSocketHandler(
     storageSerializer: KSerializer<STORAGE> = serializerOrContextual<STORAGE>(),
     crossinline willConnect: suspend ServerRuntime.(request: WebSocketConnectRequest<PATH>) -> STORAGE,
-    crossinline didConnect: suspend WebSocketConnection<PATH, STORAGE>.() -> Unit = WebSocketConnection<PATH, STORAGE>::didConnectNoOp,
-    crossinline messageFromClient: suspend WebSocketConnection<PATH, STORAGE>.(frame: WebSocketFrame) -> Unit = WebSocketConnection<PATH, STORAGE>::messageFromClientNoOp,
+    crossinline didConnect: suspend context(ServerRuntime) WebSocketConnection<PATH, STORAGE>.() -> Unit = {},
+    crossinline messageFromClient: suspend context(ServerRuntime) WebSocketConnection<PATH, STORAGE>.(frame: WebSocketFrame) -> Unit = {},
     crossinline topicHandlers: TopicHandlersBuilder<PATH, STORAGE>.() -> Unit = {},
-    crossinline disconnect: suspend WebSocketConnection<PATH, STORAGE>.(reason: WebSocketClose) -> Unit = WebSocketConnection<PATH, STORAGE>::disconnectNoOp,
+    crossinline disconnect: suspend context(ServerRuntime) WebSocketConnection<PATH, STORAGE>.(reason: WebSocketClose) -> Unit = {},
 ): WebSocketHandler<PATH, STORAGE> =
     object : WebSocketHandler<PATH, STORAGE> {
         override val storageSerializer: KSerializer<STORAGE> = storageSerializer
         override suspend context(serverRuntime: ServerRuntime)
         fun willConnect(request: WebSocketConnectRequest<PATH>): STORAGE =
-            willConnect(contextOf<ServerRuntime>(), request)
+            willConnect(serverRuntime, request)
 
-        override suspend context(connection: WebSocketConnection<PATH, STORAGE>)
-        fun didConnect() {
-            didConnect(contextOf<WebSocketConnection<PATH, STORAGE>>())
+        override suspend context(serverRuntime: ServerRuntime)
+        fun didConnect(connection: WebSocketConnection<PATH, STORAGE>) {
+            didConnect(serverRuntime, connection)
         }
 
-        override suspend context(connection: WebSocketConnection<PATH, STORAGE>)
-        fun messageFromClient(frame: WebSocketFrame) {
-            messageFromClient(contextOf<WebSocketConnection<PATH, STORAGE>>(), frame)
+        override suspend context(serverRuntime: ServerRuntime)
+        fun messageFromClient(connection: WebSocketConnection<PATH, STORAGE>, frame: WebSocketFrame) {
+            messageFromClient(serverRuntime, connection, frame)
         }
 
         private val subHandler = TopicHandlersBuilder<PATH, STORAGE>().apply(topicHandlers).build()
-        override suspend context(connection: WebSocketConnection<PATH, STORAGE>)
-        fun messageFromSubscription(topic: WebSocketSubscriptionMessage<*, *>) =
-            subHandler(contextOf<WebSocketConnection<PATH, STORAGE>>(), topic)
+        override suspend context(serverRuntime: ServerRuntime)
+        fun messageFromSubscription(
+            connection: WebSocketConnection<PATH, STORAGE>,
+            topic: WebSocketSubscriptionMessage<*, *>,
+        ): Unit = subHandler(serverRuntime, connection, topic)
 
-        override suspend context(connection: WebSocketConnection<PATH, STORAGE>)
-        fun disconnect(reason: WebSocketClose) {
-            disconnect(contextOf<WebSocketConnection<PATH, STORAGE>>(), reason)
+        override suspend context(serverRuntime: ServerRuntime)
+        fun disconnect(connection: WebSocketConnection<PATH, STORAGE>, reason: WebSocketClose) {
+            disconnect(serverRuntime, connection, reason)
         }
     }
 
 public class TopicHandlersBuilder<PATH : PathSpec, STORAGE>() {
-    public var handler: suspend WebSocketConnection<PATH, STORAGE>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
+    public var handler: suspend context(ServerRuntime) WebSocketConnection<PATH, STORAGE>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
         {}
 
     @Suppress("UNCHECKED_CAST", "DSL_MARKER_APPLIED_TO_WRONG_TARGET")
     @LightningServerDsl
     public inline infix fun <TOPICPATH : PathSpec, T> WebSocketTopic<TOPICPATH, T>.bind(
-        crossinline handler: suspend WebSocketConnection<PATH, STORAGE>.(topic: WebSocketSubscriptionMessage<TOPICPATH, T>) -> Unit,
+        crossinline handler: suspend context(ServerRuntime) WebSocketConnection<PATH, STORAGE>.(topic: WebSocketSubscriptionMessage<TOPICPATH, T>) -> Unit,
     ) {
         val topic = this
         this@TopicHandlersBuilder.handler = this@TopicHandlersBuilder.handler.let { current ->
@@ -124,6 +133,6 @@ public class TopicHandlersBuilder<PATH : PathSpec, STORAGE>() {
         }
     }
 
-    public fun build(): suspend WebSocketConnection<PATH, STORAGE>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
+    public fun build(): suspend context(ServerRuntime) WebSocketConnection<PATH, STORAGE>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
         handler
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocketInterceptor.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocketInterceptor.kt
@@ -3,7 +3,6 @@ package com.lightningkite.lightningserver.websockets
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.instrument
-import kotlinx.serialization.KSerializer
 
 /**
  * Shared contract for WebSocket interceptors.
@@ -59,74 +58,63 @@ public interface WebSocketConnectionInterceptor : WebSocketInterceptor
 public interface WebSocketLogicalInterceptor : WebSocketInterceptor
 
 
+/** One link of a compiled chain, wrapping every phase of [this] in its own instrumentation span. */
 private fun <PATH : PathSpec, T> WebSocketHandler<PATH, T>.instrumented(name: String): WebSocketHandler<PATH, T> {
-    return object : WebSocketHandler<PATH, T> {
-        override val storageSerializer: KSerializer<T>
-            get() = this@instrumented.storageSerializer
+    return object : DelegatingWebSocketHandler<PATH, T>(this@instrumented) {
+        context(serverRuntime: ServerRuntime)
+        override suspend fun willConnect(request: WebSocketConnectRequest<PATH>): T =
+            instrument(name) { wrapped.willConnect(request) }
 
         context(serverRuntime: ServerRuntime)
-        override suspend fun willConnect(request: WebSocketConnectRequest<PATH>): T {
-            return instrument(name) {
-                this@instrumented.willConnect(request)
-            }
-        }
+        override suspend fun didConnect(connection: WebSocketConnection<PATH, T>): Unit =
+            instrument(name) { wrapped.didConnect(connection) }
 
-        context(connection: WebSocketConnection<PATH, T>)
-        override suspend fun didConnect() {
-            return instrument(name) {
-                this@instrumented.didConnect()
-            }
-        }
+        context(serverRuntime: ServerRuntime)
+        override suspend fun messageFromClient(connection: WebSocketConnection<PATH, T>, frame: WebSocketFrame): Unit =
+            instrument(name) { wrapped.messageFromClient(connection, frame) }
 
-        context(connection: WebSocketConnection<PATH, T>)
-        override suspend fun messageFromClient(frame: WebSocketFrame) {
-            return instrument(name) {
-                this@instrumented.messageFromClient(frame)
-            }
-        }
+        context(serverRuntime: ServerRuntime)
+        override suspend fun messageFromSubscription(
+            connection: WebSocketConnection<PATH, T>,
+            topic: WebSocketSubscriptionMessage<*, *>,
+        ): Unit = instrument(name) { wrapped.messageFromSubscription(connection, topic) }
 
-        context(connection: WebSocketConnection<PATH, T>)
-        override suspend fun messageFromSubscription(topic: WebSocketSubscriptionMessage<*, *>) {
-            return instrument(name) {
-                this@instrumented.messageFromSubscription(topic)
-            }
-        }
-
-        context(connection: WebSocketConnection<PATH, T>)
-        override suspend fun disconnect(reason: WebSocketClose) {
-            return instrument(name) {
-                this@instrumented.disconnect(reason)
-            }
-        }
-
+        context(serverRuntime: ServerRuntime)
+        override suspend fun disconnect(connection: WebSocketConnection<PATH, T>, reason: WebSocketClose): Unit =
+            instrument(name) { wrapped.disconnect(connection, reason) }
     }
 }
 
-internal fun List<WebSocketInterceptor>.compileAndInstrument(): WebSocketInterceptor {
-    return when (size) {
-        0 -> WebSocketInterceptor.None
-        1 -> {
-            val one = this[0]
-            object : WebSocketInterceptor {
-                override val name: String
-                    get() = one.name
+/** One link of a compiled chain, wrapping [interceptor] so what it produces is instrumented under its name. */
+private fun instrumentedLink(interceptor: WebSocketInterceptor): WebSocketInterceptor = object : WebSocketInterceptor {
+    override val name: String get() = interceptor.name
 
-                override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> {
-                    return one.intercept(handler).instrumented(one.name)
-                }
-            }
-        }
+    override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> =
+        interceptor.intercept(handler).instrumented(interceptor.name)
+}
 
-        else -> {
-            reduceRightOrNull { laterInterceptors, interceptor ->
-                object : WebSocketInterceptor {
-                    override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> {
-                        return laterInterceptors.intercept(
-                            interceptor.intercept(handler).instrumented(interceptor.name)
-                        )
-                    }
-                }
-            } ?: WebSocketInterceptor.None
-        }
+/** Nests [inner] inside [outer], so [outer] wraps the handler [inner] already wrapped. */
+private fun composeLinks(outer: WebSocketInterceptor, inner: WebSocketInterceptor): WebSocketInterceptor =
+    object : WebSocketInterceptor {
+        override val name: String get() = "${outer.name} -> ${inner.name}"
+
+        override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> =
+            outer.intercept(inner.intercept(handler).instrumented(inner.name))
     }
+
+/**
+ * Compiles a list of interceptors into a single chained interceptor with instrumentation.
+ *
+ * The first interceptor in the list is outermost, so it sees a connection first and wraps everything
+ * the rest of the chain wrapped. [WebSocketInterceptor.None] entries are dropped rather than wrapped,
+ * since a chain link around a pass-through only costs a span.
+ *
+ * Accepts any list of interceptors so the same machinery serves both the connection-scoped and the
+ * logical-socket-scoped chain; which interceptors reach which chain is settled at installation by
+ * their type.
+ */
+internal fun List<WebSocketInterceptor>.compileAndInstrument(): WebSocketInterceptor {
+    val effective = filter { it !== WebSocketInterceptor.None }
+    if (effective.isEmpty()) return WebSocketInterceptor.None
+    return effective.drop(1).fold(instrumentedLink(effective.first()), ::composeLinks)
 }

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/http/RequestIdentityTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/http/RequestIdentityTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 class RequestIdentityTest {
 
@@ -16,7 +17,7 @@ class RequestIdentityTest {
     @Test
     fun `generates a fresh id when no trusted header is configured`() {
         val identity = headers().requestIdentity(trustedRequestIdHeader = null)
-        assertTrue(identity.requestId.isNotBlank())
+        assertNotEquals(Uuid.NIL, identity.requestId)
         assertNull(identity.upstreamRequestId)
     }
 
@@ -33,57 +34,63 @@ class RequestIdentityTest {
      */
     @Test
     fun `a client supplied id is never adopted when no trusted header is configured`() {
-        val identity = headers(HttpHeader.XRequestId to "attacker-chosen")
+        val claimed = Uuid.parse("00000000-0000-4000-8000-0000000000a1")
+        val identity = headers(HttpHeader.XRequestId to claimed.toString())
             .requestIdentity(trustedRequestIdHeader = null)
 
-        assertNotEquals("attacker-chosen", identity.requestId)
-        assertEquals("attacker-chosen", identity.upstreamRequestId)
+        assertNotEquals(claimed, identity.requestId)
+        assertEquals(claimed.toString(), identity.upstreamRequestId)
     }
 
     @Test
     fun `a client supplied id is not adopted when the trusted header is a different header`() {
-        val identity = headers(HttpHeader.XRequestId to "attacker-chosen")
+        val claimed = Uuid.parse("00000000-0000-4000-8000-0000000000a1")
+        val identity = headers(HttpHeader.XRequestId to claimed.toString())
             .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
 
-        assertNotEquals("attacker-chosen", identity.requestId)
-        assertEquals("attacker-chosen", identity.upstreamRequestId)
+        assertNotEquals(claimed, identity.requestId)
+        assertEquals(claimed.toString(), identity.upstreamRequestId)
     }
 
     @Test
     fun `adopts the id from the configured trusted header`() {
-        val identity = headers("X-Proxy-Request-Id" to "proxy-123")
+        val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000b2")
+        val identity = headers("X-Proxy-Request-Id" to proxyId.toString())
             .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
 
-        assertEquals("proxy-123", identity.requestId)
+        assertEquals(proxyId, identity.requestId)
     }
 
     @Test
     fun `records a separate untrusted claim alongside the trusted id`() {
+        val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000b2")
         val identity = headers(
-            "X-Proxy-Request-Id" to "proxy-123",
+            "X-Proxy-Request-Id" to proxyId.toString(),
             HttpHeader.XRequestId to "attacker-chosen",
         ).requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
 
-        assertEquals("proxy-123", identity.requestId)
+        assertEquals(proxyId, identity.requestId)
         assertEquals("attacker-chosen", identity.upstreamRequestId)
     }
 
     /** The Envoy arrangement: the proxy stamps X-Request-ID, so there is no separate untrusted claim. */
     @Test
     fun `no upstream id is recorded when the trusted header is X-Request-ID itself`() {
-        val identity = headers(HttpHeader.XRequestId to "envoy-abc")
+        val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000c3")
+        val identity = headers(HttpHeader.XRequestId to proxyId.toString())
             .requestIdentity(trustedRequestIdHeader = HttpHeader.XRequestId)
 
-        assertEquals("envoy-abc", identity.requestId)
+        assertEquals(proxyId, identity.requestId)
         assertNull(identity.upstreamRequestId)
     }
 
     @Test
     fun `header matching is case insensitive`() {
-        val identity = headers("x-request-id" to "envoy-abc")
+        val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000c3")
+        val identity = headers("x-request-id" to proxyId.toString())
             .requestIdentity(trustedRequestIdHeader = "X-Request-ID")
 
-        assertEquals("envoy-abc", identity.requestId)
+        assertEquals(proxyId, identity.requestId)
         assertNull(identity.upstreamRequestId)
     }
 
@@ -95,11 +102,24 @@ class RequestIdentityTest {
             .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id") { warned = true }
 
         assertTrue(warned)
-        assertNotEquals("attacker-chosen", identity.requestId)
         assertEquals("attacker-chosen", identity.upstreamRequestId)
     }
 
-    private fun request(id: String) = HttpRequest<PathSpec>(
+    /**
+     * A proxy that stamps something other than a UUID is a misconfiguration of the same kind as one
+     * that stamps nothing, and is handled the same way: correlation degrades, the request does not.
+     */
+    @Test
+    fun `generates an id and reports when the trusted header does not hold a UUID`() {
+        var warned = false
+        val identity = headers("X-Proxy-Request-Id" to "not-a-uuid")
+            .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id") { warned = true }
+
+        assertTrue(warned)
+        assertNotEquals(Uuid.NIL, identity.requestId)
+    }
+
+    private fun request(id: Uuid) = HttpRequest<PathSpec>(
         path = RawHttpEndpoint(asString = "/outer", method = HttpMethod.POST),
         queryParameters = QueryParameters.EMPTY,
         headers = HttpHeaders.EMPTY,
@@ -109,34 +129,36 @@ class RequestIdentityTest {
         requestId = id,
     )
 
+    private val outerId = Uuid.parse("00000000-0000-4000-8000-0000000000d4")
+
     @Test
     fun `subRequest gets its own id parented to the outer request`() {
-        val outer = request("outer-id")
+        val outer = request(outerId)
         val sub = outer.subRequest<PathSpec>(RawHttpEndpoint(asString = "/inner", method = HttpMethod.GET))
 
         assertNotEquals(outer.requestId, sub.requestId)
-        assertEquals("outer-id", sub.parentRequestId)
+        assertEquals(outerId, sub.parentRequestId)
     }
 
     @Test
     fun `sibling sub-requests get distinct ids and share a parent`() {
-        val outer = request("outer-id")
+        val outer = request(outerId)
         val a = outer.subRequest<PathSpec>(RawHttpEndpoint(asString = "/a", method = HttpMethod.GET))
         val b = outer.subRequest<PathSpec>(RawHttpEndpoint(asString = "/b", method = HttpMethod.GET))
 
         assertNotEquals(a.requestId, b.requestId)
-        assertEquals("outer-id", a.parentRequestId)
-        assertEquals("outer-id", b.parentRequestId)
+        assertEquals(outerId, a.parentRequestId)
+        assertEquals(outerId, b.parentRequestId)
     }
 
     @Test
     fun `copyWithNewPathType preserves identity`() {
-        val outer = request("outer-id")
+        val outer = request(outerId)
         val copied = outer.copyWithNewPathType<PathSpec>(
             RawHttpEndpoint(asString = "/elsewhere", method = HttpMethod.GET)
         )
 
-        assertEquals("outer-id", copied.requestId)
+        assertEquals(outerId, copied.requestId)
         assertNull(copied.parentRequestId)
     }
 }

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/websockets/MultiplexInterceptorTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/websockets/MultiplexInterceptorTest.kt
@@ -6,7 +6,6 @@ import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.test.test
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
 import java.util.Collections
 import kotlin.test.Test
@@ -38,30 +37,17 @@ class MultiplexInterceptorTest {
         override val name: String = "LogicalRecorder"
 
         override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> =
-            object : WebSocketHandler<PATH, T> {
-                override val storageSerializer: KSerializer<T> get() = handler.storageSerializer
-
+            object : DelegatingWebSocketHandler<PATH, T>(handler) {
                 context(serverRuntime: ServerRuntime)
                 override suspend fun willConnect(request: WebSocketConnectRequest<PATH>): T {
                     Observed.connects.add("/" + request.path.pathSegments.toString())
-                    return handler.willConnect(request)
+                    return wrapped.willConnect(request)
                 }
 
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun didConnect(): Unit = handler.didConnect()
-
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun messageFromClient(frame: WebSocketFrame): Unit =
-                    handler.messageFromClient(frame)
-
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun messageFromSubscription(topic: WebSocketSubscriptionMessage<*, *>): Unit =
-                    handler.messageFromSubscription(topic)
-
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun disconnect(reason: WebSocketClose) {
+                context(serverRuntime: ServerRuntime)
+                override suspend fun disconnect(connection: WebSocketConnection<PATH, T>, reason: WebSocketClose) {
                     Observed.disconnects.add("/" + connection.request.path.pathSegments.toString())
-                    handler.disconnect(reason)
+                    wrapped.disconnect(connection, reason)
                 }
             }
     }
@@ -71,28 +57,12 @@ class MultiplexInterceptorTest {
         override val name: String = "ConnectionRecorder"
 
         override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> =
-            object : WebSocketHandler<PATH, T> {
-                override val storageSerializer: KSerializer<T> get() = handler.storageSerializer
-
+            object : DelegatingWebSocketHandler<PATH, T>(handler) {
                 context(serverRuntime: ServerRuntime)
                 override suspend fun willConnect(request: WebSocketConnectRequest<PATH>): T {
                     Observed.physicalConnects.add("/" + request.path.pathSegments.toString())
-                    return handler.willConnect(request)
+                    return wrapped.willConnect(request)
                 }
-
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun didConnect(): Unit = handler.didConnect()
-
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun messageFromClient(frame: WebSocketFrame): Unit =
-                    handler.messageFromClient(frame)
-
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun messageFromSubscription(topic: WebSocketSubscriptionMessage<*, *>): Unit =
-                    handler.messageFromSubscription(topic)
-
-                context(connection: WebSocketConnection<PATH, T>)
-                override suspend fun disconnect(reason: WebSocketClose): Unit = handler.disconnect(reason)
             }
     }
 
@@ -119,7 +89,7 @@ class MultiplexInterceptorTest {
         TestServer.test(settings = {}) {
             runBlocking {
                 val mux = TestServer.multiplex.test()
-                val json = mux.server.externalSerialization.json
+                val json = contextOf<ServerRuntime>().externalSerialization.json
 
                 mux.send(
                     WebSocketFrame.Text(
@@ -144,7 +114,7 @@ class MultiplexInterceptorTest {
         TestServer.test(settings = {}) {
             runBlocking {
                 val mux = TestServer.multiplex.test()
-                val json = mux.server.externalSerialization.json
+                val json = contextOf<ServerRuntime>().externalSerialization.json
 
                 mux.send(
                     WebSocketFrame.Text(
@@ -183,7 +153,7 @@ class MultiplexInterceptorTest {
         TestServer.test(settings = {}) {
             runBlocking {
                 val mux = TestServer.multiplex.test()
-                val json = mux.server.externalSerialization.json
+                val json = contextOf<ServerRuntime>().externalSerialization.json
 
                 mux.send(
                     WebSocketFrame.Text(

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/websockets/MultiplexWebSocketHandlerTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/websockets/MultiplexWebSocketHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.websockets
 
+import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.MultiplexMessage
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.runtime.send
@@ -55,7 +56,7 @@ class MultiplexWebSocketHandlerTest {
     fun multiplex_basic_flow() = runBlocking {
         TestServer.test(settings = {}) {
             val mux = TestServer.multiplex.test()
-            val json = mux.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
             var last: WebSocketFrame? = null
             mux.onMessageSent = { last = it }
             // Start channel a -> /mirror
@@ -118,7 +119,7 @@ class MultiplexWebSocketHandlerTest {
     fun unsubscribe_actually_stops_delivery() = runBlocking {
         TestServer.test(settings = {}) {
             val mux = TestServer.multiplex.test()
-            val json = mux.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
             var last: WebSocketFrame? = null
             mux.onMessageSent = { last = it }
 

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterHttp.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterHttp.kt
@@ -35,10 +35,11 @@ internal class AwsAdapterHttp(val root: AwsAdapter) {
             domain = event.requestContext.domainName,
             protocol = "https",
             sourceIp = event.requestContext.identity.sourceIp,
-            // API Gateway mints this itself, so it is authoritative without any trusted-header
-            // configuration, and it matches the ID in the gateway's own access logs.
-            requestId = event.requestContext.requestId,
+            requestId = generateRequestId(),
             upstreamRequestId = headers[HttpHeader.XRequestId]?.root,
+            // API Gateway's ID is not a UUID, so it is kept as the join key to the gateway's own
+            // access logs rather than adopted as ours.
+            engineRequestId = event.requestContext.requestId,
         )
         val result = root.handle(request)
         return result.toAws()

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
@@ -78,7 +78,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
         val handler: WebSocketHandler<P, T>,
         val socketId: String,
         val stateAnonType: AnonType,
-    ) : WebSocketConnection<P, T>, ServerRuntime by root {
+    ) : WebSocketConnection<P, T> {
         override var currentState: T = stateAnonType.value(encoding, handler.storageSerializer)
 
         /**
@@ -153,11 +153,11 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
         }
 
         override suspend fun subscribe(topic: WebSocketSubscriptionRequest<*, *>) {
-            webSocketDynamo.subscribe(path.toString(), topic.path(), socketId)
+            webSocketDynamo.subscribe(path.toString(), with(root) { topic.path() }, socketId)
         }
 
         override suspend fun unsubscribe(topic: WebSocketSubscriptionRequest<*, *>) {
-            webSocketDynamo.unsubscribe(topic.path(), socketId)
+            webSocketDynamo.unsubscribe(with(root) { topic.path() }, socketId)
         }
 
         override suspend fun send(frame: WebSocketFrame) {
@@ -263,6 +263,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                         ) { mid ->
                             h.messageFromSubscriptionWithMetrics(
                                 p.pathSpec,
+                                root,
                                 mid,
                                 WebSocketSubscriptionMessage(
                                     fullTopicMatch.value,
@@ -348,6 +349,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
             ) { mid ->
                 rootWs.didConnectWithMetrics(
                     rootPath,
+                    root,
                     mid
                 )
                 return APIGatewayV2HTTPResponse(200)
@@ -394,9 +396,11 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                     domain = event.requestContext.domainName,
                     protocol = "https",
                     sourceIp = event.requestContext.identity.sourceIp ?: "0.0.0.0",
-                    // The gateway's connection ID is stable for the socket's whole lifetime, which is
-                    // exactly the correlation scope wanted for a connection.
-                    requestId = event.requestContext.connectionId,
+                    // Generated once here, at $connect, and persisted with the connection state, so it
+                    // is stable for the socket's whole lifetime — the correlation scope wanted for a
+                    // connection. The gateway's connection ID is not a UUID and stays in
+                    // [engineSocketId], which is where the join to the gateway's logs comes from.
+                    requestId = generateRequestId(),
                     upstreamRequestId = headers[HttpHeader.XRequestId]?.root,
                     engineSocketId = event.requestContext.connectionId
                 )
@@ -452,6 +456,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                     ) { mid ->
                         rootWs.disconnectWithMetrics(
                             rootPath,
+                            root,
                             mid,
                             WebSocketClose.NORMAL
                         )
@@ -495,6 +500,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                         }
                         rootWs.messageFromClientWithMetrics(
                             rootPath,
+                            root,
                             mid,
                             WebSocketFrame(event.body)
                         )

--- a/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/KtorEngine.kt
+++ b/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/KtorEngine.kt
@@ -328,7 +328,7 @@ public class KtorEngine(
                         }
                         closingMid = mid
 
-                        socketHandler.didConnectWithMetrics(match.pathSpec, mid)
+                        socketHandler.didConnectWithMetrics(match.pathSpec, this@KtorEngine, mid)
 
                         for (incoming in this.incoming) {
                             val m = when (incoming) {
@@ -338,16 +338,22 @@ public class KtorEngine(
                                 is Frame.Ping -> continue
                                 is Frame.Pong -> continue
                             }
-                            socketHandler.messageFromClientWithMetrics(match.pathSpec, mid, m)
+                            socketHandler.messageFromClientWithMetrics(match.pathSpec, this@KtorEngine, mid, m)
                         }
 
                         closingMid.let { mid ->
-                            socketHandler.disconnectWithMetrics(match.pathSpec, mid, WebSocketClose.NORMAL)
+                            socketHandler.disconnectWithMetrics(
+                                match.pathSpec,
+                                this@KtorEngine,
+                                mid,
+                                WebSocketClose.NORMAL
+                            )
                         }
                     } catch (e: Throwable) {
                         closingMid?.let { mid ->
                             socketHandler.disconnectWithMetrics(
                                 match.pathSpec,
+                                this@KtorEngine,
                                 mid,
                                 ((e as? HttpStatusException)?.status
                                     ?: HttpStatus.InternalServerError).bestWebSocketCloseCode

--- a/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
+++ b/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
@@ -23,9 +23,10 @@ public abstract class LocalWebSocketConnection<PATH : PathSpec, STORAGE>(
     override val request: WebSocketConnectRequest<PATH>,
     private val handler: WebSocketHandler<PATH, STORAGE>,
     private val scope: CoroutineScope,
-    server: ServerRuntime,
+    /** Needed to deliver a subscription message, which is a fresh execution rather than part of one. */
+    private val server: ServerRuntime,
     private val pubSub: (request: WebSocketSubscriptionRequest<*, Any?>) -> PubSubChannel<Any?>,
-) : WebSocketConnection<PATH, STORAGE>, ServerRuntime by server {
+) : WebSocketConnection<PATH, STORAGE> {
 
     override var currentState: STORAGE = startingState
     override suspend fun repullState(): STORAGE = currentState
@@ -49,9 +50,12 @@ public abstract class LocalWebSocketConnection<PATH : PathSpec, STORAGE>(
         subscriptions.remove(topic)?.cancel()
         subscriptions[topic] = scope.launch {
             pubSub(topic).collect { value ->
-                handler.messageFromSubscription(
-                    WebSocketSubscriptionMessage(topic.topic, topic.pathInContext.rawPathArguments, value),
-                )
+                with(server) {
+                    handler.messageFromSubscription(
+                        this@LocalWebSocketConnection,
+                        WebSocketSubscriptionMessage(topic.topic, topic.pathInContext.rawPathArguments, value),
+                    )
+                }
             }
             yield()
         }

--- a/engine-netty/src/main/kotlin/com/lightningkite/lightningserver/engine/netty/NettyEngine.kt
+++ b/engine-netty/src/main/kotlin/com/lightningkite/lightningserver/engine/netty/NettyEngine.kt
@@ -333,7 +333,7 @@ public class NettyEngine(
                         val pathspec = ctx.channel().attr(PATHSPEC_KEY).get() ?: return
                         scope.launch(ctx.executor().asCoroutineDispatcher()) {
                             try {
-                                handler.messageFromClientWithMetrics(pathspec, mid, m)
+                                handler.messageFromClientWithMetrics(pathspec, this@NettyEngine, mid, m)
                             } catch (e: Exception) {
                                 mid.close(
                                     ((e as? HttpStatusException)?.status
@@ -357,7 +357,7 @@ public class NettyEngine(
                         val pathspec = ctx.channel().attr(PATHSPEC_KEY).get() ?: return
                         scope.launch(ctx.executor().asCoroutineDispatcher()) {
                             try {
-                                handler.messageFromClientWithMetrics(pathspec, mid, m)
+                                handler.messageFromClientWithMetrics(pathspec, this@NettyEngine, mid, m)
                             } catch (e: Exception) {
                                 mid.close(
                                     ((e as? HttpStatusException)?.status
@@ -381,7 +381,7 @@ public class NettyEngine(
                         if (mid != null && handler != null && pathspec != null) {
                             scope.launch(ctx.executor().asCoroutineDispatcher()) {
                                 try {
-                                    handler.disconnectWithMetrics(pathspec, mid, WebSocketClose.NORMAL)
+                                    handler.disconnectWithMetrics(pathspec, this@NettyEngine, mid, WebSocketClose.NORMAL)
                                 } catch (e: Exception) {
                                     mid.close(
                                         ((e as? HttpStatusException)?.status
@@ -569,7 +569,7 @@ public class NettyEngine(
                 handshaker.handshake(ctx.channel(), req).addListener {
                     scope.launch {
                         try {
-                            socketHandler.didConnectWithMetrics(match.pathSpec, mid)
+                            socketHandler.didConnectWithMetrics(match.pathSpec, this@NettyEngine, mid)
                         } catch (_: Throwable) {
                         }
                     }
@@ -597,11 +597,9 @@ public class NettyEngine(
                 val handler = ctx.channel().attr(HANDLER_KEY).get()
                 if (mid != null && handler != null) {
                     try {
-                        context(mid) {
-                            scope.launch {
-                                logger.error { "Disconnected because channel is inactive " }
-                                handler.disconnect(WebSocketClose.GOING_AWAY)
-                            }
+                        scope.launch {
+                            logger.error { "Disconnected because channel is inactive " }
+                            with(this@NettyEngine) { handler.disconnect(mid, WebSocketClose.GOING_AWAY) }
                         }
                     } catch (_: Throwable) {
                     }

--- a/plans/execution-context-refactor.md
+++ b/plans/execution-context-refactor.md
@@ -1,0 +1,369 @@
+# Plan: Execution Context Refactor (`Engine` / `ServerRuntime` / `Initiator`)
+
+Status: **complete.** All stages landed; see the commits named below.
+Target: Lightning Server 5.x
+Prerequisite for: the remaining layers of [`audit-logging.md`](audit-logging.md)
+
+---
+
+## 1. Goal
+
+Make it possible to answer **"who or what initiated this execution?"** anywhere in the server, so the
+audit system has something to attribute records to.
+
+Today `ServerRuntime` is a *process-wide* object: one per server, carrying settings, serialization,
+telemetry, and task dispatch. Nothing in it knows which request, task, or socket is currently
+running. Every log that wants that information reconstructs it from whatever happens to be in scope,
+which is why `requestId` is threaded manually through `Request` and why the WebSocket lifecycle has
+to smuggle a runtime through `WebSocketConnection`.
+
+The fix splits the two concerns that are currently fused:
+
+| Concept | Scope | Contains |
+|---|---|---|
+| `Engine` | one per server process | everything `ServerRuntime` has today |
+| `ServerRuntime` | one per **execution** | an `Engine` (by delegation) + an `Initiator` |
+
+"Execution" means one run of anything the server can run: an HTTP request, one WebSocket lifecycle
+phase, a task, a schedule tick, a startup task, or a pre-deploy task.
+
+Because the new `ServerRuntime` is a subtype of `Engine` and keeps its name, **the ~622 existing
+`context(server: ServerRuntime)` declarations do not change**. The work is concentrated in the ~8
+places that *implement* it.
+
+---
+
+## 2. Design decisions (settled — do not re-litigate)
+
+### 2.1 Location: reuse the `Raw*` path types, do not invent one
+
+An initiator must name *what* is running. The obvious `location: PathSpec0` is wrong twice: it cannot
+hold an HTTP endpoint at `PathSpec1` or greater, and it cannot distinguish `GET /x` from `POST /x`.
+
+`RawHttpEndpoint<PATH>` and `RawWebSocketPath<PATH>` already solve this. Both are `@Serializable`,
+both carry concrete `PathSegments`, `RawHttpEndpoint` carries the `HttpMethod`, and both resolve the
+*pattern* on demand via `.match.path.pathSpec` given an engine. They are already what `Request.path`
+holds, so the initiator stores no new information — it stores the same information at a better scope.
+
+Tasks, schedules, startup and pre-deploy tasks are registered under all-constant `PathSpec0` keys, so
+`PathSegments` is their complete location and is already `@Serializable`.
+
+**Cardinality note.** The initiator holds the *concrete* path (`/users/abc123`). `RequestRecord.endpoint`
+deliberately stores the *pattern* (`/users/{id}`) to keep that column's cardinality bounded — see
+`audit-logging.md`. That stays true; the pattern is now derived from the initiator rather than the
+request. Do not "fix" `RequestRecord` to store concrete segments.
+
+### 2.2 The initiator is serializable
+
+Required, and not merely for log convenience: it is how `causedBy` crosses a queue. When a task is
+launched from a request, the launching `executionId` is serialized into the queued payload, so the
+task knows its parent with no database read. This is the only mechanism that works on serverless.
+
+Consequence to accept deliberately: the initiator **will** be persisted — into task queues and into
+the DynamoDB WebSocket state row. Everything in it is bounded by URL length. Keep it that way.
+
+### 2.3 The initiator carries no request data
+
+No headers, no source IP, no principal, no body. Those stay on `Request`, which is already threaded
+everywhere it is needed. The initiator answers "what is running and why", not "what did the caller
+send".
+
+### 2.4 WebSocket phases are separate executions
+
+On AWS each of the five WebSocket lifecycle methods is a **separate Lambda invocation**. Treating a
+socket as one execution is therefore factually wrong. Each phase gets its own `executionId`; the
+socket's identity is a separate `socketId` that is constant across all phases of that socket.
+
+### 2.5 Parentage: `causedBy` plus `rootExecutionId`
+
+Three real sources of parentage, no more:
+
+| Source | Crosses a process? |
+|---|---|
+| `/meta/bulk` sub-requests | no — in the call stack |
+| multiplexed WebSocket sub-sockets | no |
+| a task launched from a request | **yes** — via the serialized initiator |
+
+`causedBy` must live on `Initiator` rather than only in `RequestRecord`, otherwise launching a task
+from a request could not stamp parentage without a database read.
+
+`rootExecutionId` is carried as well (**approved**; it originated as a recommendation rather than a
+requirement). With parent pointers alone, "show me everything that happened
+because of request X" is a recursive join — and that query is the entire point of the audit system.
+With a root it is one indexed lookup, for 16 bytes on a row that already holds two UUIDs. This is
+consistent with `audit-logging.md`'s rule that parentage lives in the request log and is not repeated
+per disclosure; it just lets the request log answer in one hop.
+
+Both are **framework-set**. User code never constructs an `Initiator`.
+
+### 2.6 Ids are `Uuid`, are version 7, minted at the selected clock — and AWS ids are never adopted
+
+`generateRequestId()` originally called `SecureRandom.getInstanceStrong()` **per request** — a provider
+lookup every time, and on Linux the default strong algorithm is `NativePRNGBlocking`, i.e. a blocking
+`/dev/random` read on the request path. The ids are now **version-7 UUIDs** minted as
+`Uuid.generateV7NonMonotonicAt(engine.clock.now())` — `Uuid.random()` (v4) in two steps replaced by one
+call that reads the **selected clock for the execution** (the same `Engine.clock` as
+[`now()`](execution-context-refactor.md)), so a test's injected clock controls the id's embedded
+timestamp. Using v7 does two things: it makes the ids roughly time-ordered (so the append-mostly
+audit log inserts and its "last N" scans stay hot), and it *embeds the mint time in the id itself*,
+which is what lets `RequestRecord` drop its separate `at` column and derive the instant from the id.
+Every execution-id minting site — engines, initiator sub-request/phase/sub-connection, task runs,
+and `TestRunner.Direct` — goes through this generator so the derivation and the ordering are uniform.
+
+API Gateway ids are **not** UUIDs and not 128 bits (HTTP API request ids and WebSocket connection ids
+are both the compact ~11-byte base64 form). We do not attempt to map them. We always mint our own.
+
+The join to the gateway's access log is preserved by a new **`engineRequestId: String?`** column on
+`RequestRecord`: trusted, engine-supplied, holding the gateway/proxy's own id. It is deliberately
+**distinct from `upstreamRequestId`**, which is documented as an untrusted client claim and must not
+be conflated with a trusted gateway id. The join is: gateway log `requestId` → `engineRequestId` →
+our `Uuid`.
+
+Nothing is lost for WebSockets: `connectionId` already lives in `engineSocketId`.
+
+### 2.7 One seam for minting, interception, and instrumentation
+
+`core/.../runtime/implementationHelpers.kt` is already the single place every engine funnels through:
+`handle()`, the five `*WithMetrics` WebSocket helpers, and four near-identical `executeWithMetrics`
+overloads for Task / ScheduledTask / StartupTask / PreDeployTask.
+
+That is the same seam that must mint the `ServerRuntime`, the same seam `ExecutionInterceptor` hooks,
+and the same seam telemetry already uses. Minting, intercepting and instrumenting all happen there,
+once. The four `executeWithMetrics` copies collapse into one generic helper.
+
+### 2.8 `Engine` vs `ServerRuntime` at declaration sites
+
+Anything that genuinely has no initiator — server boot, settings resolution, `sharedResources`,
+serialization setup — takes `Engine`. Everything that runs *on behalf of something* takes
+`ServerRuntime`. This makes "who initiated this?" answerable by the type system rather than by
+convention.
+
+---
+
+## 3. Target shapes
+
+### 3.1 `Initiator`
+
+```kotlin
+package com.lightningkite.lightningserver.runtime
+
+@Serializable
+public sealed interface Initiator {
+    /** Identifies this one execution. */
+    public val executionId: Uuid
+    /** The execution that caused this one, or null if it started here. Framework-set. */
+    public val causedBy: Uuid?
+    /** The execution at the head of this causal chain; equals [executionId] when [causedBy] is null. */
+    public val rootExecutionId: Uuid
+
+    @Serializable @SerialName("http")
+    public data class Http(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        val endpoint: RawHttpEndpoint<PathSpec>,
+    ) : Initiator
+
+    @Serializable @SerialName("ws")
+    public data class WebSocket(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        /** Constant for the socket's whole lifetime, across all phases. */
+        val socketId: Uuid,
+        val path: RawWebSocketPath<PathSpec>,
+        val phase: Phase,
+    ) : Initiator {
+        public enum class Phase { Connect, Connected, ClientMessage, SubscriptionMessage, Disconnect }
+    }
+
+    @Serializable @SerialName("task")
+    public data class Task(..., val location: PathSegments) : Initiator
+
+    @Serializable @SerialName("schedule")
+    public data class Schedule(..., val location: PathSegments) : Initiator
+
+    @Serializable @SerialName("startup")
+    public data class Startup(..., val location: PathSegments) : Initiator
+
+    @Serializable @SerialName("predeploy")
+    public data class PreDeploy(..., val location: PathSegments) : Initiator
+
+    /**
+     * Executions with no server-side origin: `TestRunner`, manual invocation. A deliberate hole in
+     * "every execution names what started it" — without it nothing outside the server could build a
+     * `ServerRuntime` at all.
+     */
+    @Serializable @SerialName("direct")
+    public data class Direct(...) : Initiator
+}
+```
+
+`RawHttpEndpoint` and `RawWebSocketPath` are generic `@Serializable` classes, so a type argument must
+be named. `PathSpec` itself has a serializer (`DummyPathSpecSerializer`), so `RawHttpEndpoint<PathSpec>`
+resolves. This is mechanical, not a design question.
+
+### 3.2 `Engine` and `ServerRuntime`
+
+```kotlin
+/** One per server process. Exactly today's `ServerRuntime`, renamed. */
+public interface Engine : SettingContext, Namespaced { /* unchanged members */ }
+
+/** Today's `ServerRuntimeBase`, renamed. */
+public abstract class EngineBase(override val server: ServerDefinition) : Engine { /* unchanged */ }
+
+/** One per execution. */
+public interface ServerRuntime : Engine {
+    public val initiator: Initiator
+}
+```
+
+Plus an implementation that is `Engine by engine`, and overrides `Task.invoke` to stamp the current
+`executionId` as the launched task's `causedBy` (and propagate `rootExecutionId`).
+
+### 3.3 `WebSocketHandler`
+
+```kotlin
+public interface WebSocketHandler<PATH : PathSpec, STORAGE> {
+    public val storageSerializer: KSerializer<STORAGE>
+    public context(serverRuntime: ServerRuntime)
+    suspend fun willConnect(request: WebSocketConnectRequest<PATH>): STORAGE
+    public context(serverRuntime: ServerRuntime)
+    suspend fun didConnect(connection: WebSocketConnection<PATH, STORAGE>)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun messageFromClient(connection: WebSocketConnection<PATH, STORAGE>, frame: WebSocketFrame)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun messageFromSubscription(connection: WebSocketConnection<PATH, STORAGE>, topic: WebSocketSubscriptionMessage<*, *>)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun disconnect(connection: WebSocketConnection<PATH, STORAGE>, reason: WebSocketClose)
+}
+```
+
+`WebSocketConnection` **drops `: ServerRuntime`** and keeps only its own members. This is a knowingly
+breaking change for downstream consumers writing custom sockets; accepted, as very few exist and the
+project is still internal.
+
+### 3.4 `ExecutionInterceptor`
+
+```kotlin
+public interface ExecutionInterceptor {
+    public val name: String get() = this::class.simpleName ?: "anonymous"
+    public suspend fun <T> intercept(
+        runtime: ServerRuntime,
+        cont: suspend context(ServerRuntime) () -> T,
+    ): T
+}
+```
+
+Installed on `ServerBuilder`, applied at the seam in 2.7, so it covers HTTP endpoints, WebSocket
+phases, tasks, schedules, startup **and** pre-deploy uniformly.
+
+---
+
+## 4. Commits
+
+Each stage is one commit, must compile, and must leave `./gradlew check` no worse than the baseline.
+
+### Stage 1 — Request ids become `Uuid` (version 7, at the selected clock)
+
+- `generateRequestId()` → `Uuid.generateV7NonMonotonicAt(engine.clock.now())` as a
+  `context(engine: Engine)` function; drop the `SecureRandom` path entirely. Route every
+  execution-id minting site (engines, `subRequest`/`phase`/`subConnection`, task runs,
+  `TestRunner.Direct`) through it.
+- `Request.requestId` / `parentRequestId` → `Uuid` / `Uuid?`.
+- `RequestRecord._id` / `parentRequestId` → `Uuid` / `Uuid?`; `DisclosureRecord.requestId` → `Uuid`.
+- `RequestRecord` drops its `at` column; `RequestRecord.at` becomes a derived property reading the
+  v7 timestamp from `_id`. See `audit-logging.md` §5.8.
+- Add `RequestRecord.engineRequestId: String?` (see 2.6), separate from `upstreamRequestId`.
+- AWS: mint our own `Uuid` (v7); put `requestContext.requestId` in `engineRequestId`. Do **not** adopt.
+  WebSocket keeps `connectionId` in `engineSocketId` as it already does.
+- Trusted-proxy header path: parse to `Uuid`, generate on failure.
+- Known break, already documented and accepted in `audit-logging.md` §3.1: DynamoDB rows holding a
+  serialized `WebSocketConnectRequest` fail to deserialize, dropping in-flight sockets on deploy.
+
+### Stage 2 — Reshape `WebSocketHandler`
+
+- Apply 3.3. Six implementation sites: `LocalWebSocketConnection`, `AwsAdapterWs`, plus the wrapper
+  handlers (`MultiplexWebSocketHandler`, `QueryParamWebSocketHandler`, `CoroutineWebSocketHandler`,
+  `ApiWebSocketHandler`) and the interceptors.
+- Removes the `with(connection as ServerRuntime)` casts in `AccessLogInterceptor` and
+  `RequestRecordInterceptor`.
+- **Add `abstract class DelegatingWebSocketHandler(wrapped)`** in core. `AccessLogInterceptor` and
+  `RequestRecordInterceptor` each hand-write all five methods to pass four of them straight through.
+- **Fix `WebSocketInterceptor.compileAndInstrument()`**: its 3-branch `when` drops the `name` override
+  in the `else` branch and never filters `None`. The HTTP side is a clean `fold`. Unify them.
+
+### Stage 2b — the typed socket loses the fusion too
+
+Stage 2 left `ApiWebSocketHandler.Connection` extending `ServerRuntime`, on the grounds that breaking
+it reaches every *typed* socket in user code rather than only hand-written ones. Confirmed as
+acceptable: very few custom sockets exist downstream, typed ones included, and most systems use
+`ModelRestUpdatesSocket`, which is updated here in the same commit.
+
+So `ApiWebSocketHandler.Connection` drops `: ServerRuntime`, `ConnectionWrapper` stops delegating,
+and the typed lifecycle methods take the runtime as a context alongside the connection — the same
+shape Stage 2 gave the raw handler, for the same reason. `ModelRestUpdatesWebsocket` and every other
+typed socket in the repo follow.
+
+### Stage 3 — `Initiator`
+
+- Add the type per 3.1.
+- Move `requestId` / `parentRequestId` **off** `Request` onto `Initiator`. `Request` keeps
+  `upstreamRequestId` only (a wire-level fact about the caller).
+- AWS persists the initiator alongside the connect request in the DynamoDB socket row so `socketId`
+  survives the round trip.
+
+### Stage 4 — `ServerRuntime` → `Engine`, new `ServerRuntime`
+
+- Rename `ServerRuntime` → `Engine`, `ServerRuntimeBase` → `EngineBase`. **Do not touch use sites.**
+- Add the new `ServerRuntime` per 3.2 and mint it at the seam in 2.7.
+- Move genuinely engine-scoped declarations to take `Engine` (2.8).
+- `Task.invoke` stamps `causedBy` / `rootExecutionId`.
+
+### Stage 5 — `ExecutionInterceptor`
+
+- Add per 3.4, install on `ServerBuilder`, apply at the seam.
+- Collapse the four `executeWithMetrics` overloads into one.
+- ~~Existing telemetry becomes a built-in interceptor.~~ **Not done, and it should not be.**
+  An interceptor sees only `(runtime, cont)`, but the spans need attributes the initiator
+  deliberately does not carry (§2.3), post-hoc enrichment a bare generic `T` cannot reach, and
+  per-kind span names. Converting would reshape spans that production dashboards observe. This
+  bullet was an aspiration that does not survive contact with what the spans actually carry.
+
+---
+
+## 5. Out of scope
+
+Everything downstream in `audit-logging.md` — the disclosure log, data access log and auth event log
+build on this, but none of them change here.
+
+
+---
+
+## 6. As-built notes
+
+Two things differ from the plan above, both deliberate:
+
+- **Stage 3 carried the initiator on the runtime and started minting at the seam**, which section 4
+  assigned to Stage 4. It was forced, not chosen: `DisclosureLogInterceptor` is reached through
+  `emitTypedOutput` from *inside handler bodies*, so a parameter would have to be added to
+  `HttpHandler.handle` and thus to every endpoint handler in the framework and in user code. The
+  runtime context is the only carrier already threaded to all three audit sites. Stage 4 therefore
+  changed *what* is minted, not *where*.
+- **Telemetry stays as `instrument` / `instrumentHttpRequest`**, per the struck bullet above.
+
+### Known gaps left behind
+
+- `RequestRecord` for a socket is keyed by `socketId`, so a disclosure during a message phase answers
+  "sometime during this session" rather than "in response to this message". Non-regressing, since a
+  socket's correlation id was already lifetime-constant. Finer attribution means a row per phase —
+  see `audit-logging.md` §5.8.2.
+- `Runtime<T>` resolves against an `Engine`, so anything inside a `Runtime { }` lambda can never read
+  an initiator. That includes the file validators in `files/validation.kt`, whose lambdas run during
+  request handling.
+- An `ExecutionInterceptor` cannot substitute the `ServerRuntime` seen by the handler; the seam holds
+  the runtime it minted.
+- `TestRunner` drives WebSocket phases directly rather than through the `*WithMetrics` helpers, so
+  neither execution interceptors nor telemetry fire for sockets under test.
+- Eight typed test helpers in `typed/testing.kt` still run on `Initiator.Direct`, so disclosures from
+  them reference no `RequestRecord`. Pre-existing, and true before this work too.

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/AccessLogInterceptorTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/AccessLogInterceptorTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlin.uuid.Uuid
 
 /**
  * The access log previously emitted before the handler ran, so a line carried no status, no duration,
@@ -69,6 +70,8 @@ class AccessLogInterceptorTest {
 
     private fun accessLines(lines: List<String>) = lines.filter { it.contains("accessed by") || it.startsWith("ws ") }
 
+    private val requestIdUnderTest = Uuid.parse("11111111-2222-3333-4444-555555555555")
+
     private fun get(path: String) = HttpRequest<PathSpec>(
         path = RawHttpEndpoint(asString = path, method = HttpMethod.GET),
         queryParameters = QueryParameters.EMPTY,
@@ -76,7 +79,7 @@ class AccessLogInterceptorTest {
         domain = "example.com",
         protocol = "https",
         sourceIp = "10.0.0.1",
-        requestId = "req-under-test",
+        requestId = requestIdUnderTest,
     )
 
     @Test
@@ -88,7 +91,7 @@ class AccessLogInterceptorTest {
         val line = accessLines(lines).singleOrNull() ?: fail("expected one access line; got $lines")
         assertTrue(line.contains("-> 200"), "line should carry the status; was: $line")
         assertTrue(Regex("in \\d+ms").containsMatchIn(line), "line should carry the duration; was: $line")
-        assertTrue(line.contains("req-under-test"), "line should carry the request id; was: $line")
+        assertTrue(line.contains(requestIdUnderTest.toString()), "line should carry the request id; was: $line")
         assertTrue(line.contains("10.0.0.1"), "line should carry the source ip; was: $line")
     }
 

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/ApiWebsocketHandler.ext.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/ApiWebsocketHandler.ext.kt
@@ -13,24 +13,6 @@ import com.lightningkite.services.database.HasId
 import com.lightningkite.services.database.serializerOrContextual
 import kotlinx.serialization.KSerializer
 
-@Suppress("RedundantSuspendModifier", "UnusedReceiverParameter")
-@InternalLightningServerApi
-public suspend fun <PATH : PathSpec, STORAGE, USER : HasId<*>?, INPUT, OUTPUT> Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.didConnectNoOp(): Unit =
-    Unit
-
-@Suppress("RedundantSuspendModifier", "UnusedReceiverParameter")
-@InternalLightningServerApi
-public suspend fun <PATH : PathSpec, STORAGE, USER : HasId<*>?, INPUT, OUTPUT> Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.messageFromClientNoOp(
-    frame: INPUT,
-): Unit = Unit
-
-@Suppress("RedundantSuspendModifier", "UnusedReceiverParameter")
-@InternalLightningServerApi
-public suspend fun <PATH : PathSpec, STORAGE, USER : HasId<*>?, INPUT, OUTPUT> Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.disconnectNoOp(
-    reason: WebSocketClose,
-): Unit = Unit
-
-
 @Deprecated("Use corrected spelling, ApiWebSocketHandler", ReplaceWith("ApiWebSocketHandler"))
 public inline fun <PATH : PathSpec, reified STORAGE, USER : HasId<*>?, reified INPUT, reified OUTPUT> ApiWebsocketHandler(
     summary: String,
@@ -40,10 +22,10 @@ public inline fun <PATH : PathSpec, reified STORAGE, USER : HasId<*>?, reified I
     errorCases: List<LSError> = emptyList(),
 //    examples: List<ApiHttpHandler.Example<INPUT, OUTPUT>> = emptyList(),
     crossinline willConnectType: suspend ServerRuntime.(access: WebSocketConnectRequestAccess<PATH, USER>) -> STORAGE,
-    crossinline didConnectType: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.() -> Unit = Connection<PATH, STORAGE, USER, INPUT, OUTPUT>::didConnectNoOp,
-    crossinline messageFromClientType: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(frame: INPUT) -> Unit = Connection<PATH, STORAGE, USER, INPUT, OUTPUT>::messageFromClientNoOp,
+    crossinline didConnectType: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.() -> Unit = {},
+    crossinline messageFromClientType: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(frame: INPUT) -> Unit = {},
     crossinline topicHandlersType: ApiTopicHandlersBuilder<PATH, STORAGE, USER, INPUT, OUTPUT>.() -> Unit = {},
-    crossinline disconnectType: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(reason: WebSocketClose) -> Unit = Connection<PATH, STORAGE, USER, INPUT, OUTPUT>::disconnectNoOp,
+    crossinline disconnectType: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(reason: WebSocketClose) -> Unit = {},
 ): ApiWebSocketHandler<PATH, STORAGE, USER, INPUT, OUTPUT> = ApiWebSocketHandler(
     summary = summary,
     description = description,
@@ -57,6 +39,15 @@ public inline fun <PATH : PathSpec, reified STORAGE, USER : HasId<*>?, reified I
     disconnectType = disconnectType,
 )
 
+/**
+ * Builds a typed handler from one lambda per lifecycle phase.
+ *
+ * As with the raw `WebSocketHandler` builder, the connection is the lambdas' receiver and the
+ * [ServerRuntime] their context, which is the opposite of how [ApiWebSocketHandler] declares them. A
+ * socket body spends most of its lines on the socket — `send`, `currentState`, `subscribe` — so that
+ * is what `this` should be, while the runtime is what the settings and service accessors want and
+ * they take it as a context anyway.
+ */
 public inline fun <PATH : PathSpec, reified STORAGE, USER : HasId<*>?, reified INPUT, reified OUTPUT> ApiWebSocketHandler(
     summary: String,
     description: String = "",
@@ -65,10 +56,10 @@ public inline fun <PATH : PathSpec, reified STORAGE, USER : HasId<*>?, reified I
     errorCases: List<LSError> = emptyList(),
 //    examples: List<ApiHttpHandler.Example<INPUT, OUTPUT>> = emptyList(),
     crossinline willConnectType: suspend ServerRuntime.(access: WebSocketConnectRequestAccess<PATH, USER>) -> STORAGE,
-    crossinline didConnectType: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.() -> Unit = Connection<PATH, STORAGE, USER, INPUT, OUTPUT>::didConnectNoOp,
-    crossinline messageFromClientType: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(frame: INPUT) -> Unit = Connection<PATH, STORAGE, USER, INPUT, OUTPUT>::messageFromClientNoOp,
+    crossinline didConnectType: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.() -> Unit = {},
+    crossinline messageFromClientType: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(frame: INPUT) -> Unit = {},
     crossinline topicHandlersType: ApiTopicHandlersBuilder<PATH, STORAGE, USER, INPUT, OUTPUT>.() -> Unit = {},
-    crossinline disconnectType: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(reason: WebSocketClose) -> Unit = Connection<PATH, STORAGE, USER, INPUT, OUTPUT>::disconnectNoOp,
+    crossinline disconnectType: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(reason: WebSocketClose) -> Unit = {},
 ): ApiWebSocketHandler<PATH, STORAGE, USER, INPUT, OUTPUT> =
     object : ApiWebSocketHandler<PATH, STORAGE, USER, INPUT, OUTPUT> {
         override val summary: String = summary
@@ -86,32 +77,41 @@ public inline fun <PATH : PathSpec, reified STORAGE, USER : HasId<*>?, reified I
         override suspend fun willConnectTyped(access: WebSocketConnectRequestAccess<PATH, USER>): STORAGE =
             willConnectType(serverRuntime, access)
 
-        public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-        override suspend fun didConnectTyped(): Unit = didConnectType(connection)
+        public context(serverRuntime: ServerRuntime)
+        override suspend fun didConnectTyped(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>): Unit =
+            didConnectType(serverRuntime, connection)
 
-        public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-        override suspend fun messageFromClientTyped(frame: INPUT): Unit = messageFromClientType(connection, frame)
+        public context(serverRuntime: ServerRuntime)
+        override suspend fun messageFromClientTyped(
+            connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>,
+            frame: INPUT,
+        ): Unit = messageFromClientType(serverRuntime, connection, frame)
 
         private val subHandler =
             ApiTopicHandlersBuilder<PATH, STORAGE, USER, INPUT, OUTPUT>().apply(topicHandlersType).build()
 
-        public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-        override suspend fun messageFromSubscriptionTyped(topic: WebSocketSubscriptionMessage<*, *>): Unit =
-            subHandler(contextOf<Connection<PATH, STORAGE, USER, INPUT, OUTPUT>>(), topic)
+        public context(serverRuntime: ServerRuntime)
+        override suspend fun messageFromSubscriptionTyped(
+            connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>,
+            topic: WebSocketSubscriptionMessage<*, *>,
+        ): Unit = subHandler(serverRuntime, connection, topic)
 
-        public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-        override suspend fun disconnectTyped(reason: WebSocketClose): Unit = disconnectType(connection, reason)
+        public context(serverRuntime: ServerRuntime)
+        override suspend fun disconnectTyped(
+            connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>,
+            reason: WebSocketClose,
+        ): Unit = disconnectType(serverRuntime, connection, reason)
     }
 
 
 public class ApiTopicHandlersBuilder<PATH : PathSpec, STORAGE, USER : HasId<*>?, INPUT, OUTPUT>() {
-    public var handler: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
+    public var handler: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
         {}
 
     @Suppress("UNCHECKED_CAST", "DSL_MARKER_APPLIED_TO_WRONG_TARGET")
     @LightningServerDsl
     public inline infix fun <TOPICPATH : PathSpec, T> WebSocketTopic<TOPICPATH, T>.bind(
-        crossinline handler: suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(topic: WebSocketSubscriptionMessage<TOPICPATH, T>) -> Unit,
+        crossinline handler: suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(topic: WebSocketSubscriptionMessage<TOPICPATH, T>) -> Unit,
     ) {
         val topic = this
         this@ApiTopicHandlersBuilder.handler = this@ApiTopicHandlersBuilder.handler.let { current ->
@@ -122,6 +122,6 @@ public class ApiTopicHandlersBuilder<PATH : PathSpec, STORAGE, USER : HasId<*>?,
         }
     }
 
-    public fun build(): suspend Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
+    public fun build(): suspend context(ServerRuntime) Connection<PATH, STORAGE, USER, INPUT, OUTPUT>.(topic: WebSocketSubscriptionMessage<*, *>) -> Unit =
         handler
 }

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/ApiWebsocketHandler.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/ApiWebsocketHandler.kt
@@ -27,7 +27,13 @@ public interface ApiWebSocketHandler<PATH : PathSpec, STORAGE, USER : HasId<*>?,
     override val storageSerializer: KSerializer<ApiWebSocketStorage<STORAGE>>
         get() = ApiWebSocketStorage.serializer(innerStorageSerializer)
 
-    public interface Connection<PATH : PathSpec, STORAGE, USER : HasId<*>?, INPUT, OUTPUT> : ServerRuntime {
+    /**
+     * The typed view of one socket: its request, its decoded state, and typed sending.
+     *
+     * The socket alone, like [WebSocketConnection] underneath it. The server it runs on arrives
+     * separately, as the [ServerRuntime] context of every `*Typed` method below.
+     */
+    public interface Connection<PATH : PathSpec, STORAGE, USER : HasId<*>?, INPUT, OUTPUT> {
         public val request: WebSocketConnectRequest<PATH>
         public val currentState: STORAGE
         public suspend fun auth(): Authentication<USER & Any>?
@@ -40,20 +46,28 @@ public interface ApiWebSocketHandler<PATH : PathSpec, STORAGE, USER : HasId<*>?,
         public suspend fun close(reason: WebSocketClose)
     }
 
+    /*
+     * The typed phases mirror the raw ones: the server is the context and the socket is an argument,
+     * because they have different lifetimes. On a serverless engine each phase is a separate
+     * invocation with its own runtime, while the connection persists across all of them.
+     */
     public context(serverRuntime: ServerRuntime)
     suspend fun willConnectTyped(access: WebSocketConnectRequestAccess<PATH, USER>): STORAGE
 
-    public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-    suspend fun didConnectTyped()
+    public context(serverRuntime: ServerRuntime)
+    suspend fun didConnectTyped(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
 
-    public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-    suspend fun messageFromClientTyped(frame: INPUT)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun messageFromClientTyped(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>, frame: INPUT)
 
-    public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-    suspend fun messageFromSubscriptionTyped(topic: WebSocketSubscriptionMessage<*, *>)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun messageFromSubscriptionTyped(
+        connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>,
+        topic: WebSocketSubscriptionMessage<*, *>,
+    )
 
-    public context(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>)
-    suspend fun disconnectTyped(reason: WebSocketClose)
+    public context(serverRuntime: ServerRuntime)
+    suspend fun disconnectTyped(connection: Connection<PATH, STORAGE, USER, INPUT, OUTPUT>, reason: WebSocketClose)
 
 
     override context(serverRuntime: ServerRuntime)
@@ -68,55 +82,55 @@ public interface ApiWebSocketHandler<PATH : PathSpec, STORAGE, USER : HasId<*>?,
         }
     }
 
-    override context(connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>)
-    suspend fun didConnect() {
-        with(ConnectionWrapper<PATH, STORAGE, USER, INPUT, OUTPUT>(connection, outputType, auth)) { didConnectTyped() }
+    override context(serverRuntime: ServerRuntime)
+    suspend fun didConnect(connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>) {
+        didConnectTyped(connection.typed())
     }
 
-    override context(connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>)
-    suspend fun messageFromClient(frame: WebSocketFrame) {
+    override context(serverRuntime: ServerRuntime)
+    suspend fun messageFromClient(
+        connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>,
+        frame: WebSocketFrame,
+    ) {
         val parsed = try {
             connection.currentState.mediaType.decoder!!(frame, inputType)
         } catch (e: SerializationException) {
             throw BadRequestException(e.message ?: "Could not parse", cause = e)
         }
-        with(
-            ConnectionWrapper<PATH, STORAGE, USER, INPUT, OUTPUT>(
-                connection,
-                outputType,
-                auth
-            )
-        ) { messageFromClientTyped(parsed) }
+        messageFromClientTyped(connection.typed(), parsed)
     }
 
-    override context(connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>)
-    suspend fun messageFromSubscription(topic: WebSocketSubscriptionMessage<*, *>) {
-        with(
-            ConnectionWrapper<PATH, STORAGE, USER, INPUT, OUTPUT>(
-                connection,
-                outputType,
-                auth
-            )
-        ) { messageFromSubscriptionTyped(topic) }
+    override context(serverRuntime: ServerRuntime)
+    suspend fun messageFromSubscription(
+        connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>,
+        topic: WebSocketSubscriptionMessage<*, *>,
+    ) {
+        messageFromSubscriptionTyped(connection.typed(), topic)
     }
 
-    override context(connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>)
-    suspend fun disconnect(reason: WebSocketClose) {
-        with(ConnectionWrapper<PATH, STORAGE, USER, INPUT, OUTPUT>(connection, outputType, auth)) {
-            disconnectTyped(
-                reason
-            )
-        }
+    override context(serverRuntime: ServerRuntime)
+    suspend fun disconnect(
+        connection: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>,
+        reason: WebSocketClose,
+    ) {
+        disconnectTyped(connection.typed(), reason)
     }
+
+    /** Presents the raw connection as the typed one this handler's own methods are written against. */
+    private context(serverRuntime: ServerRuntime)
+    fun WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>.typed(): Connection<PATH, STORAGE, USER, INPUT, OUTPUT> =
+        ConnectionWrapper<PATH, STORAGE, USER, INPUT, OUTPUT>(serverRuntime, this, outputType, auth)
 }
 
 
 private class ConnectionWrapper<PATH : PathSpec, STORAGE, USER : HasId<*>?, INPUT, OUTPUT>(
+    /** Needed for the wrapper's own work — resolving auth and encoding output — not exposed to the socket. */
+    private val runtime: ServerRuntime,
     val wraps: WebSocketConnection<PATH, ApiWebSocketStorage<STORAGE>>,
     val outputSerializer: KSerializer<OUTPUT>,
     val authRequirement: AuthRequirement<USER>,
-) : ApiWebSocketHandler.Connection<PATH, STORAGE, USER, INPUT, OUTPUT>, ServerRuntime by wraps {
-    override suspend fun auth(): Authentication<USER & Any>? = wraps.request.auth(authRequirement)
+) : ApiWebSocketHandler.Connection<PATH, STORAGE, USER, INPUT, OUTPUT> {
+    override suspend fun auth(): Authentication<USER & Any>? = with(runtime) { wraps.request.auth(authRequirement) }
     override val request: WebSocketConnectRequest<PATH> get() = wraps.request
     override val currentState: STORAGE get() = wraps.currentState.storage
     override suspend fun repullState(): STORAGE = wraps.repullState().storage
@@ -130,7 +144,7 @@ private class ConnectionWrapper<PATH : PathSpec, STORAGE, USER : HasId<*>?, INPU
     override suspend fun unsubscribe(topic: WebSocketSubscriptionRequest<*, *>) = wraps.unsubscribe(topic)
     // The single chokepoint for every typed WebSocket output, model update streams included. See
     // TypedOutputInterceptor for why observation happens before encoding.
-    override suspend fun send(frame: OUTPUT) {
+    override suspend fun send(frame: OUTPUT): Unit = with(runtime) {
         emitTypedOutput(wraps.request, outputSerializer, frame)
         wraps.send(wraps.currentState.mediaType.encoder!!.ws(wraps.currentState.mediaType, outputSerializer, frame))
     }

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/ModelRestUpdatesWebsocket.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/ModelRestUpdatesWebsocket.kt
@@ -92,17 +92,22 @@ public class ModelRestUpdatesWebSocket<USER : HasId<*>?, T : HasId<ID>, ID : Com
             )
         }
 
-        context(connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>)
-        override suspend fun didConnectTyped() {
+        context(serverRuntime: ServerRuntime)
+        override suspend fun didConnectTyped(
+            connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>,
+        ) {
         }
 
-        context(connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>)
-        override suspend fun messageFromClientTyped(frame: Condition<T>) {
+        context(serverRuntime: ServerRuntime)
+        override suspend fun messageFromClientTyped(
+            connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>,
+            frame: Condition<T>,
+        ) {
             val p = info.table(connection.auth())
             val c = p.fullCondition(frame).simplify()
             val oldTopics: Set<WebSocketSubscriptionRequest<out PathSpec, *>> =
                 connection.currentState.topics.mapTo(HashSet()) {
-                    connection.server.webSocketTopics.match(connection.internalSerialization.stringArrayFormat, it)
+                    serverRuntime.server.webSocketTopics.match(serverRuntime.internalSerialization.stringArrayFormat, it)
                         ?.let { match -> WebSocketSubscriptionRequest(match.value, match.path.rawPathArguments) }
                         ?: throw IllegalArgumentException(
                             "WebSocket topic $it does not exist.  " +
@@ -122,15 +127,18 @@ public class ModelRestUpdatesWebSocket<USER : HasId<*>?, T : HasId<ID>, ID : Com
                     condition = c,
                     mask = refreshedMask,
                     permissionsCheckedAt = now(),
-                    topics = newTopics.mapTo(HashSet()) { it.pathInContext.path(connection.internalSerialization.stringArrayFormat) })
+                    topics = newTopics.mapTo(HashSet()) { it.pathInContext.path(serverRuntime.internalSerialization.stringArrayFormat) })
             }
             (oldTopics - newTopics.toHashSet()).forEach { connection.unsubscribe(it) }
             newTopics.filter { it !in oldTopics }.forEach { connection.subscribe(it) }
             connection.send(CollectionUpdates(condition = frame))
         }
 
-        context(connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>)
-        override suspend fun messageFromSubscriptionTyped(topic: WebSocketSubscriptionMessage<*, *>) {
+        context(serverRuntime: ServerRuntime)
+        override suspend fun messageFromSubscriptionTyped(
+            connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>,
+            topic: WebSocketSubscriptionMessage<*, *>,
+        ) {
             val state = connection.currentState
             val now = now()
 
@@ -182,7 +190,7 @@ public class ModelRestUpdatesWebSocket<USER : HasId<*>?, T : HasId<ID>, ID : Com
             )
             // Measured on the unmasked payload: masking only ever removes content, so this errs toward
             // declaring an overload, which costs the client an HTTP refetch rather than a huge frame.
-            val approxSize = connection.externalSerialization.approximateJsonSize(
+            val approxSize = serverRuntime.externalSerialization.approximateJsonSize(
                 CollectionUpdates.serializer(info.serializer, info.idSerializer),
                 unmaskedUpdates,
                 limit = OVERLOAD_THRESHOLD_BYTES,
@@ -197,8 +205,11 @@ public class ModelRestUpdatesWebSocket<USER : HasId<*>?, T : HasId<ID>, ID : Com
             }
         }
 
-        context(connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>)
-        override suspend fun disconnectTyped(reason: WebSocketClose) {
+        context(serverRuntime: ServerRuntime)
+        override suspend fun disconnectTyped(
+            connection: ApiWebSocketHandler.Connection<PathSpec0, ModelRestUpdatesWebSocketData<T, ID>, USER, Condition<T>, CollectionUpdates<T, ID>>,
+            reason: WebSocketClose,
+        ) {
         }
     }
 

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/BulkInterceptorScopeTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/BulkInterceptorScopeTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 /**
  * `/meta/bulk` used to invoke each sub-request's handler directly, so sub-requests bypassed the
@@ -33,7 +34,9 @@ import kotlin.test.assertTrue
  */
 class BulkInterceptorScopeTest {
 
-    private data class Seen(val path: String, val requestId: String, val parentRequestId: String?)
+    private data class Seen(val path: String, val requestId: Uuid, val parentRequestId: Uuid?)
+
+    private val outerRequestId = Uuid.parse("00000000-0000-4000-8000-000000000001")
 
     private object Observed {
         val logical: MutableList<Seen> = Collections.synchronizedList(mutableListOf())
@@ -122,7 +125,7 @@ class BulkInterceptorScopeTest {
                     domain = "example.com",
                     protocol = "https",
                     sourceIp = "local",
-                    requestId = "outer-request",
+                    requestId = outerRequestId,
                     body = TypedData.text(body, MediaType.Application.Json),
                 )
             )
@@ -156,9 +159,9 @@ class BulkInterceptorScopeTest {
     ) {
         val subs = Observed.logical.filter { it.path != "/meta/bulk" }
         assertEquals(2, subs.size, "expected two sub-requests, saw ${Observed.logical.map { it.path }}")
-        subs.forEach { assertEquals("outer-request", it.parentRequestId) }
+        subs.forEach { assertEquals(outerRequestId, it.parentRequestId) }
         assertEquals(2, subs.map { it.requestId }.toSet().size, "sub-requests must have distinct ids")
-        assertTrue(subs.none { it.requestId == "outer-request" }, "a sub-request reused the outer id")
+        assertTrue(subs.none { it.requestId == outerRequestId }, "a sub-request reused the outer id")
     }
 
     /**
@@ -176,7 +179,7 @@ class BulkInterceptorScopeTest {
                 domain = "example.com",
                 protocol = "https",
                 sourceIp = "local",
-                requestId = "hand-rolled",
+                requestId = Uuid.random(),
             )
             val failure = assertFailsWith<IllegalArgumentException> {
                 runBlocking { serverRuntime.handleSubRequest(notASubRequest) }

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/ModelRestUpdatesWebsocketTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/ModelRestUpdatesWebsocketTest.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.typed
 
+import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.auth.noAuth
 import com.lightningkite.lightningserver.definition.GeneralServerSettings
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
@@ -41,7 +42,7 @@ class ModelRestUpdatesWebSocketTest {
             database set Database.Settings()
         }) {
             val socket = TestServer.ws.webSocket.test()
-            val json = socket.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
 
             // Send a condition from client: Always
             val cond: Condition<Sample> = Condition.Always
@@ -94,7 +95,7 @@ class ModelRestUpdatesWebSocketTest {
             database set Database.Settings()
         }) {
             val socket = TestServer.ws.webSocket.test()
-            val json = socket.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
 
             var count = 0
             socket.onMessageSent = { count++ }
@@ -148,7 +149,7 @@ class ModelRestUpdatesWebSocketTest {
             )
 
             val socket = KeyedServer.ws.webSocket.test()
-            val json = socket.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
 
             // An Equal condition on the key is what lets the server shard onto the hash topic.
             val narrowed: Condition<Sample> = condition { it.name eq "shared" }
@@ -184,7 +185,7 @@ class ModelRestUpdatesWebSocketTest {
             database set Database.Settings()
         }) {
             val socket = TestServer.ws.webSocket.test()
-            val json = socket.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
 
             val always: Condition<Sample> = Condition.Always
             socket.send(WebSocketFrame.Text(json.encodeToString(Condition.serializer(Sample.serializer()), always)))
@@ -211,7 +212,7 @@ class ModelRestUpdatesWebSocketTest {
             database set Database.Settings()
         }) {
             val socket = TestServer.ws.webSocket.test()
-            val json = socket.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
 
             val always: Condition<Sample> = Condition.Always
             val frameText = json.encodeToString(Condition.serializer(Sample.serializer()), always)

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/TypedOutputInterceptorTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/TypedOutputInterceptorTest.kt
@@ -26,6 +26,7 @@ import java.util.Collections
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 /**
  * The disclosure log's entire premise is that no typed value reaches a client unobserved. These
@@ -36,8 +37,8 @@ import kotlin.test.assertTrue
 class TypedOutputInterceptorTest {
 
     private data class Seen(
-        val requestId: String,
-        val parentRequestId: String?,
+        val requestId: Uuid,
+        val parentRequestId: Uuid?,
         val serialName: String,
         val value: Any?,
     )
@@ -104,6 +105,8 @@ class TypedOutputInterceptorTest {
         )
     }
 
+    private val outerRequestId = Uuid.parse("00000000-0000-4000-8000-000000000001")
+
     private fun request(path: String, method: HttpMethod = HttpMethod.GET, body: String? = null) =
         HttpRequest<PathSpec>(
             path = RawHttpEndpoint(asString = path, method = method),
@@ -112,7 +115,7 @@ class TypedOutputInterceptorTest {
             domain = "example.com",
             protocol = "https",
             sourceIp = "local",
-            requestId = "outer-request",
+            requestId = outerRequestId,
             body = body?.let { TypedData.text(it, MediaType.Application.Json) },
         )
 
@@ -131,7 +134,7 @@ class TypedOutputInterceptorTest {
         assertEquals(1, Observed.seen.size, "expected exactly one observation, saw ${Observed.seen}")
         val seen = Observed.seen.single()
         assertEquals("alpha", seen.value)
-        assertEquals("outer-request", seen.requestId)
+        assertEquals(outerRequestId, seen.requestId)
         assertTrue(seen.serialName.contains("String"), "expected the output serializer; was ${seen.serialName}")
     }
 
@@ -154,7 +157,7 @@ class TypedOutputInterceptorTest {
         assertTrue("beta" in values, "sub-response from /beta was not observed; saw $values")
 
         val subs = Observed.seen.filter { it.value == "alpha" || it.value == "beta" }
-        subs.forEach { assertEquals("outer-request", it.parentRequestId, "sub-response lost its parent") }
+        subs.forEach { assertEquals(outerRequestId, it.parentRequestId, "sub-response lost its parent") }
         assertEquals(2, subs.map { it.requestId }.toSet().size, "sub-responses must be separately attributable")
     }
 
@@ -178,7 +181,7 @@ class TypedOutputInterceptorTest {
         }) {
             Observed.reset()
             val socket = TestServer.updates.webSocket.test()
-            val json = socket.server.externalSerialization.json
+            val json = contextOf<ServerRuntime>().externalSerialization.json
             val always: Condition<Sample> = Condition.Always
             socket.send(WebSocketFrame.Text(json.encodeToString(Condition.serializer(Sample.serializer()), always)))
 

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/WebSocketPermissionStalenessTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/WebSocketPermissionStalenessTest.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.typed
 
+import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.auth.noAuth
 import com.lightningkite.lightningserver.definition.GeneralServerSettings
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
@@ -86,7 +87,7 @@ class WebSocketPermissionStalenessTest {
         ) {
             runBlocking {
                 val socket = fixture.ws.webSocket.test()
-                val json = socket.server.externalSerialization.json
+                val json = contextOf<ServerRuntime>().externalSerialization.json
                 val watchEverything = WebSocketFrame.Text(
                     json.encodeToString(Condition.serializer(Sample.serializer()), Condition.Always)
                 )


### PR DESCRIPTION
**Stack: 2 of 16.** Based on `split/e1` — review that one first.
Groundwork for the execution-context refactor described in the new
plans/execution-context-refactor.md (which covers this PR and the next two).

- Request correlation ids change from String to `Uuid`. A correlation id is
  an identifier, not free text, and the audit layer later derives a record's
  timestamp from it — which only works if it is a real UUID.
- `WebSocketConnection` separates from `ServerRuntime`. A socket is not a
  runtime; conflating them meant every socket-shaped operation had to be
  reachable from anything holding a runtime, and vice versa.
- The typed socket separates the same way.

Mechanical for the most part: the bulk of the diff is signature propagation
across the engines and their tests.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd