### PR TITLE
Introduce Initiator: every execution says what started it, and who did it

### DIFF
--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AccessLogInterceptor.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AccessLogInterceptor.kt
@@ -6,6 +6,7 @@ import com.lightningkite.lightningserver.http.HttpResponse
 import com.lightningkite.lightningserver.http.HttpLogicalInterceptor
 import com.lightningkite.lightningserver.logger
 import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.runtime.Initiator
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.websockets.DelegatingWebSocketHandler
 import com.lightningkite.lightningserver.websockets.WebSocketClose
@@ -67,7 +68,7 @@ public class AccessLogInterceptor : HttpLogicalInterceptor, WebSocketLogicalInte
             val elapsedMs = started.elapsedNow().inWholeMilliseconds
             runtime.logger.info {
                 "${request.path} accessed by $principal (${request.sourceIp}) " +
-                    "-> $outcome in ${elapsedMs}ms ${request.idSuffix()}"
+                    "-> $outcome in ${elapsedMs}ms ${idSuffix()}"
             }
         }
     }
@@ -80,7 +81,7 @@ public class AccessLogInterceptor : HttpLogicalInterceptor, WebSocketLogicalInte
                     val principal = request.principalName()
                     serverRuntime.logger.info {
                         "ws ${request.path} opened by $principal (${request.sourceIp}) " +
-                            request.idSuffix(idLabel = "conn")
+                            idSuffix(idLabel = "conn")
                     }
                 }
                 return wrapped.willConnect(request)
@@ -93,7 +94,7 @@ public class AccessLogInterceptor : HttpLogicalInterceptor, WebSocketLogicalInte
                     val principal = request.principalName()
                     serverRuntime.logger.info {
                         "ws ${request.path} closed by $principal (${request.sourceIp}) " +
-                            "-> $reason ${request.idSuffix(idLabel = "conn")}"
+                            "-> $reason ${idSuffix(idLabel = "conn")}"
                     }
                 }
                 wrapped.disconnect(connection, reason)
@@ -119,6 +120,22 @@ private suspend fun com.lightningkite.lightningserver.data.Request<*>.principalN
 /**
  * Renders the correlation IDs, including the parent for a sub-request or virtual socket, so a line
  * can be tied back to the request that carried it.
+ *
+ * A socket is named by its socket id rather than by the phase's execution id: a reader following a
+ * socket wants the one identifier that is the same at open and at close. For the same reason the
+ * socket's parent is read from the causal root rather than from `causedBy`, which on any phase after
+ * connect points at that socket's own connect and would render as "X of X".
  */
-private fun com.lightningkite.lightningserver.data.Request<*>.idSuffix(idLabel: String = "req"): String =
-    parentRequestId?.let { "[$idLabel $requestId of $it]" } ?: "[$idLabel $requestId]"
+context(runtime: ServerRuntime)
+private fun idSuffix(idLabel: String = "req"): String {
+    val initiator = runtime.initiator
+    return when (initiator) {
+        is Initiator.WebSocket -> initiator.socketId.let { socket ->
+            initiator.rootExecutionId.takeIf { it != socket }?.let { "[$idLabel $socket of $it]" }
+                ?: "[$idLabel $socket]"
+        }
+
+        else -> initiator.causedBy?.let { "[$idLabel ${initiator.executionId} of $it]" }
+            ?: "[$idLabel ${initiator.executionId}]"
+    }
+}

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/data/Request.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/data/Request.kt
@@ -4,7 +4,6 @@ import com.lightningkite.lightningserver.http.HttpHeaders
 import com.lightningkite.lightningserver.http.QueryParameters
 import com.lightningkite.lightningserver.pathing.*
 import com.lightningkite.lightningserver.runtime.ServerRuntime
-import kotlin.uuid.Uuid
 
 /**
  * Base class for HTTP requests in Lightning Server.
@@ -13,6 +12,11 @@ import kotlin.uuid.Uuid
  * and includes a built-in cache for computed values via the [Caching] interface.
  *
  * This is typically implemented by the framework and passed to endpoint handlers.
+ *
+ * What is *not* here is any identifier of ours: correlation lives on
+ * [com.lightningkite.lightningserver.runtime.ServerRuntime.initiator], because a task or a schedule
+ * tick has no request to hang it on. The two identifiers that remain below are wire-level facts
+ * about the caller and the gateway, not identifiers the server minted.
  *
  * @param PATH The path specification type for this request
  */
@@ -34,20 +38,6 @@ public abstract class Request<out PATH : PathSpec> : HasContextualPath<PATH>, Ca
 
     /** The source IP address of the client making the request. */
     public abstract val sourceIp: String
-
-    /**
-     * Server-controlled identifier correlating this request across every log the server writes.
-     *
-     * Never derived from an untrusted caller — see
-     * [com.lightningkite.lightningserver.http.requestIdentity] for how engines resolve it.
-     */
-    public abstract val requestId: Uuid
-
-    /**
-     * The [requestId] of the request that dispatched this one, for sub-requests of a multiplexed
-     * request, or null for a request that arrived directly from a client.
-     */
-    public abstract val parentRequestId: Uuid?
 
     /**
      * An identifier the caller supplied that was not trusted, kept for diagnostics only.

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpInterceptor.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpInterceptor.kt
@@ -101,7 +101,9 @@ public fun interface HttpConnectionInterceptor : HttpInterceptor
  * how much was done inside it.
  *
  * An implementation must tolerate running several times within one physical request, and should
- * attribute its work to [HttpRequest.requestId] rather than assuming one request per connection.
+ * attribute its work to the running execution
+ * ([com.lightningkite.lightningserver.runtime.ServerRuntime.initiator]) rather than assuming one
+ * request per connection.
  */
 public fun interface HttpLogicalInterceptor : HttpInterceptor
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpRequest.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/HttpRequest.kt
@@ -7,7 +7,6 @@ import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
 import com.lightningkite.services.data.TypedData
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlin.uuid.Uuid
 
 /**
  * Represents an HTTP request with all associated data.
@@ -44,8 +43,6 @@ public data class HttpRequest<PATH : PathSpec>(
     override val domain: String,
     override val protocol: String,
     override val sourceIp: String,
-    override val requestId: Uuid,
-    override val parentRequestId: Uuid? = null,
     override val upstreamRequestId: String? = null,
     override val engineRequestId: String? = null,
     override val cache: SerializableCache = SerializableCache(),
@@ -68,8 +65,6 @@ public data class HttpRequest<PATH : PathSpec>(
         domain: String = this.domain,
         protocol: String = this.protocol,
         sourceIp: String = this.sourceIp,
-        requestId: Uuid = this.requestId,
-        parentRequestId: Uuid? = this.parentRequestId,
         upstreamRequestId: String? = this.upstreamRequestId,
         engineRequestId: String? = this.engineRequestId,
         cache: SerializableCache = this.cache,
@@ -81,8 +76,6 @@ public data class HttpRequest<PATH : PathSpec>(
         domain = domain,
         protocol = protocol,
         sourceIp = sourceIp,
-        requestId = requestId,
-        parentRequestId = parentRequestId,
         upstreamRequestId = upstreamRequestId,
         engineRequestId = engineRequestId,
         cache = cache,
@@ -92,9 +85,9 @@ public data class HttpRequest<PATH : PathSpec>(
     /**
      * Derives a sub-request of this one, as dispatched by a multiplexed request such as `/meta/bulk`.
      *
-     * The sub-request gets its own [requestId] with [parentRequestId] pointing back here, so each
-     * logical request is independently attributable while remaining joinable to the request that
-     * carried it.
+     * Named separately from [copyWithNewPathType] so that a caller has to say which of the two it
+     * means: the sub-request is a distinct logical request, and the initiator the dispatcher derives
+     * alongside it with [com.lightningkite.lightningserver.runtime.subRequest] is what records that.
      */
     public fun <PATH2 : PathSpec> subRequest(
         path: RawHttpEndpoint<PATH2>,
@@ -104,8 +97,6 @@ public data class HttpRequest<PATH : PathSpec>(
         path = path,
         queryParameters = queryParameters,
         body = body,
-        requestId = generateRequestId(),
-        parentRequestId = this.requestId,
     )
 }
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/RawWebsocketPath.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/RawWebsocketPath.kt
@@ -48,7 +48,7 @@ public class PathSerializer<T : PathSpec>(ignored: KSerializer<T>) : KSerializer
  * @see HasContextualPath
  */
 @Serializable(with = PathSerializer::class)
-public class RawWebSocketPath<PATH : PathSpec>(public val pathSegments: PathSegments) : HasContextualPath<PATH> {
+public class RawWebSocketPath<out PATH : PathSpec>(public val pathSegments: PathSegments) : HasContextualPath<PATH> {
     /** Constructs a raw WebSocket path from a string. */
     public constructor(path: String) : this(PathSegments.parse(path))
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ExecutionRuntime.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ExecutionRuntime.kt
@@ -1,0 +1,35 @@
+package com.lightningkite.lightningserver.runtime
+
+import com.lightningkite.lightningserver.InternalLightningServerApi
+
+/**
+ * This runtime, attributed to [initiator].
+ *
+ * Everything a runtime offers — settings, serialization, telemetry, task dispatch — is process-wide
+ * and shared; only the attribution differs per execution, so this delegates the whole of it and
+ * overrides one property. Minted at the single seam every engine funnels through
+ * ([handle] and the `*WithMetrics` helpers), never by user code, so that "who initiated this?" is
+ * answerable from the runtime alone rather than reconstructed from whatever happens to be in scope.
+ */
+@InternalLightningServerApi
+public fun ServerRuntime.forExecution(initiator: Initiator): ServerRuntime = ExecutionRuntime(this, initiator)
+
+private class ExecutionRuntime(
+    engine: ServerRuntime,
+    override val initiator: Initiator,
+) : ServerRuntime by engine
+
+/**
+ * The socket this execution is a phase of.
+ *
+ * For the handlers that wrap a socket in another — multiplexing, path rewriting — which have to name
+ * the socket they are wrapping in order to derive the inner one's identity from it.
+ *
+ * @throws IllegalStateException off a WebSocket execution, where there is no socket to name.
+ */
+@InternalLightningServerApi
+public val ServerRuntime.socketInitiator: Initiator.WebSocket
+    get() = initiator as? Initiator.WebSocket
+        ?: throw IllegalStateException(
+            "Expected to be running a WebSocket phase, but this execution was initiated by $initiator."
+        )

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Initiator.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Initiator.kt
@@ -1,0 +1,268 @@
+package com.lightningkite.lightningserver.runtime
+
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.http.PathSegments
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
+import com.lightningkite.lightningserver.pathing.RawWebSocketPath
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+/**
+ * What started one execution, and what caused it to start.
+ *
+ * An "execution" is one run of anything the server can run: an HTTP request, one WebSocket lifecycle
+ * phase, a task, a schedule tick, a startup task, or a pre-deploy task. Every log the server writes
+ * attributes itself to one of these, which is why the identifiers live here rather than on
+ * [com.lightningkite.lightningserver.data.Request]: a task and a schedule tick have no request at
+ * all, and threading correlation ids through request objects meant only requests could be correlated.
+ *
+ * ## Serializable, and deliberately small
+ * Serialization is not a logging convenience: it is how [causedBy] crosses a queue. A task launched
+ * from a request carries the launching execution's id in its queued payload, which is the only
+ * mechanism that works on a serverless engine, where the launcher's process is gone by the time the
+ * task runs. That means an initiator really is persisted — into task queues and into the DynamoDB
+ * row backing a WebSocket. Everything here is bounded by URL length, and must stay that way: no
+ * headers, no source IP, no principal, no body. Those stay on the request, which is already threaded
+ * wherever they are needed. An initiator answers "what is running and why", not "what did the caller
+ * send".
+ *
+ * ## Framework-set
+ * Constructors are [InternalLightningServerApi] because an initiator that user code could mint would
+ * let a caller's activity be filed under another execution's identity, which is the one thing the
+ * audit trail must not permit. Read it freely; never build one.
+ */
+@Serializable
+public sealed interface Initiator {
+    /** Identifies this one execution. */
+    public val executionId: Uuid
+
+    /** The execution that caused this one, or null if it started here. */
+    public val causedBy: Uuid?
+
+    /**
+     * The execution at the head of this causal chain; equals [executionId] when [causedBy] is null.
+     *
+     * Carried alongside [causedBy] so that "everything that happened because of request X" is one
+     * indexed lookup rather than a recursive walk of parent pointers — which is the query the audit
+     * system exists to answer.
+     *
+     * **Not an attribution key.** The outermost execution is not necessarily the one that carried
+     * the credentials — see [attributedTo].
+     */
+    public val rootExecutionId: Uuid
+
+    /**
+     * The execution whose request-log row names who is responsible for this one.
+     *
+     * Distinct from [rootExecutionId], and the distinction is load-bearing. The root answers "what
+     * set this off"; this answers "who did it". For a plain request or socket they are the same
+     * execution, which is why one field looked like enough — but the framework creates *inner*
+     * executions that carry their own credentials, and there the two come apart:
+     *
+     * - a `/meta/bulk` sub-request takes per-sub-request query parameters, and `SessionManager.read`
+     *   falls back to the `Authorization` and `jwt` query parameters
+     * - a multiplexed sub-socket takes per-sub-socket query parameters the same way
+     *
+     * So an anonymous carrier can dispatch an authenticated inner execution. When that inner
+     * execution launches a task, the task has no request row of its own, and [rootExecutionId] leads
+     * to the *carrier's* row — which names nobody. The change becomes untraceable to the person who
+     * made it. Both shapes are pinned by tests in the audit module.
+     *
+     * The rule is uniform: an execution that has a request-log row of its own attributes to that
+     * row; one that does not — a task, a schedule tick — inherits the anchor of whatever launched
+     * it. That is why this is carried rather than derived, and why it survives a queue.
+     *
+     * For an execution with no request row anywhere in its ancestry (startup, pre-deploy, a direct
+     * runtime) this is its own [executionId] and resolves to nothing, exactly as [rootExecutionId]
+     * does for the same executions.
+     */
+    public val attributedTo: Uuid
+
+    /**
+     * One HTTP request, whether it arrived from a client or was dispatched inside a multiplexed one
+     * such as `/meta/bulk`.
+     *
+     * [endpoint] is the concrete path the caller asked for, not the route pattern. The pattern is
+     * derived from it on demand via `endpoint.match`, so nothing is stored twice; a record that wants
+     * bounded cardinality (`RequestRecord.endpoint`) resolves the pattern itself.
+     */
+    @Serializable
+    @SerialName("http")
+    public data class Http @InternalLightningServerApi constructor(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        val endpoint: RawHttpEndpoint<PathSpec>,
+    ) : Initiator {
+        /** An HTTP execution has a request-log row of its own, keyed by its execution id. */
+        override val attributedTo: Uuid get() = executionId
+    }
+
+    /**
+     * One phase of one WebSocket's life.
+     *
+     * Each phase is its own execution with its own [executionId], because on a serverless engine each
+     * of the five lifecycle methods is a separate invocation — treating a socket as a single
+     * execution would be factually wrong there. [socketId] is what stays constant across all phases
+     * of one socket, and is the identity to attribute a socket's whole session to.
+     */
+    @Serializable
+    @SerialName("ws")
+    public data class WebSocket @InternalLightningServerApi constructor(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        /** Constant for the socket's whole lifetime, across all phases. */
+        val socketId: Uuid,
+        val path: RawWebSocketPath<PathSpec>,
+        val phase: Phase,
+    ) : Initiator {
+        public enum class Phase { Connect, Connected, ClientMessage, SubscriptionMessage, Disconnect }
+
+        /**
+         * A socket's request-log row is keyed by [socketId] rather than by any one phase's execution
+         * id, because connect and disconnect are separate invocations on a serverless engine. So the
+         * socket, not the phase, is what a socket's work attributes to.
+         */
+        override val attributedTo: Uuid get() = socketId
+    }
+
+    /**
+     * One run of a queued task.
+     *
+     * Tasks, schedules, startup and pre-deploy tasks are all registered under all-constant paths, so
+     * [PathSegments] is their complete location.
+     */
+    @Serializable
+    @SerialName("task")
+    public data class Task @InternalLightningServerApi constructor(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        /** A task has no request-log row of its own, so it inherits the anchor of whatever launched
+         * it. Required, with no default: a task that invented its own anchor would attribute a
+         * change to an execution that never authenticated anyone. */
+        override val attributedTo: Uuid,
+        val location: PathSegments,
+    ) : Initiator
+
+    /** One tick of a scheduled task. */
+    @Serializable
+    @SerialName("schedule")
+    public data class Schedule @InternalLightningServerApi constructor(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        /** A schedule tick has no request-log row, and normally no launching request either — its
+         * anchor is then its own execution id and resolves to nothing, which is the honest answer. */
+        override val attributedTo: Uuid,
+        val location: PathSegments,
+    ) : Initiator
+
+    /** One run of a startup task. */
+    @Serializable
+    @SerialName("startup")
+    public data class Startup @InternalLightningServerApi constructor(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        val location: PathSegments,
+    ) : Initiator {
+        /** No request is involved at any point, so this anchors to itself and resolves to nothing. */
+        override val attributedTo: Uuid get() = executionId
+    }
+
+    /** One run of a pre-deploy task. */
+    @Serializable
+    @SerialName("predeploy")
+    public data class PreDeploy @InternalLightningServerApi constructor(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+        val location: PathSegments,
+    ) : Initiator {
+        /** No request is involved at any point, so this anchors to itself and resolves to nothing. */
+        override val attributedTo: Uuid get() = executionId
+    }
+
+    /**
+     * An execution with no server-side origin: `TestRunner`, or a runtime built by hand.
+     *
+     * A deliberate hole in "every execution names what started it". Without it nothing outside the
+     * server — a test, a script, an embedding application — could build a runtime at all, so the hole
+     * is the price of the rule being enforceable everywhere else.
+     */
+    @Serializable
+    @SerialName("direct")
+    public data class Direct @InternalLightningServerApi constructor(
+        override val executionId: Uuid,
+        override val causedBy: Uuid? = null,
+        override val rootExecutionId: Uuid = executionId,
+    ) : Initiator {
+        /** No request row exists, so this anchors to itself and resolves to nothing. */
+        override val attributedTo: Uuid get() = executionId
+    }
+}
+
+/**
+ * The initiator of a logical request dispatched inside this one, such as a `/meta/bulk` sub-request.
+ *
+ * A sub-request is a separate execution — it is independently attributable, and independently
+ * audited — so it gets its own id rather than reusing the carrying request's, while staying joinable
+ * to it through [Initiator.causedBy] and to the whole batch through [Initiator.rootExecutionId].
+ */
+@InternalLightningServerApi
+public fun Initiator.Http.subRequest(endpoint: RawHttpEndpoint<PathSpec>): Initiator.Http = Initiator.Http(
+    executionId = Uuid.random(),
+    causedBy = executionId,
+    rootExecutionId = rootExecutionId,
+    endpoint = endpoint,
+)
+
+/**
+ * The initiator of a later phase of the same socket.
+ *
+ * Derive from the socket's connect initiator — the one an engine persists with the connection — so
+ * that every phase of a socket names the connect that opened it.
+ */
+@InternalLightningServerApi
+public fun Initiator.WebSocket.phase(phase: Initiator.WebSocket.Phase): Initiator.WebSocket = copy(
+    executionId = Uuid.random(),
+    causedBy = executionId,
+    rootExecutionId = rootExecutionId,
+    phase = phase,
+)
+
+/**
+ * The initiator of a logical sub-socket multiplexed inside this physical connection.
+ *
+ * A new [Initiator.WebSocket.socketId], because a virtual socket has its own lifetime and its own
+ * subscriptions; the physical connection carrying it stays reachable through [Initiator.causedBy].
+ */
+@InternalLightningServerApi
+public fun Initiator.WebSocket.subConnection(path: RawWebSocketPath<PathSpec>): Initiator.WebSocket {
+    // One id for both, exactly as every engine mints a real connect. Minting two left a sub-socket's
+    // own request-log row — which is keyed by socketId — unreachable from its execution id, so
+    // nothing descending from it could find the row that names the person who opened it.
+    val id = Uuid.random()
+    return Initiator.WebSocket(
+        executionId = id,
+        causedBy = executionId,
+        rootExecutionId = rootExecutionId,
+        socketId = id,
+        path = path,
+        phase = Initiator.WebSocket.Phase.Connect,
+    )
+}
+
+/**
+ * The same socket and the same execution, at a rewritten path.
+ *
+ * For shims that only re-target where a socket was opened — the path arrives in a query parameter
+ * rather than the URL, say. Rewriting is not opening: reusing the identity is what keeps the two
+ * indistinguishable in the audit trail, which is correct here and wrong for [subConnection].
+ */
+@InternalLightningServerApi
+public fun Initiator.WebSocket.rewritePath(path: RawWebSocketPath<PathSpec>): Initiator.WebSocket = copy(path = path)

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ServerRuntime.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ServerRuntime.kt
@@ -43,6 +43,22 @@ public interface ServerRuntime : SettingContext, Namespaced {
     public val server: ServerDefinition
 
     /**
+     * What started the execution this runtime is serving.
+     *
+     * ## Why it lives here rather than being passed as a parameter
+     * Not a stylistic choice, and not a candidate for "simplification" into an argument. The sites
+     * that must attribute their work are the two logical interceptors *and the inside of a handler
+     * body*: disclosure auditing hangs off `emitTypedOutput`, which is called from within
+     * `ApiHttpHandler` and `ApiWebSocketHandler`. Reaching that by parameter would mean adding one to
+     * `HttpHandler.handle`, and so to every endpoint handler in the framework and in user code. The
+     * runtime context is the only carrier already threaded to all three.
+     *
+     * A runtime obtained outside any execution — the engine itself, during boot — carries
+     * [Initiator.Direct].
+     */
+    public val initiator: Initiator
+
+    /**
      * Whether the different parts of the webSocket handler (willConnect, didConnect, messageFromClient,
      * messageFromSubscription, disconnect) all occur in the same process.  If they do, you can use RAM to store
      * information between those events.

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ServerRuntimeBase.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ServerRuntimeBase.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.runtime
 
+import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.serialization.Serialization
@@ -7,6 +8,7 @@ import com.lightningkite.lightningserver.settings.ServerSettings
 import com.lightningkite.services.telemetry.TelemetryBackend
 import com.lightningkite.services.SharedResources
 import kotlinx.coroutines.*
+import kotlin.uuid.Uuid
 
 /**
  * Base implementation of [ServerRuntime] providing common functionality.
@@ -29,6 +31,14 @@ import kotlinx.coroutines.*
  * @param server The server definition to run
  */
 public abstract class ServerRuntimeBase(override val server: ServerDefinition) : ServerRuntime {
+    /**
+     * The engine itself is not running on anyone's behalf — executions get their own runtime from
+     * [forExecution] at the seam. Work done directly on the engine, such as boot, is attributed to
+     * this one [Initiator.Direct] rather than to nothing at all.
+     */
+    @OptIn(InternalLightningServerApi::class)
+    override val initiator: Initiator = Initiator.Direct(Uuid.random())
+
     /**
      * Settings manager with automatically included system settings.
      *

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
@@ -3,6 +3,8 @@ package com.lightningkite.lightningserver.runtime
 import com.lightningkite.lightningserver.*
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.http.*
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.http.PathSegments
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.websockets.*
@@ -13,6 +15,7 @@ import com.lightningkite.services.telemetry.emptyTelemetryAttributes
 import com.lightningkite.services.telemetry.telemetryTrace
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
+import kotlin.uuid.Uuid
 
 // Pre-allocated TelemetryKey instances for custom WebSocket and task attributes (backend caches by equality).
 private val wsRoute = TelemetryKey.OfString("ws.route")
@@ -45,35 +48,47 @@ private val errorType = TelemetryKey.OfString("error.type")
  * [com.lightningkite.lightningserver.compression.GzipInterceptor] if you want it.
  *
  * @param request The HTTP request to handle
+ * @param executionId Identifies this run. Supplied by the engine, which is the only thing that knows
+ *   whether the id was minted fresh or adopted from a trusted proxy; the rest of the initiator is
+ *   derived from [request], so the two cannot disagree about what ran.
  * @return The HTTP response
  */
-public suspend fun ServerRuntime.handle(request: HttpRequest<PathSpec>): HttpResponse = instrumentHttpRequest(request) {
-    var errorType: String? = null
+@OptIn(InternalLightningServerApi::class)
+public suspend fun ServerRuntime.handle(
+    request: HttpRequest<PathSpec>,
+    executionId: Uuid,
+): HttpResponse = forExecution(
+    Initiator.Http(executionId = executionId, endpoint = request.path)
+).handleInExecution(request)
 
-    val response = try {
-        server.compiledHttpConnectionInterceptors.intercept(request) { req ->
-            @Suppress("UNCHECKED_CAST")
-            val outcome = this@handle.dispatchLogicalRequest(req as HttpRequest<PathSpec>)
-            errorType = outcome.errorType
-            outcome.response
+private suspend fun ServerRuntime.handleInExecution(request: HttpRequest<PathSpec>): HttpResponse =
+    instrumentHttpRequest(request) {
+        var errorType: String? = null
+
+        val response = try {
+            server.compiledHttpConnectionInterceptors.intercept(request) { req ->
+                @Suppress("UNCHECKED_CAST")
+                val outcome = this@handleInExecution.dispatchLogicalRequest(req as HttpRequest<PathSpec>)
+                errorType = outcome.errorType
+                outcome.response
+            }
+        } catch (e: Exception) {
+            // Last-resort safety net. Exceptions thrown by an interceptor itself are now recovered
+            // inside HttpInterceptor.interceptInstrumented, at the point each interceptor is invoked,
+            // so outer interceptors (e.g. CORS) still get to post-process the resulting response. This
+            // catch only fires when there are no interceptors installed (the compiled chain is
+            // HttpInterceptor.NoOp, which bypasses interceptInstrumented) or some other exception
+            // escapes the chain machinery itself — headers from would-be interceptors are absent here.
+            this.logger.error(e) { "Exception in HTTP interceptor chain" }
+            errorType = "unhandled_exception"
+            try {
+                instrument("exceptionHandler") { server.exceptionHandler.handle(request, e) }
+            } catch (_: Exception) {
+                HttpResponse(status = HttpStatus.InternalServerError)
+            }
         }
-    } catch (e: Exception) {
-        // Last-resort safety net. Exceptions thrown by an interceptor itself are now recovered
-        // inside HttpInterceptor.interceptInstrumented, at the point each interceptor is invoked,
-        // so outer interceptors (e.g. CORS) still get to post-process the resulting response. This
-        // catch only fires when there are no interceptors installed (the compiled chain is
-        // HttpInterceptor.NoOp, which bypasses interceptInstrumented) or some other exception
-        // escapes the chain machinery itself — headers from would-be interceptors are absent here.
-        this.logger.error(e) { "Exception in HTTP interceptor chain" }
-        errorType = "unhandled_exception"
-        try {
-            instrument("exceptionHandler") { server.exceptionHandler.handle(request, e) }
-        } catch (_: Exception) {
-            HttpResponse(status = HttpStatus.InternalServerError)
-        }
+        HttpInstrumentationResult(response, response.status.code, errorType)
     }
-    HttpInstrumentationResult(response, response.status.code, errorType)
-}
 
 /**
  * Handles one logical sub-request dispatched by a multiplexed request such as `/meta/bulk`.
@@ -83,20 +98,27 @@ public suspend fun ServerRuntime.handle(request: HttpRequest<PathSpec>): HttpRes
  * auditing and rate limiting among them — and execute unobserved. [HttpConnectionInterceptor]s are
  * deliberately not re-run: they already ran for the physical request that carried this one.
  *
- * @param request must be derived with [HttpRequest.subRequest], so it carries its own request ID
- *   parented to the outer request. A sub-request that reused the outer ID would make the two
- *   indistinguishable in the audit trail; one with no parent would be unattributable to the request
- *   that actually carried it.
- * @throws IllegalArgumentException if [request] was not derived as a sub-request.
+ * The sub-request's initiator is derived here rather than supplied, so it cannot be got wrong: it
+ * gets its own execution id, parented to the request that carried it. A sub-request that reused the
+ * outer id would make the two indistinguishable in the audit trail; one with no parent would be
+ * unattributable to the request that actually carried it.
+ *
+ * @param request must be derived with [HttpRequest.subRequest].
+ * @throws IllegalArgumentException if this is not running inside an HTTP execution, which means
+ *   there is no request for the sub-request to be a sub-request *of*.
  */
+@OptIn(InternalLightningServerApi::class)
 public suspend fun ServerRuntime.handleSubRequest(request: HttpRequest<PathSpec>): HttpResponse {
-    require(request.parentRequestId != null) {
-        "Sub-requests must be derived with HttpRequest.subRequest so they carry their own request ID " +
-            "parented to the outer request; ${request.path} arrived with no parentRequestId."
+    val outer = initiator
+    require(outer is Initiator.Http) {
+        "Sub-requests may only be dispatched from inside an HTTP execution, so that they can be " +
+            "parented to the request that carried them; ${request.path} was dispatched from $outer."
     }
-    return instrumentHttpRequest(request) {
-        val outcome = dispatchLogicalRequest(request)
-        HttpInstrumentationResult(outcome.response, outcome.response.status.code, outcome.errorType)
+    return with(forExecution(outer.subRequest(request.path))) {
+        instrumentHttpRequest(request) {
+            val outcome = dispatchLogicalRequest(request)
+            HttpInstrumentationResult(outcome.response, outcome.response.status.code, outcome.errorType)
+        }
     }
 }
 
@@ -208,15 +230,19 @@ private suspend fun ServerRuntime.dispatchLogicalRequest(request: HttpRequest<Pa
  *
  * @param location The path specification for this WebSocket endpoint
  * @param serverRuntime The server runtime context
+ * @param initiator The socket's connect initiator, minted by the engine and kept with the connection
+ *   so that every later phase can derive its own from it with [phase].
  * @param request The WebSocket connection request
  * @return The connection storage state
  */
+@OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.willConnectWithMetrics(
     location: PATH,
     serverRuntime: ServerRuntime,
+    initiator: Initiator.WebSocket,
     request: WebSocketConnectRequest<PATH>,
 ): STORAGE {
-    return with(serverRuntime) {
+    return with(serverRuntime.forExecution(initiator)) {
         instrument("willConnect", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, request.sourceIp)
@@ -231,14 +257,18 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.wi
  *
  * @param location The path specification for this WebSocket endpoint
  * @param serverRuntime The runtime this phase runs on
+ * @param initiator This phase's initiator, derived from the socket's connect initiator with
+ *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The established WebSocket connection
  */
+@OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.didConnectWithMetrics(
     location: PATH,
     serverRuntime: ServerRuntime,
+    initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
 ) {
-    return with(serverRuntime) {
+    return with(serverRuntime.forExecution(initiator)) {
         instrument("didConnect", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
@@ -255,16 +285,20 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.di
  *
  * @param location The path specification for this WebSocket endpoint
  * @param serverRuntime The runtime this phase runs on
+ * @param initiator This phase's initiator, derived from the socket's connect initiator with
+ *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The WebSocket connection
  * @param frame The frame received from the client
  */
+@OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.messageFromClientWithMetrics(
     location: PATH,
     serverRuntime: ServerRuntime,
+    initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
     frame: WebSocketFrame,
 ) {
-    return with(serverRuntime) {
+    return with(serverRuntime.forExecution(initiator)) {
         instrument("messageFromClient", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
@@ -291,16 +325,20 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
  *
  * @param location The path specification for this WebSocket endpoint
  * @param serverRuntime The runtime this phase runs on
+ * @param initiator This phase's initiator, derived from the socket's connect initiator with
+ *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The WebSocket connection
  * @param topic The subscription message received
  */
+@OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.messageFromSubscriptionWithMetrics(
     location: PATH,
     serverRuntime: ServerRuntime,
+    initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
     topic: WebSocketSubscriptionMessage<*, *>,
 ) {
-    return with(serverRuntime) {
+    return with(serverRuntime.forExecution(initiator)) {
         instrument("messageFromSubscription", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
@@ -316,16 +354,20 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
  *
  * @param location The path specification for this WebSocket endpoint
  * @param serverRuntime The runtime this phase runs on
+ * @param initiator This phase's initiator, derived from the socket's connect initiator with
+ *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The WebSocket connection being closed
  * @param reason The close reason and code
  */
+@OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.disconnectWithMetrics(
     location: PATH,
     serverRuntime: ServerRuntime,
+    initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
     reason: WebSocketClose,
 ) {
-    return with(serverRuntime) {
+    return with(serverRuntime.forExecution(initiator)) {
         instrument("disconnect", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
@@ -338,21 +380,40 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.di
 }
 
 /**
+ * The location a task-like execution is registered under, as an initiator can hold it.
+ *
+ * Tasks, schedules, startup and pre-deploy tasks are all registered under all-constant paths, so the
+ * segments are the whole of their location.
+ */
+private fun PathSpec0.asPathSegments(): PathSegments = PathSegments.parse(toString())
+
+/**
  * Executes a task with telemetry metrics.
  *
  * @param location The path specification for this task
  * @param input The input parameter for the task
  */
+@OptIn(InternalLightningServerApi::class)
 context(serverRuntime: ServerRuntime)
 public suspend fun <T> Task<T>.executeWithMetrics(location: PathSpec0, input: T) {
+    // Anchors to itself: nothing launched it that this call site can see. Tasks inherit their
+    // launcher's parentage — and with it the anchor — where that is threaded through.
+    val executionId = Uuid.random()
+    val runtime = serverRuntime.forExecution(
+        Initiator.Task(
+            executionId = executionId,
+            attributedTo = executionId,
+            location = location.asPathSegments(),
+        )
+    )
     // Span name includes the location so traces distinguish one task from another, the same way
     // HTTP root spans are named "$method $route". Locations are a fixed, static set, so this is
     // low-cardinality.
-    return instrument("task $location", TelemetryAttributes {
-        put(taskType, "TASK")
-        put(taskRoute, location.toString())
-    }) {
-        with(serverRuntime) {
+    return with(runtime) {
+        instrument("task $location", TelemetryAttributes {
+            put(taskType, "TASK")
+            put(taskRoute, location.toString())
+        }) {
             this@executeWithMetrics.executeInline(input)
         }
     }
@@ -363,13 +424,24 @@ public suspend fun <T> Task<T>.executeWithMetrics(location: PathSpec0, input: T)
  *
  * @param location The path specification for this scheduled task
  */
+@OptIn(InternalLightningServerApi::class)
 context(serverRuntime: ServerRuntime)
 public suspend fun ScheduledTask.executeWithMetrics(location: PathSpec0) {
-    return instrument("schedule $location", TelemetryAttributes {
-        put(taskType, "SCHEDULE")
-        put(taskRoute, location.toString())
-    }) {
-        with(serverRuntime) {
+    // Anchors to itself: nothing launched it that this call site can see. Tasks inherit their
+    // launcher's parentage — and with it the anchor — where that is threaded through.
+    val executionId = Uuid.random()
+    val runtime = serverRuntime.forExecution(
+        Initiator.Schedule(
+            executionId = executionId,
+            attributedTo = executionId,
+            location = location.asPathSegments(),
+        )
+    )
+    return with(runtime) {
+        instrument("schedule $location", TelemetryAttributes {
+            put(taskType, "SCHEDULE")
+            put(taskRoute, location.toString())
+        }) {
             this@executeWithMetrics.execute()
         }
     }
@@ -380,13 +452,19 @@ public suspend fun ScheduledTask.executeWithMetrics(location: PathSpec0) {
  *
  * @param location The path specification for this startup task
  */
+@OptIn(InternalLightningServerApi::class)
 context(serverRuntime: ServerRuntime)
 public suspend fun StartupTask.executeWithMetrics(location: PathSpec0) {
-    return instrument("startup $location", TelemetryAttributes {
-        put(taskType, "STARTUP")
-        put(taskRoute, location.toString())
-    }) {
-        execute()
+    val runtime = serverRuntime.forExecution(
+        Initiator.Startup(executionId = Uuid.random(), location = location.asPathSegments())
+    )
+    return with(runtime) {
+        instrument("startup $location", TelemetryAttributes {
+            put(taskType, "STARTUP")
+            put(taskRoute, location.toString())
+        }) {
+            execute()
+        }
     }
 }
 
@@ -395,13 +473,19 @@ public suspend fun StartupTask.executeWithMetrics(location: PathSpec0) {
  *
  * @param location The path specification for this pre-deploy task
  */
+@OptIn(InternalLightningServerApi::class)
 context(serverRuntime: ServerRuntime)
 public suspend fun PreDeployTask.executeWithMetrics(location: PathSpec0) {
-    return instrument("predeploy $location", TelemetryAttributes {
-        put(taskType, "PREDEPLOY")
-        put(taskRoute, location.toString())
-    }) {
-        execute()
+    val runtime = serverRuntime.forExecution(
+        Initiator.PreDeploy(executionId = Uuid.random(), location = location.asPathSegments())
+    )
+    return with(runtime) {
+        instrument("predeploy $location", TelemetryAttributes {
+            put(taskType, "PREDEPLOY")
+            put(taskRoute, location.toString())
+        }) {
+            execute()
+        }
     }
 }
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.ext.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.ext.kt
@@ -1,8 +1,14 @@
+@file:OptIn(InternalLightningServerApi::class)
+
 package com.lightningkite.lightningserver.runtime.test
 
+import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.definition.generalSettings
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.runtime.phase
 import com.lightningkite.lightningserver.runtime.handle
 import com.lightningkite.lightningserver.runtime.location
 import com.lightningkite.lightningserver.websockets.*
@@ -35,7 +41,7 @@ public suspend fun <STORAGE> WebSocketHandler<PathSpec0, STORAGE>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: Uuid = generateRequestId(),
+    socketId: Uuid = Uuid.random(),
 ): TestRunner<*>.TestWebSocket<PathSpec0, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -45,11 +51,18 @@ public suspend fun <STORAGE> WebSocketHandler<PathSpec0, STORAGE>.test(
         domain = domain,
         protocol = protocol,
         sourceIp = sourceIp,
-        requestId = requestId,
     )
-    val storage = intercepted.willConnect(request)
-    return test.TestWebSocket(intercepted, request, storage).also {
-        with(test) { intercepted.didConnect(it.server) }
+    val initiator = Initiator.WebSocket(
+        executionId = socketId,
+        socketId = socketId,
+        path = request.path,
+        phase = Initiator.WebSocket.Phase.Connect,
+    )
+    val storage = with(test.forExecution(initiator)) { intercepted.willConnect(request) }
+    return test.TestWebSocket(intercepted, request, initiator, storage).also {
+        with(test.forExecution(initiator.phase(Initiator.WebSocket.Phase.Connected))) {
+            intercepted.didConnect(it.server)
+        }
     }
 }
 
@@ -62,7 +75,7 @@ public suspend fun <STORAGE, A> WebSocketHandler<PathSpec1<A>, STORAGE>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: Uuid = generateRequestId(),
+    socketId: Uuid = Uuid.random(),
 ): TestRunner<*>.TestWebSocket<PathSpec1<A>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -72,11 +85,18 @@ public suspend fun <STORAGE, A> WebSocketHandler<PathSpec1<A>, STORAGE>.test(
         domain = domain,
         protocol = protocol,
         sourceIp = sourceIp,
-        requestId = requestId,
     )
-    val storage = intercepted.willConnect(request)
-    return test.TestWebSocket(intercepted, request, storage).also {
-        with(test) { intercepted.didConnect(it.server) }
+    val initiator = Initiator.WebSocket(
+        executionId = socketId,
+        socketId = socketId,
+        path = request.path,
+        phase = Initiator.WebSocket.Phase.Connect,
+    )
+    val storage = with(test.forExecution(initiator)) { intercepted.willConnect(request) }
+    return test.TestWebSocket(intercepted, request, initiator, storage).also {
+        with(test.forExecution(initiator.phase(Initiator.WebSocket.Phase.Connected))) {
+            intercepted.didConnect(it.server)
+        }
     }
 }
 
@@ -90,7 +110,7 @@ public suspend fun <STORAGE, A, B> WebSocketHandler<PathSpec2<A, B>, STORAGE>.te
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: Uuid = generateRequestId(),
+    socketId: Uuid = Uuid.random(),
 ): TestRunner<*>.TestWebSocket<PathSpec2<A, B>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -100,11 +120,18 @@ public suspend fun <STORAGE, A, B> WebSocketHandler<PathSpec2<A, B>, STORAGE>.te
         domain = domain,
         protocol = protocol,
         sourceIp = sourceIp,
-        requestId = requestId,
     )
-    val storage = with(test) { intercepted.willConnect(request) }
-    return test.TestWebSocket(intercepted, request, storage).also {
-        with(test) { intercepted.didConnect(it.server) }
+    val initiator = Initiator.WebSocket(
+        executionId = socketId,
+        socketId = socketId,
+        path = request.path,
+        phase = Initiator.WebSocket.Phase.Connect,
+    )
+    val storage = with(test.forExecution(initiator)) { intercepted.willConnect(request) }
+    return test.TestWebSocket(intercepted, request, initiator, storage).also {
+        with(test.forExecution(initiator.phase(Initiator.WebSocket.Phase.Connected))) {
+            intercepted.didConnect(it.server)
+        }
     }
 }
 
@@ -119,7 +146,7 @@ public suspend fun <STORAGE, A, B, C> WebSocketHandler<PathSpec3<A, B, C>, STORA
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    requestId: Uuid = generateRequestId(),
+    socketId: Uuid = Uuid.random(),
 ): TestRunner<*>.TestWebSocket<PathSpec3<A, B, C>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -129,11 +156,18 @@ public suspend fun <STORAGE, A, B, C> WebSocketHandler<PathSpec3<A, B, C>, STORA
         domain = domain,
         protocol = protocol,
         sourceIp = sourceIp,
-        requestId = requestId,
     )
-    val storage = with(test) { intercepted.willConnect(request) }
-    return test.TestWebSocket(this, request, storage).also {
-        with(test) { intercepted.didConnect(it.server) }
+    val initiator = Initiator.WebSocket(
+        executionId = socketId,
+        socketId = socketId,
+        path = request.path,
+        phase = Initiator.WebSocket.Phase.Connect,
+    )
+    val storage = with(test.forExecution(initiator)) { intercepted.willConnect(request) }
+    return test.TestWebSocket(this, request, initiator, storage).also {
+        with(test.forExecution(initiator.phase(Initiator.WebSocket.Phase.Connected))) {
+            intercepted.didConnect(it.server)
+        }
     }
 }
 
@@ -148,18 +182,16 @@ public suspend fun HttpHandler<PathSpec0>.test(
     requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
-    return test.handle(
-        HttpRequest(
-            RawHttpEndpoint(location.path, location.method, trailingWildcard),
-            queryParameters = queryParameters,
-            headers = headers,
-            domain = domain,
-            protocol = protocol,
-            sourceIp = sourceIp,
-            requestId = requestId,
-            body = body,
-        )
+    val request: HttpRequest<PathSpec> = HttpRequest(
+        RawHttpEndpoint(location.path, location.method, trailingWildcard),
+        queryParameters = queryParameters,
+        headers = headers,
+        domain = domain,
+        protocol = protocol,
+        sourceIp = sourceIp,
+        body = body,
     )
+    return test.handle(request, requestId)
 }
 
 context(test: TestRunner<*>)
@@ -174,18 +206,16 @@ public suspend fun <A> HttpHandler<PathSpec1<A>>.test(
     requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
-    return test.handle(
-        HttpRequest(
-            RawHttpEndpoint(location.path, path1, location.method, trailingWildcard),
-            queryParameters = queryParameters,
-            headers = headers,
-            domain = domain,
-            protocol = protocol,
-            sourceIp = sourceIp,
-            requestId = requestId,
-            body = body,
-        )
+    val request: HttpRequest<PathSpec> = HttpRequest(
+        RawHttpEndpoint(location.path, path1, location.method, trailingWildcard),
+        queryParameters = queryParameters,
+        headers = headers,
+        domain = domain,
+        protocol = protocol,
+        sourceIp = sourceIp,
+        body = body,
     )
+    return test.handle(request, requestId)
 }
 
 context(test: TestRunner<*>)
@@ -201,18 +231,16 @@ public suspend fun <A, B> HttpHandler<PathSpec2<A, B>>.test(
     requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
-    return test.handle(
-        HttpRequest(
-            RawHttpEndpoint(location.path, path1, path2, location.method, trailingWildcard),
-            queryParameters = queryParameters,
-            headers = headers,
-            domain = domain,
-            protocol = protocol,
-            sourceIp = sourceIp,
-            requestId = requestId,
-            body = body,
-        )
+    val request: HttpRequest<PathSpec> = HttpRequest(
+        RawHttpEndpoint(location.path, path1, path2, location.method, trailingWildcard),
+        queryParameters = queryParameters,
+        headers = headers,
+        domain = domain,
+        protocol = protocol,
+        sourceIp = sourceIp,
+        body = body,
     )
+    return test.handle(request, requestId)
 }
 
 context(test: TestRunner<*>)
@@ -229,17 +257,15 @@ public suspend fun <A, B, C> HttpHandler<PathSpec3<A, B, C>>.test(
     requestId: Uuid = generateRequestId(),
     body: TypedData? = null,
 ): HttpResponse {
-    return test.handle(
-        HttpRequest(
-            RawHttpEndpoint(location.path, path1, path2, path3, location.method, trailingWildcard),
-            queryParameters = queryParameters,
-            headers = headers,
-            domain = domain,
-            protocol = protocol,
-            sourceIp = sourceIp,
-            requestId = requestId,
-            body = body,
-        )
+    val request: HttpRequest<PathSpec> = HttpRequest(
+        RawHttpEndpoint(location.path, path1, path2, path3, location.method, trailingWildcard),
+        queryParameters = queryParameters,
+        headers = headers,
+        domain = domain,
+        protocol = protocol,
+        sourceIp = sourceIp,
+        body = body,
     )
+    return test.handle(request, requestId)
 }
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
@@ -1,11 +1,15 @@
 package com.lightningkite.lightningserver.runtime.test
 
+import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.definition.ServerSetting
 import com.lightningkite.lightningserver.definition.Task
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.runtime.Initiator
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.ServerRuntimeBase
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.runtime.phase
 import com.lightningkite.lightningserver.settings.ServerSettings
 import com.lightningkite.lightningserver.websockets.*
 import com.lightningkite.services.SettingContext
@@ -107,15 +111,21 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
      *
      * @param handler The WebSocket handler being tested
      * @param request The connection request
+     * @param initiator The socket's connect initiator, from which each phase derives its own
      * @param currentState The current connection state (mutable for inspection)
      * @param name Display name for debug output (default: "Client")
      */
+    @OptIn(InternalLightningServerApi::class)
     public inner class TestWebSocket<PATH : PathSpec, STORAGE>(
         private val handler: WebSocketHandler<PATH, STORAGE>,
         public val request: WebSocketConnectRequest<PATH>,
+        public val initiator: Initiator.WebSocket,
         public var currentState: STORAGE,
         public val name: String = "Client",
     ) {
+        private fun runtimeFor(phase: Initiator.WebSocket.Phase): ServerRuntime =
+            this@TestRunner.forExecution(initiator.phase(phase))
+
         public var onMessageSent: (frame: WebSocketFrame) -> Unit = {}
         public suspend fun close() {
             /*logger.debug*/run { "$name --> <close>" }.let(::println)
@@ -126,7 +136,7 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
         public suspend fun send(frame: WebSocketFrame) {
             /*logger.debug*/run { "$name --> '$frame'" }.let(::println)
             val connection = this@TestWebSocket.server
-            with(this@TestRunner) { handler.messageFromClient(connection, frame) }
+            with(runtimeFor(Initiator.WebSocket.Phase.ClientMessage)) { handler.messageFromClient(connection, frame) }
             connection.flush()
         }
 
@@ -135,7 +145,9 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
         public inner class ServerSide() : WebSocketConnection<PATH, STORAGE> {
             private val changeQueue = ArrayList<(STORAGE) -> STORAGE>()
             private val sub: suspend (WebSocketSubscriptionMessage<*, *>) -> Unit = {
-                with(this@TestRunner) { handler.messageFromSubscription(this@ServerSide, it) }
+                with(runtimeFor(Initiator.WebSocket.Phase.SubscriptionMessage)) {
+                    handler.messageFromSubscription(this@ServerSide, it)
+                }
                 flush()
             }
 
@@ -184,7 +196,7 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
 
             override suspend fun close(reason: WebSocketClose) {
                 /*logger.debug*/run { "$name <-- <close>" }.let(::println)
-                with(this@TestRunner) { handler.disconnect(this@ServerSide, reason) }
+                with(runtimeFor(Initiator.WebSocket.Phase.Disconnect)) { handler.disconnect(this@ServerSide, reason) }
             }
 
             internal fun clean() {

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/typedoutput/TypedOutputInterceptor.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/typedoutput/TypedOutputInterceptor.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.KSerializer
  * — a disclosure that could not be recorded must not happen.
  *
  * An implementation must tolerate being called many times per connection: a WebSocket pushes many
- * frames under one [Request.requestId].
+ * frames, and on a local engine they all belong to one socket.
  */
 public interface TypedOutputInterceptor {
     /** The name of this interceptor, used for instrumentation and debugging. */
@@ -31,7 +31,7 @@ public interface TypedOutputInterceptor {
      * Called with a value that is about to be serialized and sent.
      *
      * @param request The request or connection this output belongs to; correlate by
-     *   [Request.requestId].
+     *   [com.lightningkite.lightningserver.runtime.ServerRuntime.initiator].
      * @param serializer The serializer that will encode [value] — walk this rather than reflecting,
      *   so that what is observed is exactly what the client will receive.
      * @param value The value being sent.

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/MultiplexWebSocketHandler.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/MultiplexWebSocketHandler.kt
@@ -18,6 +18,11 @@ public data class MultiplexWebSocketHandlerConnectionInfo(
     val storage: AnonType,
     val topics: Set<String> = setOf(),
     val request: WebSocketConnectRequest<*>,
+    /**
+     * The virtual socket's connect initiator, kept here for the same reason the request is: a later
+     * phase may run in a different process, and the socket's identity has to survive the trip.
+     */
+    val initiator: Initiator.WebSocket,
 )
 
 /**
@@ -36,6 +41,7 @@ private fun MultiplexWebSocketHandlerState.updateChannel(
     return copy(map = map + (channel to change(existing)))
 }
 
+@OptIn(InternalLightningServerApi::class)
 public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, MultiplexWebSocketHandlerState> {
     override val storageSerializer: KSerializer<MultiplexWebSocketHandlerState> get() = serializer()
 
@@ -191,11 +197,14 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                         queryParameters = QueryParameters(connection.request.queryParameters + (message.queryParams?.entries?.flatMap { it.value.map { v -> it.key to v } }
                             ?: listOf())),
                     )
-                    val storage = otherHandler.willConnectWithMetrics(match.path.pathSpec, serverRuntime, r)
+                    val subInitiator = serverRuntime.socketInitiator.subConnection(r.path)
+                    val storage =
+                        otherHandler.willConnectWithMetrics(match.path.pathSpec, serverRuntime, subInitiator, r)
                     connection.updateStateImmediately {
                         it.copy(
                             map = it.map + (channel to MultiplexWebSocketHandlerConnectionInfo(
                                 request = r,
+                                initiator = subInitiator,
                                 storage = AnonType(
                                     serverRuntime.internalSerialization.kotlinBytesFormat,
                                     storage,
@@ -208,6 +217,7 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                         otherHandler.didConnectWithMetrics(
                             match.pathSpec,
                             serverRuntime,
+                            subInitiator.phase(Initiator.WebSocket.Phase.Connected),
                             it
                         )
                     }
@@ -234,6 +244,7 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                         otherHandler.disconnectWithMetrics(
                             match.pathSpec,
                             serverRuntime,
+                            info.initiator.phase(Initiator.WebSocket.Phase.Disconnect),
                             it,
                             WebSocketClose.NORMAL
                         )
@@ -263,7 +274,15 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                         serverRuntime,
                         otherHandler,
                         channel
-                    ) { otherHandler.messageFromClientWithMetrics(match.pathSpec, serverRuntime, it, textFrame) }
+                    ) {
+                        otherHandler.messageFromClientWithMetrics(
+                            match.pathSpec,
+                            serverRuntime,
+                            info.initiator.phase(Initiator.WebSocket.Phase.ClientMessage),
+                            it,
+                            textFrame,
+                        )
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -285,6 +304,7 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                     otherHandler.disconnectWithMetrics(
                         match.pathSpec,
                         serverRuntime,
+                        info.initiator.phase(Initiator.WebSocket.Phase.Disconnect),
                         it,
                         ((e as? HttpStatusException)?.status ?: HttpStatus.InternalServerError).bestWebSocketCloseCode
                     )
@@ -306,7 +326,13 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
                 val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
                     .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
                 connection.withWrapped(serverRuntime, otherHandler, channel) {
-                    otherHandler.messageFromSubscriptionWithMetrics(match.pathSpec, serverRuntime, it, topic)
+                    otherHandler.messageFromSubscriptionWithMetrics(
+                        match.pathSpec,
+                        serverRuntime,
+                        info.initiator.phase(Initiator.WebSocket.Phase.SubscriptionMessage),
+                        it,
+                        topic,
+                    )
                 }
             }
         }
@@ -323,7 +349,13 @@ public class MultiplexWebSocketHandler() : WebSocketHandler<PathSpec0, Multiplex
             val otherHandler = serverRuntime.server.compiledWebSocketLogicalInterceptors
                 .intercept(match.value as WebSocketHandler<PathSpec, Any?>)
             connection.withWrapped(serverRuntime, otherHandler, channel) {
-                otherHandler.disconnectWithMetrics(match.pathSpec, serverRuntime, it, reason)
+                otherHandler.disconnectWithMetrics(
+                    match.pathSpec,
+                    serverRuntime,
+                    info.initiator.phase(Initiator.WebSocket.Phase.Disconnect),
+                    it,
+                    reason,
+                )
             }
         }
     }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/QueryParamWebSocketHandler.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/QueryParamWebSocketHandler.kt
@@ -1,6 +1,7 @@
 package com.lightningkite.lightningserver.websockets
 
 import com.lightningkite.lightningserver.AnonType
+import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.NotFoundException
 import com.lightningkite.lightningserver.http.PathSegments
 import com.lightningkite.lightningserver.http.QueryParameters
@@ -16,6 +17,7 @@ public data class QueryParamWebSocketHandlerData(
     val underlyingData: AnonType,
 )
 
+@OptIn(InternalLightningServerApi::class)
 public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryParamWebSocketHandlerData> {
     override val storageSerializer: KSerializer<QueryParamWebSocketHandlerData> =
         QueryParamWebSocketHandlerData.serializer()
@@ -134,9 +136,6 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
                 domain = request.domain,
                 protocol = request.protocol,
                 sourceIp = request.sourceIp,
-                // Same physical socket, only the path is rewritten, so the identity carries over.
-                requestId = request.requestId,
-                parentRequestId = request.parentRequestId,
                 upstreamRequestId = request.upstreamRequestId,
                 cache = request.cache,
             )
@@ -153,7 +152,13 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
 //                    null /*TODO*/
 //                )
 //            ) {
-            otherHandler.willConnectWithMetrics(match.pathSpec, serverRuntime, request)
+            // Same physical socket, only the path is rewritten, so the identity carries over.
+            otherHandler.willConnectWithMetrics(
+                match.pathSpec,
+                serverRuntime,
+                serverRuntime.socketInitiator.rewritePath(request.path),
+                request,
+            )
 //            }
 
         @Suppress("UNCHECKED_CAST")
@@ -181,11 +186,24 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
         return match.pathSpec to (otherHandler as WebSocketHandler<PathSpec, Any?>)
     }
 
+    /**
+     * This phase, re-pointed at the path the socket was really opened against.
+     *
+     * Rewriting a path is not opening a socket, so the execution and the socket stay the same; only
+     * the location the initiator names would otherwise be the placeholder the client connected to.
+     */
+    context(serverRuntime: ServerRuntime)
+    private fun WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>.innerInitiator(): Initiator.WebSocket {
+        @Suppress("UNCHECKED_CAST")
+        val path = currentState.request.path as RawWebSocketPath<PathSpec>
+        return serverRuntime.socketInitiator.rewritePath(path)
+    }
+
     context(serverRuntime: ServerRuntime)
     override suspend fun didConnect(connection: WebSocketConnection<PathSpec0, QueryParamWebSocketHandlerData>) {
         val (pathSpec, otherHandler) = connection.inner()
         connection.withWrapped(serverRuntime, otherHandler) {
-            otherHandler.didConnectWithMetrics(pathSpec, serverRuntime, it)
+            otherHandler.didConnectWithMetrics(pathSpec, serverRuntime, connection.innerInitiator(), it)
         }
     }
 
@@ -196,7 +214,7 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
     ) {
         val (pathSpec, otherHandler) = connection.inner()
         connection.withWrapped(serverRuntime, otherHandler) {
-            otherHandler.messageFromClientWithMetrics(pathSpec, serverRuntime, it, frame)
+            otherHandler.messageFromClientWithMetrics(pathSpec, serverRuntime, connection.innerInitiator(), it, frame)
         }
     }
 
@@ -207,7 +225,13 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
     ) {
         val (pathSpec, otherHandler) = connection.inner()
         connection.withWrapped(serverRuntime, otherHandler) {
-            otherHandler.messageFromSubscriptionWithMetrics(pathSpec, serverRuntime, it, topic)
+            otherHandler.messageFromSubscriptionWithMetrics(
+                pathSpec,
+                serverRuntime,
+                connection.innerInitiator(),
+                it,
+                topic,
+            )
         }
     }
 
@@ -218,7 +242,7 @@ public class QueryParamWebSocketHandler() : WebSocketHandler<PathSpec0, QueryPar
     ) {
         val (pathSpec, otherHandler) = connection.inner()
         connection.withWrapped(serverRuntime, otherHandler) {
-            otherHandler.disconnectWithMetrics(pathSpec, serverRuntime, it, reason)
+            otherHandler.disconnectWithMetrics(pathSpec, serverRuntime, connection.innerInitiator(), it, reason)
         }
     }
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocket.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocket.kt
@@ -4,13 +4,11 @@ import com.lightningkite.lightningserver.data.Request
 import com.lightningkite.lightningserver.data.SerializableCache
 import com.lightningkite.lightningserver.http.HttpHeaders
 import com.lightningkite.lightningserver.http.QueryParameters
-import com.lightningkite.lightningserver.http.generateRequestId
 import com.lightningkite.lightningserver.pathing.*
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.location
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlin.uuid.Uuid
 
 
 /**
@@ -86,13 +84,6 @@ public data class WebSocketConnectRequest<PATH : PathSpec>(
     override val domain: String = "",
     override val protocol: String = "",
     override val sourceIp: String = "",
-    /**
-     * Identifies this connection for the lifetime of the socket. Every message and every push on
-     * this connection correlates back to it, since a long-lived socket is one logical session rather
-     * than one request.
-     */
-    override val requestId: Uuid,
-    override val parentRequestId: Uuid? = null,
     override val upstreamRequestId: String? = null,
     override val cache: SerializableCache = SerializableCache(),
     /**
@@ -109,10 +100,10 @@ public data class WebSocketConnectRequest<PATH : PathSpec>(
      * Derives a logical sub-connection of this one, as multiplexing carries several logical sockets
      * over a single physical connection.
      *
-     * The sub-connection gets its own [requestId] with [parentRequestId] pointing back here, so each
-     * logical socket is independently attributable while remaining joinable to the physical
-     * connection carrying it. Use this only for a genuinely distinct logical connection — a shim that
-     * merely rewrites the path of the same socket should keep the existing [requestId].
+     * Use this only for a genuinely distinct logical socket, with
+     * [com.lightningkite.lightningserver.runtime.subConnection] deriving the initiator that gives it
+     * its own socket identity. A shim that merely rewrites the path of the same socket is not opening
+     * one, and should use [com.lightningkite.lightningserver.runtime.rewritePath] instead.
      */
     public fun <PATH2 : PathSpec> subConnection(
         path: RawWebSocketPath<PATH2>,
@@ -124,8 +115,6 @@ public data class WebSocketConnectRequest<PATH : PathSpec>(
         domain = domain,
         protocol = protocol,
         sourceIp = sourceIp,
-        requestId = generateRequestId(),
-        parentRequestId = requestId,
         upstreamRequestId = upstreamRequestId,
         cache = cache,
         engineSocketId = engineSocketId,
@@ -214,16 +203,13 @@ public interface WebSocketConnection<PATH : PathSpec, STORAGE> {
  * 3. No way to query current subscriptions for a connection. Adding a `val subscriptions: Set<WebSocketSubscriptionRequest<*, *>>`
  *    would be useful for debugging and state inspection.
  *
- * 4. No way to identify a connection from the connection itself; callers reach for
- *    `request.requestId`. Consider exposing the socket's identity directly.
- *
- * 5. The subscribe/unsubscribe operations don't return success/failure. If a topic doesn't exist or
+ * 4. The subscribe/unsubscribe operations don't return success/failure. If a topic doesn't exist or
  *    subscription fails, how does the caller know? Consider returning Boolean or throwing exceptions.
  *
- * 6. No ping/pong support exposed in the API. WebSocket implementations typically need this for
+ * 5. No ping/pong support exposed in the API. WebSocket implementations typically need this for
  *    connection keepalive. Consider adding automatic ping or exposing manual ping control.
  *
- * 7. The currentState property could be stale if queueStateUpdate is used. Document the
+ * 6. The currentState property could be stale if queueStateUpdate is used. Document the
  *    consistency model (eventual consistency? last-write-wins?).
  */
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocketInterceptor.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocketInterceptor.kt
@@ -49,9 +49,9 @@ public interface WebSocketConnectionInterceptor : WebSocketInterceptor
  * many independent subscriptions were running over it.
  *
  * An implementation must tolerate wrapping several handlers within one physical connection, and
- * should attribute its work to the connection's own
- * [com.lightningkite.lightningserver.websockets.WebSocketConnectRequest.requestId] rather than
- * assuming one socket per client.
+ * should attribute its work to the socket's own
+ * [com.lightningkite.lightningserver.runtime.Initiator.WebSocket.socketId] rather than assuming one
+ * socket per client.
  *
  * @see WebSocketConnectionInterceptor for the per-physical-connection counterpart.
  */

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/WebSocketConnectRequestTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/WebSocketConnectRequestTest.kt
@@ -32,7 +32,6 @@ class WebSocketConnectRequestTest {
             domain = "localhost",
             protocol = "https",
             sourceIp = "127.0.0.1",
-            requestId = generateRequestId(),
         )
         r.roundTripTest()
         object : ServerBuilder() {}.test(

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
@@ -31,6 +31,7 @@ class ServerSettingThreadSafetyTest {
         // Create a minimal test runtime context
         val testRuntime = object : com.lightningkite.lightningserver.runtime.ServerRuntime {
             override val server get() = throw NotImplementedError()
+            override val initiator get() = throw NotImplementedError()
             override val settings get() = throw NotImplementedError()
             override val internalSerialization get() = throw NotImplementedError()
             override val externalSerialization get() = throw NotImplementedError()
@@ -98,6 +99,7 @@ class ServerSettingThreadSafetyTest {
     /** Minimal [ServerRuntime] stub whose only usable capability is acting as the settings/transformation context. */
     private fun stubRuntime(): ServerRuntime = object : ServerRuntime {
         override val server get() = throw NotImplementedError()
+        override val initiator get() = throw NotImplementedError()
         override val settings get() = throw NotImplementedError()
         override val internalSerialization get() = throw NotImplementedError()
         override val externalSerialization get() = throw NotImplementedError()

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/http/RequestIdentityTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/http/RequestIdentityTest.kt
@@ -1,5 +1,8 @@
 package com.lightningkite.lightningserver.http
 
+import com.lightningkite.lightningserver.runtime.subRequest
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
@@ -119,46 +122,41 @@ class RequestIdentityTest {
         assertNotEquals(Uuid.NIL, identity.requestId)
     }
 
-    private fun request(id: Uuid) = HttpRequest<PathSpec>(
-        path = RawHttpEndpoint(asString = "/outer", method = HttpMethod.POST),
-        queryParameters = QueryParameters.EMPTY,
-        headers = HttpHeaders.EMPTY,
-        domain = "example.com",
-        protocol = "https",
-        sourceIp = "local",
-        requestId = id,
+    private val outerId = Uuid.parse("00000000-0000-4000-8000-0000000000d4")
+
+    @OptIn(InternalLightningServerApi::class)
+    private fun outer() = Initiator.Http(
+        executionId = outerId,
+        endpoint = RawHttpEndpoint(asString = "/outer", method = HttpMethod.POST),
     )
 
-    private val outerId = Uuid.parse("00000000-0000-4000-8000-0000000000d4")
+    private fun endpoint(path: String) = RawHttpEndpoint<PathSpec>(asString = path, method = HttpMethod.GET)
 
     @Test
     fun `subRequest gets its own id parented to the outer request`() {
-        val outer = request(outerId)
-        val sub = outer.subRequest<PathSpec>(RawHttpEndpoint(asString = "/inner", method = HttpMethod.GET))
+        val sub = outer().subRequest(endpoint("/inner"))
 
-        assertNotEquals(outer.requestId, sub.requestId)
-        assertEquals(outerId, sub.parentRequestId)
+        assertNotEquals(outerId, sub.executionId)
+        assertEquals(outerId, sub.causedBy)
+        assertEquals(outerId, sub.rootExecutionId)
     }
 
     @Test
     fun `sibling sub-requests get distinct ids and share a parent`() {
-        val outer = request(outerId)
-        val a = outer.subRequest<PathSpec>(RawHttpEndpoint(asString = "/a", method = HttpMethod.GET))
-        val b = outer.subRequest<PathSpec>(RawHttpEndpoint(asString = "/b", method = HttpMethod.GET))
+        val outer = outer()
+        val a = outer.subRequest(endpoint("/a"))
+        val b = outer.subRequest(endpoint("/b"))
 
-        assertNotEquals(a.requestId, b.requestId)
-        assertEquals(outerId, a.parentRequestId)
-        assertEquals(outerId, b.parentRequestId)
+        assertNotEquals(a.executionId, b.executionId)
+        assertEquals(outerId, a.causedBy)
+        assertEquals(outerId, b.causedBy)
     }
 
     @Test
-    fun `copyWithNewPathType preserves identity`() {
-        val outer = request(outerId)
-        val copied = outer.copyWithNewPathType<PathSpec>(
-            RawHttpEndpoint(asString = "/elsewhere", method = HttpMethod.GET)
-        )
+    fun `nesting keeps the root while the parent follows the nesting`() {
+        val inner = outer().subRequest(endpoint("/a")).subRequest(endpoint("/b"))
 
-        assertEquals(outerId, copied.requestId)
-        assertNull(copied.parentRequestId)
+        assertEquals(outerId, inner.rootExecutionId)
+        assertNotEquals(outerId, inner.causedBy)
     }
 }

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ImplementationHelpersHandleTest.kt
@@ -140,8 +140,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.OK, resp.status)
                 assertNotNull(resp.body)
@@ -163,8 +163,8 @@ class ImplementationHelpersHandleTest {
                     domain = "example.com",
                     protocol = "https",
                     sourceIp = "local",
-                    requestId = generateRequestId(),
-                )
+                ),
+                generateRequestId(),
             )
             assertEquals(HttpStatus.OK, resp.status)
             assertEquals("pong", resp.body!!.text())
@@ -195,8 +195,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 // On success, translation should set NoContent and remove body
                 assertEquals(HttpStatus.NoContent, resp.status)
@@ -231,8 +231,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 // Should be NoContent with Access-Control-Allow-Methods including GET, POST, HEAD
                 assertEquals(HttpStatus.NoContent, resp.status)
@@ -269,8 +269,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 // Expect a redirect with Location header pointing to alternate form
                 assertEquals(HttpStatus.TemporaryRedirect, resp.status)
@@ -306,8 +306,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 // Should succeed directly, NOT redirect (which would cause infinite loop)
                 assertEquals(HttpStatus.OK, resp.status, "Request to /slash/ should succeed directly")
@@ -340,8 +340,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 // Expect a redirect with Location header pointing to alternate form
                 println(resp)
@@ -374,8 +374,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 // Expect a redirect with Location header pointing to alternate form
                 println(resp)
@@ -415,8 +415,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.ServiceUnavailable, resp.status)
             }
@@ -439,8 +439,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.NotFound, resp.status)
                 assertEquals(
@@ -490,8 +490,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.TooManyRequests, resp.status)
                 assertEquals(
@@ -516,8 +516,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
                 assertEquals(
@@ -542,8 +542,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "http",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
                 assertNull(
@@ -568,8 +568,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.NotFound, resp.status)
                 assertEquals("nosniff", resp.headers[HttpHeader.XContentTypeOptions]?.root)
@@ -594,8 +594,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.OK, resp.status)
                 assertEquals("quick", resp.body?.text())
@@ -629,8 +629,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 // Small payload should not be compressed even if gzip is accepted
                 assertNull(resp.headers[HttpHeader.ContentEncoding])
@@ -665,8 +665,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.OK, resp.status)
                 // Should have content-encoding: gzip and body compressed
@@ -692,8 +692,8 @@ class ImplementationHelpersHandleTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
                 assertEquals(HttpStatus.OK, resp.status)
                 assertEquals("gzip", resp.headers[HttpHeader.ContentEncoding]?.root)

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/InitiatorTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/InitiatorTest.kt
@@ -1,0 +1,59 @@
+package com.lightningkite.lightningserver.runtime
+
+import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.http.PathSegments
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
+import com.lightningkite.lightningserver.pathing.RawWebSocketPath
+import com.lightningkite.lightningserver.roundTripTest
+import kotlin.test.Test
+import kotlin.uuid.Uuid
+
+/**
+ * An initiator crosses a task queue and the DynamoDB socket row, so a subtype that cannot round-trip
+ * is a socket dropped on deploy or a task that cannot say what launched it — neither of which would
+ * show up at compile time.
+ */
+@OptIn(InternalLightningServerApi::class)
+class InitiatorTest {
+    private val execution = Uuid.parse("00000000-0000-4000-8000-000000000001")
+    private val root = Uuid.parse("00000000-0000-4000-8000-000000000002")
+    private val socket = Uuid.parse("00000000-0000-4000-8000-000000000003")
+    private val location = PathSegments.parse("tasks/reindex")
+
+    @Test
+    fun `every subtype survives a round trip`() {
+        Initiator.Http(
+            executionId = execution,
+            causedBy = root,
+            rootExecutionId = root,
+            endpoint = RawHttpEndpoint<PathSpec>(asString = "/users/abc", method = HttpMethod.GET),
+        ).roundTripTest()
+        Initiator.WebSocket(
+            executionId = execution,
+            rootExecutionId = execution,
+            socketId = socket,
+            path = RawWebSocketPath<PathSpec>("/updates"),
+            phase = Initiator.WebSocket.Phase.ClientMessage,
+        ).roundTripTest()
+        Initiator.Task(
+            executionId = execution,
+            causedBy = root,
+            rootExecutionId = root,
+            attributedTo = root,
+            location = location,
+        ).roundTripTest()
+        Initiator.Schedule(executionId = execution, attributedTo = execution, location = location).roundTripTest()
+        Initiator.Startup(executionId = execution, location = location).roundTripTest()
+        Initiator.PreDeploy(executionId = execution, location = location).roundTripTest()
+        Initiator.Direct(executionId = execution).roundTripTest()
+    }
+
+    /** Polymorphic dispatch is what makes the persisted form readable back as the right subtype. */
+    @Test
+    fun `a subtype survives a round trip through the sealed interface`() {
+        val initiator: Initiator = Initiator.Task(executionId = execution, attributedTo = execution, location = location)
+        initiator.roundTripTest()
+    }
+}

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/HttpSpanTest.kt
@@ -62,8 +62,8 @@ class HttpSpanTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
             }
 
@@ -125,8 +125,8 @@ class HttpSpanTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
-                    )
+                    ),
+                    generateRequestId(),
                 )
             }
 

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/websockets/DirectWebSocketSenderTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/websockets/DirectWebSocketSenderTest.kt
@@ -1,7 +1,6 @@
 // Fixed by Claude - added delay(50) after test() to allow didConnect() subscription to complete
 package com.lightningkite.lightningserver.websockets
 
-import com.lightningkite.lightningserver.http.generateRequestId
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.http.PathSegments
 import com.lightningkite.lightningserver.pathing.PathSpec0
@@ -87,7 +86,6 @@ class DirectWebSocketSenderTest {
         // Test that engineSocketId can be explicitly set in a request
         val request = WebSocketConnectRequest<PathSpec0>(
             path = RawWebSocketPath(PathSegments.EMPTY),
-            requestId = generateRequestId(),
             engineSocketId = "test-socket-123"
         )
 
@@ -99,7 +97,6 @@ class DirectWebSocketSenderTest {
         // Verify that Storage correctly preserves the request's engineSocketId
         val request = WebSocketConnectRequest<PathSpec0>(
             path = RawWebSocketPath(PathSegments.EMPTY),
-            requestId = generateRequestId(),
             engineSocketId = "aws-connection-id-xyz"
         )
 

--- a/docs-guide/guide/bulk-endpoints.md
+++ b/docs-guide/guide/bulk-endpoints.md
@@ -177,21 +177,19 @@ fun bulkTest() = BulkServer.testBlocking(settings = {}) {
     // Drive /meta/bulk through the full HTTP pipeline so the framework can resolve
     // sub-request paths via the registered route table.  ApiHttpHandler.test() would
     // bypass routing and cannot match sub-request paths, so we use serverRuntime.handle().
-    val response = serverRuntime.handle(
-        HttpRequest<PathSpec>(
-            path = RawHttpEndpoint(asString = "/meta/bulk", method = HttpMethod.POST),
-            queryParameters = QueryParameters.EMPTY,
-            headers = HttpHeaders.EMPTY,
-            domain = "example.com",
-            protocol = "https",
-            sourceIp = "local",
-            requestId = generateRequestId(),
-            body = TypedData.text(
-                """{"ping":{"path":"/ping","method":"GET"},"gone":{"path":"/missing","method":"GET"}}""",
-                MediaType.Application.Json,
-            ),
-        )
+    val request = HttpRequest<PathSpec>(
+        path = RawHttpEndpoint(asString = "/meta/bulk", method = HttpMethod.POST),
+        queryParameters = QueryParameters.EMPTY,
+        headers = HttpHeaders.EMPTY,
+        domain = "example.com",
+        protocol = "https",
+        sourceIp = "local",
+        body = TypedData.text(
+            """{"ping":{"path":"/ping","method":"GET"},"gone":{"path":"/missing","method":"GET"}}""",
+            MediaType.Application.Json,
+        ),
     )
+    val response = serverRuntime.handle(request, generateRequestId())
 
     // The outer bulk endpoint always returns HTTP 200; per-sub-request errors appear in the body.
     check(response.status.code == 200)

--- a/docs-guide/src/samples/kotlin/com/lightningkite/lightningserver/guide/samples/BulkEndpointsSamples.kt
+++ b/docs-guide/src/samples/kotlin/com/lightningkite/lightningserver/guide/samples/BulkEndpointsSamples.kt
@@ -61,21 +61,19 @@ fun bulkTest() = BulkServer.testBlocking(settings = {}) {
     // Drive /meta/bulk through the full HTTP pipeline so the framework can resolve
     // sub-request paths via the registered route table.  ApiHttpHandler.test() would
     // bypass routing and cannot match sub-request paths, so we use serverRuntime.handle().
-    val response = serverRuntime.handle(
-        HttpRequest<PathSpec>(
-            path = RawHttpEndpoint(asString = "/meta/bulk", method = HttpMethod.POST),
-            queryParameters = QueryParameters.EMPTY,
-            headers = HttpHeaders.EMPTY,
-            domain = "example.com",
-            protocol = "https",
-            sourceIp = "local",
-            requestId = generateRequestId(),
-            body = TypedData.text(
-                """{"ping":{"path":"/ping","method":"GET"},"gone":{"path":"/missing","method":"GET"}}""",
-                MediaType.Application.Json,
-            ),
-        )
+    val request = HttpRequest<PathSpec>(
+        path = RawHttpEndpoint(asString = "/meta/bulk", method = HttpMethod.POST),
+        queryParameters = QueryParameters.EMPTY,
+        headers = HttpHeaders.EMPTY,
+        domain = "example.com",
+        protocol = "https",
+        sourceIp = "local",
+        body = TypedData.text(
+            """{"ping":{"path":"/ping","method":"GET"},"gone":{"path":"/missing","method":"GET"}}""",
+            MediaType.Application.Json,
+        ),
     )
+    val response = serverRuntime.handle(request, generateRequestId())
 
     // The outer bulk endpoint always returns HTTP 200; per-sub-request errors appear in the body.
     check(response.status.code == 200)

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterHttp.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterHttp.kt
@@ -1,5 +1,7 @@
 package com.lightningkite.lightningserver.engine.awsserverless
 
+import com.lightningkite.lightningserver.pathing.PathSpec
+import kotlin.uuid.Uuid
 import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
@@ -28,20 +30,20 @@ internal class AwsAdapterHttp(val root: AwsAdapter) {
             ?: emptyList()
 
         val request = HttpRequest(
-            path = RawHttpEndpoint(event.path.removePrefix("/" + event.requestContext.stage), method),
+            path = RawHttpEndpoint<PathSpec>(event.path.removePrefix("/" + event.requestContext.stage), method),
             queryParameters = QueryParameters(queryParams),
             headers = headers,
             body = body,
             domain = event.requestContext.domainName,
             protocol = "https",
             sourceIp = event.requestContext.identity.sourceIp,
-            requestId = generateRequestId(),
             upstreamRequestId = headers[HttpHeader.XRequestId]?.root,
             // API Gateway's ID is not a UUID, so it is kept as the join key to the gateway's own
             // access logs rather than adopted as ours.
             engineRequestId = event.requestContext.requestId,
         )
-        val result = root.handle(request)
+        // API Gateway's ID is not a UUID, so we always mint our own execution id.
+        val result = root.handle(request, Uuid.random())
         return result.toAws()
     }
 }

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.engine.awsserverless
 
+import kotlin.uuid.Uuid
 import com.lightningkite.lightningserver.AnonType
 import com.lightningkite.lightningserver.HttpStatusException
 import com.lightningkite.lightningserver.definition.generalSettings
@@ -43,6 +44,8 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
     data class WebSocketDidConnect(
         val socketId: String,
         val connection: WebSocketConnectRequest<Nothing>,
+        /** `didConnect` is its own Lambda invocation, so the socket's identity has to travel with it. */
+        val initiator: Initiator.WebSocket,
         val storage: AnonType,
     ) : AwsLambdaInput
 
@@ -264,6 +267,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                             h.messageFromSubscriptionWithMetrics(
                                 p.pathSpec,
                                 root,
+                                s.initiator.phase(Initiator.WebSocket.Phase.SubscriptionMessage),
                                 mid,
                                 WebSocketSubscriptionMessage(
                                     fullTopicMatch.value,
@@ -350,6 +354,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                 rootWs.didConnectWithMetrics(
                     rootPath,
                     root,
+                    event.initiator.phase(Initiator.WebSocket.Phase.Connected),
                     mid
                 )
                 return APIGatewayV2HTTPResponse(200)
@@ -396,18 +401,29 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                     domain = event.requestContext.domainName,
                     protocol = "https",
                     sourceIp = event.requestContext.identity.sourceIp ?: "0.0.0.0",
-                    // Generated once here, at $connect, and persisted with the connection state, so it
-                    // is stable for the socket's whole lifetime — the correlation scope wanted for a
-                    // connection. The gateway's connection ID is not a UUID and stays in
-                    // [engineSocketId], which is where the join to the gateway's logs comes from.
-                    requestId = generateRequestId(),
                     upstreamRequestId = headers[HttpHeader.XRequestId]?.root,
                     engineSocketId = event.requestContext.connectionId
                 )
+                // Minted once here, at $connect, and persisted with the connection state, so the socket
+                // is one identity across the five separate Lambda invocations its lifetime is made of.
+                // The gateway's connection ID is not a UUID and stays in [engineSocketId], which is where
+                // the join to the gateway's own logs comes from.
+                val socketId = Uuid.random()
+                val connectInitiator = Initiator.WebSocket(
+                    executionId = socketId,
+                    socketId = socketId,
+                    path = lkEvent.path,
+                    phase = Initiator.WebSocket.Phase.Connect,
+                )
                 try {
-                    val storage = rootWs.willConnectWithMetrics(rootPath, root, lkEvent)
+                    val storage = rootWs.willConnectWithMetrics(rootPath, root, connectInitiator, lkEvent)
                     val storageBytes = encoding.encodeToByteArray(rootWs.storageSerializer, storage)
-                    webSocketDynamo.setState(event.requestContext.connectionId, lkEvent, storageBytes)
+                    webSocketDynamo.setState(
+                        event.requestContext.connectionId,
+                        lkEvent,
+                        connectInitiator,
+                        storageBytes,
+                    )
                     try {
                         root.invokeLambda(InvokeRequest.builder().also {
                             it.functionName(System.getenv("AWS_LAMBDA_FUNCTION_NAME"))
@@ -422,6 +438,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                                         WebSocketDidConnect(
                                             event.requestContext.connectionId,
                                             lkEvent as WebSocketConnectRequest<Nothing>,
+                                            connectInitiator,
                                             AnonType(storageBytes)
                                         )
                                     )
@@ -457,6 +474,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                         rootWs.disconnectWithMetrics(
                             rootPath,
                             root,
+                            state.initiator.phase(Initiator.WebSocket.Phase.Disconnect),
                             mid,
                             WebSocketClose.NORMAL
                         )
@@ -501,6 +519,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                         rootWs.messageFromClientWithMetrics(
                             rootPath,
                             root,
+                            state.initiator.phase(Initiator.WebSocket.Phase.ClientMessage),
                             mid,
                             WebSocketFrame(event.body)
                         )

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsWebSocketDynamoDb.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsWebSocketDynamoDb.kt
@@ -2,6 +2,7 @@
 
 package com.lightningkite.lightningserver.engine.awsserverless
 
+import com.lightningkite.lightningserver.runtime.Initiator
 import com.lightningkite.lightningserver.websockets.WebSocketConnectRequest
 import com.lightningkite.services.serializers.KotlinBytesFormat
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -23,7 +24,16 @@ internal class AwsWebSocketDynamoDb(
     val baseTableName: String,
     val encoding: KotlinBytesFormat,
 ) {
-    class StateAndConnectRequest(val state: ByteArray, val connectRequest: WebSocketConnectRequest<*>)
+    class StateAndConnectRequest(
+        val state: ByteArray,
+        val connectRequest: WebSocketConnectRequest<*>,
+        /**
+         * The socket's connect initiator. Persisted beside the request because each of the five
+         * lifecycle phases is a separate Lambda invocation: without it, nothing after `${'$'}connect`
+         * could say which socket it belongs to.
+         */
+        val initiator: Initiator.WebSocket,
+    )
 
     private val socketExpiration = 8.hours
     private val tableSubs = "$baseTableName-ws-subs"
@@ -42,6 +52,7 @@ internal class AwsWebSocketDynamoDb(
         private const val stateKey = "wsState"
         private const val fromStateKey = "wsFromState"
         private const val requestKey = "wsRequest"
+        private const val initiatorKey = "wsInitiator"
     }
 
     private val initMutex = Mutex()
@@ -210,7 +221,7 @@ internal class AwsWebSocketDynamoDb(
         val out = HashMap<String, StateAndConnectRequest>()
         client.scanPaginator {
             it.tableName(tableStates)
-            it.projectionExpression("$socketIdKey, $stateKey, $requestKey")
+            it.projectionExpression("$socketIdKey, $stateKey, $requestKey, $initiatorKey")
         }.asFlow().collect {
             it.items()?.forEach {
                 out[it[socketIdKey]!!.s()] = StateAndConnectRequest(
@@ -218,6 +229,10 @@ internal class AwsWebSocketDynamoDb(
                     encoding.decodeFromByteArray(
                         WebSocketConnectRequest.serializer(NothingSerializer()),
                         it[requestKey]!!.b().asByteArray()
+                    ),
+                    encoding.decodeFromByteArray(
+                        Initiator.WebSocket.serializer(),
+                        it[initiatorKey]!!.b().asByteArray()
                     )
                 )
             }
@@ -237,7 +252,7 @@ internal class AwsWebSocketDynamoDb(
             val response = client.getItem {
                 it.tableName(tableStates)
                 it.key(mapOf(socketIdKey to AttributeValue.fromS(id)))
-                it.projectionExpression("$stateKey, $requestKey")
+                it.projectionExpression("$stateKey, $requestKey, $initiatorKey")
                 it.consistentRead(true)
             }.await()
             // item() is an SDK auto-construct map: it returns empty rather than null when the socket
@@ -249,6 +264,10 @@ internal class AwsWebSocketDynamoDb(
                     encoding.decodeFromByteArray(
                         WebSocketConnectRequest.serializer(NothingSerializer()),
                         it[requestKey]!!.b().asByteArray()
+                    ),
+                    encoding.decodeFromByteArray(
+                        Initiator.WebSocket.serializer(),
+                        it[initiatorKey]!!.b().asByteArray()
                     ),
                 )
             }
@@ -280,7 +299,7 @@ internal class AwsWebSocketDynamoDb(
         val out = HashMap<String, StateAndConnectRequest>()
         measureTime {
             val getState = KeysAndAttributes.builder()
-                .projectionExpression("$socketIdKey, $stateKey, $requestKey")
+                .projectionExpression("$socketIdKey, $stateKey, $requestKey, $initiatorKey")
                 .consistentRead(true)
                 .keys(ids.map { mapOf(socketIdKey to AttributeValue.fromS(it)) }).build()
             client.batchGetItemPaginator {
@@ -292,6 +311,10 @@ internal class AwsWebSocketDynamoDb(
                         encoding.decodeFromByteArray(
                             WebSocketConnectRequest.serializer(NothingSerializer()),
                             it[requestKey]!!.b().asByteArray()
+                        ),
+                        encoding.decodeFromByteArray(
+                            Initiator.WebSocket.serializer(),
+                            it[initiatorKey]!!.b().asByteArray()
                         )
                     )
                 }
@@ -300,7 +323,12 @@ internal class AwsWebSocketDynamoDb(
         return out
     }
 
-    suspend fun setState(socketId: String, request: WebSocketConnectRequest<*>, toState: ByteArray) {
+    suspend fun setState(
+        socketId: String,
+        request: WebSocketConnectRequest<*>,
+        initiator: Initiator.WebSocket,
+        toState: ByteArray,
+    ) {
         ensureTables()
         measureTime {
             client.putItem {
@@ -316,6 +344,11 @@ internal class AwsWebSocketDynamoDb(
                                     WebSocketConnectRequest.serializer(NothingSerializer()),
                                     request as WebSocketConnectRequest<Nothing>
                                 )
+                            )
+                        ),
+                        initiatorKey to AttributeValue.fromB(
+                            SdkBytes.fromByteArray(
+                                encoding.encodeToByteArray(Initiator.WebSocket.serializer(), initiator)
                             )
                         ),
                         expireKey to AttributeValue.fromN(

--- a/engine-jdk-server/src/main/kotlin/com/lightningkite/lightningserver/engine/jdk/JdkEngine.kt
+++ b/engine-jdk-server/src/main/kotlin/com/lightningkite/lightningserver/engine/jdk/JdkEngine.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.engine.jdk
 
+import kotlin.uuid.Uuid
 import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.plainText
 import com.lightningkite.lightningserver.definition.ServerDefinition
@@ -132,10 +133,11 @@ public class JdkEngine(
                     exchange.respondPlain(HttpStatus.PayloadTooLarge.code, "Payload Too Large")
                     return@createContext
                 }
-                val request = exchange.requestToLightningServer(cfg.realIpHeader, cfg.requestIdHeader, this@JdkEngine, maxBody)
+                val (request, executionId) =
+                    exchange.requestToLightningServer(cfg.realIpHeader, cfg.requestIdHeader, this@JdkEngine, maxBody)
                 // Request timeout is enforced centrally in ServerRuntime.handle (per-handler HttpHandler.timeout).
                 runBlocking {
-                    val result: HttpResponse = this@JdkEngine.handle(request)
+                    val result: HttpResponse = this@JdkEngine.handle(request, executionId)
                     exchange.write(result)
                 }
             } catch (e: BodyTooLargeException) {
@@ -271,7 +273,7 @@ private fun HttpExchange.requestToLightningServer(
     requestIdHeader: String?,
     engine: JdkEngine,
     maxBody: Long,
-): HttpRequest<PathSpec> {
+): Pair<HttpRequest<PathSpec>, Uuid> {
     val method = this.requestMethod
     val uri = this.requestURI
     val queryParams = QueryParameters.parse(uri.rawQuery ?: "")
@@ -300,17 +302,17 @@ private fun HttpExchange.requestToLightningServer(
         engine.logger.warn { "Request ID header for proxy '$requestIdHeader' was missing from the request." }
     }
 
-    return HttpRequest(
-        path = RawHttpEndpoint(uri.path ?: "/", HttpMethod(method)),
+    val adapted = HttpRequest(
+        path = RawHttpEndpoint<PathSpec>(uri.path ?: "/", HttpMethod(method)),
         queryParameters = queryParams,
         headers = headers,
         domain = domain,
         protocol = protocol,
         sourceIp = sourceIp,
-        requestId = identity.requestId,
         upstreamRequestId = identity.upstreamRequestId,
         body = body
     )
+    return adapted to identity.requestId
 }
 
 /**

--- a/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/KtorEngine.kt
+++ b/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/KtorEngine.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalLightningServerApi::class)
+
 package com.lightningkite.lightningserver.engine.ktor
 
 import com.lightningkite.lightningserver.HttpStatusException
@@ -14,6 +16,10 @@ import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.logger
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.RawWebSocketPath
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.runtime.phase
 import com.lightningkite.lightningserver.runtime.didConnectWithMetrics
 import com.lightningkite.lightningserver.runtime.disconnectWithMetrics
 import com.lightningkite.lightningserver.runtime.handle
@@ -140,10 +146,10 @@ public class KtorEngine(
                         call.respondText("Payload Too Large", status = HttpStatusCode.PayloadTooLarge)
                         return@handle
                     }
-                    val request = call.adapt(maxBody)
+                    val (request, executionId) = call.adapt(maxBody)
                     // Request timeout is enforced centrally in ServerRuntime.handle (per-handler HttpHandler.timeout).
                     val result: HttpResponse = try {
-                        this@KtorEngine.handle(request)
+                        this@KtorEngine.handle(request, executionId)
                     } catch (_: BodyTooLargeException) {
                         // 2.5: streamed body exceeded the cap mid-read.
                         HttpResponse.plainText("Payload Too Large", HttpStatus.PayloadTooLarge)
@@ -222,7 +228,6 @@ public class KtorEngine(
                     path = RawWebSocketPath(queryParams["path"] ?: call.request.path().decodeURLPart()),
                     queryParameters = queryParams,
                     headers = adaptedHeaders,
-                    requestId = identity.requestId,
                     upstreamRequestId = identity.upstreamRequestId,
                     domain = call.request.origin.serverHost,
                     protocol = call.request.origin.scheme,
@@ -245,6 +250,15 @@ public class KtorEngine(
                     return@webSocket
                 }
                 val socketHandler = server.interceptIncomingSocket(match.value)
+
+                // The socket's identity is minted once, here, and every phase below derives its own
+                // execution from it, so a socket stays one thing across five separate executions.
+                val connectInitiator = Initiator.WebSocket(
+                    executionId = identity.requestId,
+                    socketId = identity.requestId,
+                    path = request.path,
+                    phase = Initiator.WebSocket.Phase.Connect,
+                )
 
                 // Check for direct execution capability - bypasses pub/sub overhead
                 if (socketHandler is DirectExecutableWebSocketHandler<*> && !forceWebSocketPubSub()) {
@@ -282,8 +296,10 @@ public class KtorEngine(
                     }
 
                     // Run handler directly - no pub/sub, no task indirection
+                    // A directly-run socket is not phase-structured — the whole session runs in this
+                    // one coroutine — so it is one execution, named by the socket it is.
                     directHandler.handleDirect(
-                        serverRuntime = this@KtorEngine,
+                        serverRuntime = this@KtorEngine.forExecution(connectInitiator),
                         request = request,
                         incoming = incomingChannel,
                         send = { frame ->
@@ -301,13 +317,15 @@ public class KtorEngine(
                     @Suppress("UNCHECKED_CAST")
                     socketHandler as WebSocketHandler<PathSpec, Any?>
 
-                    val startingState = socketHandler.willConnectWithMetrics(match.pathSpec, this@KtorEngine, request)
+                    val startingState =
+                        socketHandler.willConnectWithMetrics(match.pathSpec, this@KtorEngine, connectInitiator, request)
                     var closingMid: WebSocketConnection<PathSpec, Any?>? = null
                     try {
 
                         val mid = object : LocalWebSocketConnection<PathSpec, Any?>(
                             startingState = startingState,
                             request = request,
+                            connectInitiator = connectInitiator,
                             handler = socketHandler,
                             scope = this@webSocket,
                             server = this@KtorEngine,
@@ -328,7 +346,12 @@ public class KtorEngine(
                         }
                         closingMid = mid
 
-                        socketHandler.didConnectWithMetrics(match.pathSpec, this@KtorEngine, mid)
+                        socketHandler.didConnectWithMetrics(
+                            match.pathSpec,
+                            this@KtorEngine,
+                            connectInitiator.phase(Initiator.WebSocket.Phase.Connected),
+                            mid,
+                        )
 
                         for (incoming in this.incoming) {
                             val m = when (incoming) {
@@ -338,13 +361,20 @@ public class KtorEngine(
                                 is Frame.Ping -> continue
                                 is Frame.Pong -> continue
                             }
-                            socketHandler.messageFromClientWithMetrics(match.pathSpec, this@KtorEngine, mid, m)
+                            socketHandler.messageFromClientWithMetrics(
+                                match.pathSpec,
+                                this@KtorEngine,
+                                connectInitiator.phase(Initiator.WebSocket.Phase.ClientMessage),
+                                mid,
+                                m,
+                            )
                         }
 
                         closingMid.let { mid ->
                             socketHandler.disconnectWithMetrics(
                                 match.pathSpec,
                                 this@KtorEngine,
+                                connectInitiator.phase(Initiator.WebSocket.Phase.Disconnect),
                                 mid,
                                 WebSocketClose.NORMAL
                             )
@@ -354,6 +384,7 @@ public class KtorEngine(
                             socketHandler.disconnectWithMetrics(
                                 match.pathSpec,
                                 this@KtorEngine,
+                                connectInitiator.phase(Initiator.WebSocket.Phase.Disconnect),
                                 mid,
                                 ((e as? HttpStatusException)?.status
                                     ?: HttpStatus.InternalServerError).bestWebSocketCloseCode

--- a/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/extensions.kt
+++ b/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/extensions.kt
@@ -7,6 +7,7 @@ import com.lightningkite.lightningserver.logger
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
 import com.lightningkite.lightningserver.runtime.ServerRuntimeBase
+import kotlin.uuid.Uuid
 import com.lightningkite.services.data.MediaType
 import com.lightningkite.services.data.TypedData
 import io.ktor.http.*
@@ -34,16 +35,15 @@ internal fun Headers.adapt(): HttpHeaders = HttpHeaders(flattenEntries())
  * Falls back to the origin remote address if the header is not present.
  */
 context(server: ServerRuntimeBase)
-internal suspend fun ApplicationCall.adapt(maxBody: Long): HttpRequest<PathSpec> {
+internal suspend fun ApplicationCall.adapt(maxBody: Long): Pair<HttpRequest<PathSpec>, Uuid> {
     val adaptedHeaders = request.headers.adapt()
     val identity = adaptedHeaders.requestIdentity(ktorRunConfig().requestIdHeader) {
         server.logger.warn { "Request ID header for proxy '${ktorRunConfig().requestIdHeader}' was missing from the request." }
     }
-    return HttpRequest(
+    val adapted = HttpRequest(
         path = RawHttpEndpoint(request.path().decodeURLPart(), HttpMethod(request.httpMethod.value)),
         queryParameters = QueryParameters(request.queryParameters.flattenEntries()),
         headers = adaptedHeaders,
-        requestId = identity.requestId,
         upstreamRequestId = identity.upstreamRequestId,
         domain = request.origin.serverHost,
         protocol = request.origin.scheme,
@@ -65,6 +65,7 @@ internal suspend fun ApplicationCall.adapt(maxBody: Long): HttpRequest<PathSpec>
             )
         },
     )
+    return adapted to identity.requestId
 }
 
 // TODO: Implement MultiPart support - the code below is a partial implementation that needs completion

--- a/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
+++ b/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
@@ -3,7 +3,10 @@ package com.lightningkite.lightningserver.engine.local
 import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.path
+import com.lightningkite.lightningserver.runtime.Initiator
 import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.runtime.phase
 import com.lightningkite.lightningserver.websockets.*
 import com.lightningkite.services.pubsub.PubSubChannel
 import kotlinx.coroutines.CoroutineScope
@@ -21,6 +24,8 @@ import kotlinx.coroutines.yield
 public abstract class LocalWebSocketConnection<PATH : PathSpec, STORAGE>(
     startingState: STORAGE,
     override val request: WebSocketConnectRequest<PATH>,
+    /** The socket's connect initiator, so a delivery can name the socket it is being delivered to. */
+    public val connectInitiator: Initiator.WebSocket,
     private val handler: WebSocketHandler<PATH, STORAGE>,
     private val scope: CoroutineScope,
     /** Needed to deliver a subscription message, which is a fresh execution rather than part of one. */
@@ -50,7 +55,7 @@ public abstract class LocalWebSocketConnection<PATH : PathSpec, STORAGE>(
         subscriptions.remove(topic)?.cancel()
         subscriptions[topic] = scope.launch {
             pubSub(topic).collect { value ->
-                with(server) {
+                with(server.forExecution(connectInitiator.phase(Initiator.WebSocket.Phase.SubscriptionMessage))) {
                     handler.messageFromSubscription(
                         this@LocalWebSocketConnection,
                         WebSocketSubscriptionMessage(topic.topic, topic.pathInContext.rawPathArguments, value),

--- a/engine-netty/src/main/kotlin/com/lightningkite/lightningserver/engine/netty/NettyEngine.kt
+++ b/engine-netty/src/main/kotlin/com/lightningkite/lightningserver/engine/netty/NettyEngine.kt
@@ -1,5 +1,8 @@
+@file:OptIn(InternalLightningServerApi::class)
+
 package com.lightningkite.lightningserver.engine.netty
 
+import kotlin.uuid.Uuid
 import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.HttpStatusException
 import com.lightningkite.lightningserver.NotFoundException
@@ -7,7 +10,11 @@ import com.lightningkite.lightningserver.definition.ServerDefinition
 import com.lightningkite.lightningserver.engine.local.LocalEngine
 import com.lightningkite.lightningserver.engine.local.WsOversizePolicy
 import com.lightningkite.lightningserver.engine.local.forceWebSocketPubSub
+import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.engine.local.LocalWebSocketConnection
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.runtime.phase
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.http.HttpHeaders
 import com.lightningkite.lightningserver.http.HttpRequest
@@ -111,6 +118,7 @@ public class NettyEngine(
     private lateinit var HANDSHAKER_KEY: AttributeKey<WebSocketServerHandshaker>
     private lateinit var MID_KEY: AttributeKey<WebSocketConnection<PathSpec, Any?>>
     private lateinit var PATHSPEC_KEY: AttributeKey<PathSpec>
+    private lateinit var INITIATOR_KEY: AttributeKey<Initiator.WebSocket>
     private lateinit var HANDLER_KEY: AttributeKey<WebSocketHandler<PathSpec, Any?>>
     private lateinit var DIRECT_CHANNEL_KEY: AttributeKey<SendChannel<LkWebSocketFrame>>
 
@@ -174,6 +182,7 @@ public class NettyEngine(
         HANDSHAKER_KEY = AttributeKey.valueOf("HANDSHAKER")
         MID_KEY = AttributeKey.valueOf("MID")
         PATHSPEC_KEY = AttributeKey.valueOf("PATHSPEC")
+        INITIATOR_KEY = AttributeKey.valueOf("SOCKET_INITIATOR")
         HANDLER_KEY = AttributeKey.valueOf("SOCKET_HANDLER")
         DIRECT_CHANNEL_KEY = AttributeKey.valueOf("DIRECT_CHANNEL")
 
@@ -279,12 +288,12 @@ public class NettyEngine(
                             handleWebSocketStartup(ctx, msg)
                         }
                     } else {
-                        val request = msg.toLightningHttpRequest(ctx, cfg)
+                        val (request, executionId) = msg.toLightningHttpRequest(ctx, cfg)
                         scope.launch(ctx.executor().asCoroutineDispatcher()) {
                             try {
                                 try {
                                     // Request timeout is enforced centrally in ServerRuntime.handle (per-handler HttpHandler.timeout).
-                                    val result: HttpResponse = this@NettyEngine.handle(request)
+                                    val result: HttpResponse = this@NettyEngine.handle(request, executionId)
                                     val nettyRes = result.toNettyResponse(msg.protocolVersion())
                                     val keepAlive = HttpUtil.isKeepAlive(msg)
                                     if (keepAlive) {
@@ -331,9 +340,16 @@ public class NettyEngine(
                         val mid = ctx.channel().attr(MID_KEY).get() ?: return
                         val handler = ctx.channel().attr(HANDLER_KEY).get() ?: return
                         val pathspec = ctx.channel().attr(PATHSPEC_KEY).get() ?: return
+                        val socketInitiator = ctx.channel().attr(INITIATOR_KEY).get() ?: return
                         scope.launch(ctx.executor().asCoroutineDispatcher()) {
                             try {
-                                handler.messageFromClientWithMetrics(pathspec, this@NettyEngine, mid, m)
+                                handler.messageFromClientWithMetrics(
+                                    pathspec,
+                                    this@NettyEngine,
+                                    socketInitiator.phase(Initiator.WebSocket.Phase.ClientMessage),
+                                    mid,
+                                    m,
+                                )
                             } catch (e: Exception) {
                                 mid.close(
                                     ((e as? HttpStatusException)?.status
@@ -355,9 +371,16 @@ public class NettyEngine(
                         val mid = ctx.channel().attr(MID_KEY).get() ?: return
                         val handler = ctx.channel().attr(HANDLER_KEY).get() ?: return
                         val pathspec = ctx.channel().attr(PATHSPEC_KEY).get() ?: return
+                        val socketInitiator = ctx.channel().attr(INITIATOR_KEY).get() ?: return
                         scope.launch(ctx.executor().asCoroutineDispatcher()) {
                             try {
-                                handler.messageFromClientWithMetrics(pathspec, this@NettyEngine, mid, m)
+                                handler.messageFromClientWithMetrics(
+                                    pathspec,
+                                    this@NettyEngine,
+                                    socketInitiator.phase(Initiator.WebSocket.Phase.ClientMessage),
+                                    mid,
+                                    m,
+                                )
                             } catch (e: Exception) {
                                 mid.close(
                                     ((e as? HttpStatusException)?.status
@@ -378,10 +401,17 @@ public class NettyEngine(
                         val mid = ctx.channel().attr(MID_KEY).get()
                         val handler = ctx.channel().attr(HANDLER_KEY).get()
                         val pathspec = ctx.channel().attr(PATHSPEC_KEY).get()
-                        if (mid != null && handler != null && pathspec != null) {
+                        val socketInitiator = ctx.channel().attr(INITIATOR_KEY).get()
+                        if (mid != null && handler != null && pathspec != null && socketInitiator != null) {
                             scope.launch(ctx.executor().asCoroutineDispatcher()) {
                                 try {
-                                    handler.disconnectWithMetrics(pathspec, this@NettyEngine, mid, WebSocketClose.NORMAL)
+                                    handler.disconnectWithMetrics(
+                                        pathspec,
+                                        this@NettyEngine,
+                                        socketInitiator.phase(Initiator.WebSocket.Phase.Disconnect),
+                                        mid,
+                                        WebSocketClose.NORMAL,
+                                    )
                                 } catch (e: Exception) {
                                     mid.close(
                                         ((e as? HttpStatusException)?.status
@@ -434,7 +464,7 @@ public class NettyEngine(
         }
 
         private suspend fun handleWebSocketStartup(ctx: ChannelHandlerContext, req: FullHttpRequest) {
-            val wsRequest = try {
+            val (wsRequest, wsInitiator) = try {
                 req.toLightningWebSocketConnectRequest(ctx, cfg)
             } catch (e: Throwable) {
                 logger.error(e) { "" }
@@ -486,8 +516,10 @@ public class NettyEngine(
                 handshaker.handshake(ctx.channel(), req).addListener {
                     scope.launch {
                         try {
+                            // A directly-run socket is not phase-structured — the whole session runs
+                            // in this one coroutine — so it is one execution, named by the socket it is.
                             directHandler.handleDirect(
-                                serverRuntime = this@NettyEngine,
+                                serverRuntime = this@NettyEngine.forExecution(wsInitiator),
                                 request = wsRequest,
                                 incoming = incomingChannel,
                                 send = { frame ->
@@ -516,7 +548,7 @@ public class NettyEngine(
                 socketHandler as WebSocketHandler<PathSpec, Any?>
 
                 val startingState = try {
-                    socketHandler.willConnectWithMetrics(match.pathSpec, this@NettyEngine, wsRequest)
+                    socketHandler.willConnectWithMetrics(match.pathSpec, this@NettyEngine, wsInitiator, wsRequest)
                 } catch (e: HttpStatusException) {
                     logger.error(e) { "" }
                     val res = DefaultFullHttpResponse(req.protocolVersion(), HttpResponseStatus.valueOf(e.status.code))
@@ -532,6 +564,7 @@ public class NettyEngine(
                 val mid = object : LocalWebSocketConnection<PathSpec, Any?>(
                     startingState = startingState,
                     request = wsRequest,
+                    connectInitiator = wsInitiator,
                     handler = socketHandler,
                     scope = CoroutineScope(Dispatchers.IO),
                     server = this@NettyEngine,
@@ -565,11 +598,17 @@ public class NettyEngine(
                 ctx.channel().attr(MID_KEY).set(mid)
                 ctx.channel().attr(HANDLER_KEY).set(socketHandler)
                 ctx.channel().attr(PATHSPEC_KEY).set(match.pathSpec)
+                ctx.channel().attr(INITIATOR_KEY).set(wsInitiator)
 
                 handshaker.handshake(ctx.channel(), req).addListener {
                     scope.launch {
                         try {
-                            socketHandler.didConnectWithMetrics(match.pathSpec, this@NettyEngine, mid)
+                            socketHandler.didConnectWithMetrics(
+                                match.pathSpec,
+                                this@NettyEngine,
+                                wsInitiator.phase(Initiator.WebSocket.Phase.Connected),
+                                mid,
+                            )
                         } catch (_: Throwable) {
                         }
                     }
@@ -618,7 +657,7 @@ public class NettyEngine(
         private fun FullHttpRequest.toLightningHttpRequest(
             ctx: ChannelHandlerContext,
             cfg: NettyRuntimeSettings,
-        ): HttpRequest<PathSpec> {
+        ): Pair<HttpRequest<PathSpec>, Uuid> {
 
             val parts = QueryStringDecoder(this.uri())
             val headers = (this.headers() as NettyHttpHeaders).toLightningHeaders()
@@ -646,24 +685,24 @@ public class NettyEngine(
                 logger.warn { "Request ID header for proxy '${cfg.requestIdHeader}' was missing from the request." }
             }
 
-            return HttpRequest(
-                path = RawHttpEndpoint(parts.path(), HttpMethod(this.method().name())),
+            val adapted = HttpRequest(
+                path = RawHttpEndpoint<PathSpec>(parts.path(), HttpMethod(this.method().name())),
                 queryParameters = QueryParameters(
                     parts.parameters().flatMap { (key, values) -> values.map { key to it } }),
                 headers = headers,
                 domain = domain.ifEmpty { (ctx.channel().localAddress() as? InetSocketAddress)?.hostString.orEmpty() },
                 protocol = "http",
                 sourceIp = sourceIp,
-                requestId = identity.requestId,
                 upstreamRequestId = identity.upstreamRequestId,
                 body = body,
             )
+            return adapted to identity.requestId
         }
 
         private fun FullHttpRequest.toLightningWebSocketConnectRequest(
             ctx: ChannelHandlerContext,
             cfg: NettyRuntimeSettings,
-        ): WebSocketConnectRequest<PathSpec> {
+        ): Pair<WebSocketConnectRequest<PathSpec>, Initiator.WebSocket> {
             val parts = QueryStringDecoder(this.uri())
             val headers = (this.headers() as NettyHttpHeaders).toLightningHeaders()
             val hostHeader = this.headers()[HOST] ?: ""
@@ -679,16 +718,23 @@ public class NettyEngine(
                 logger.warn { "Request ID header for proxy '${cfg.requestIdHeader}' was missing from the request." }
             }
 
-            return WebSocketConnectRequest(
-                path = RawWebSocketPath(parts.path()),
+            val adapted = WebSocketConnectRequest(
+                path = RawWebSocketPath<PathSpec>(parts.path()),
                 queryParameters = QueryParameters(
                     parts.parameters().flatMap { (key, values) -> values.map { key to it } }),
                 headers = headers,
                 domain = domain.ifEmpty { (ctx.channel().localAddress() as? InetSocketAddress)?.hostString.orEmpty() },
                 protocol = "http",
                 sourceIp = sourceIp,
-                requestId = identity.requestId,
                 upstreamRequestId = identity.upstreamRequestId,
+            )
+            // The socket's identity is minted once, at connect, and every phase derives its own
+            // execution from it, so a socket stays one thing across five separate executions.
+            return adapted to Initiator.WebSocket(
+                executionId = identity.requestId,
+                socketId = identity.requestId,
+                path = adapted.path,
+                phase = Initiator.WebSocket.Phase.Connect,
             )
         }
 

--- a/ratelimit/src/test/kotlin/com/lightningkite/lightningserver/ratelimit/RateLimitInterceptorTest.kt
+++ b/ratelimit/src/test/kotlin/com/lightningkite/lightningserver/ratelimit/RateLimitInterceptorTest.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.ratelimit
 
+import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.HttpStatusException
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
@@ -43,13 +44,12 @@ class RateLimiterTest {
     ) {
 
         val dummy = HttpRequest(
-            RawHttpEndpoint("", method = HttpMethod.GET),
+            RawHttpEndpoint<PathSpec>("", method = HttpMethod.GET),
             queryParameters = QueryParameters.EMPTY,
             headers = HttpHeaders(),
             domain = "Domain",
             protocol = "Http",
             sourceIp = "localhost",
-            requestId = generateRequestId(),
             body = null,
         )
         var successRequests = 0
@@ -242,13 +242,12 @@ class RateLimiterTest {
                 )
 
                 val dummy = HttpRequest(
-                    RawHttpEndpoint("", method = HttpMethod.GET),
+                    RawHttpEndpoint<PathSpec>("", method = HttpMethod.GET),
                     queryParameters = QueryParameters.EMPTY,
                     headers = HttpHeaders(),
                     domain = "Domain",
                     protocol = "Http",
                     sourceIp = "localhost",
-                    requestId = generateRequestId(),
                     body = null,
                 )
                 var successRequests = 0

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/AccessLogInterceptorTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/AccessLogInterceptorTest.kt
@@ -79,14 +79,13 @@ class AccessLogInterceptorTest {
         domain = "example.com",
         protocol = "https",
         sourceIp = "10.0.0.1",
-        requestId = requestIdUnderTest,
     )
 
     @Test
     fun `an http line carries the outcome and the request id`() {
         var lines: List<String> = emptyList()
         TestServer.test(settings = {}) {
-            lines = capturing { runBlocking { serverRuntime.handle(get("/ok")) } }
+            lines = capturing { runBlocking { serverRuntime.handle(get("/ok"), requestIdUnderTest) } }
         }
         val line = accessLines(lines).singleOrNull() ?: fail("expected one access line; got $lines")
         assertTrue(line.contains("-> 200"), "line should carry the status; was: $line")
@@ -101,7 +100,7 @@ class AccessLogInterceptorTest {
         var lines: List<String> = emptyList()
         TestServer.test(settings = {}) {
             lines = capturing {
-                runBlocking { runCatching { serverRuntime.handle(get("/boom")) } }
+                runBlocking { runCatching { serverRuntime.handle(get("/boom"), requestIdUnderTest) } }
             }
         }
         val line = accessLines(lines).singleOrNull() ?: fail("expected one access line; got $lines")

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
@@ -144,8 +144,8 @@ class SessionManagerTest {
                                 domain = "example.com",
                                 protocol = "https",
                                 sourceIp = "local",
-                                requestId = generateRequestId(),
-                            )
+                            ),
+                            generateRequestId(),
                         )
                     }
                 } finally {

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/testing.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/testing.kt
@@ -112,7 +112,6 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT> ApiHttpHandler<PathSpec0, US
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json
@@ -139,7 +138,6 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT, A> ApiHttpHandler<PathSpec1<
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json
@@ -167,7 +165,6 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT, A, B> ApiHttpHandler<PathSpe
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json
@@ -196,7 +193,6 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT, A, B, C> ApiHttpHandler<Path
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json
@@ -222,7 +218,6 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT>
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json
@@ -249,7 +244,6 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT,
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json
@@ -277,7 +271,6 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT,
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json
@@ -306,7 +299,6 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT,
                 domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                 protocol = generalSettings().publicUrl.substringBefore("://"),
                 sourceIp = "localhost",
-                requestId = generateRequestId(),
                 body = TypedData.text(
                     test.externalSerialization.json.encodeToString(inputType, input),
                     MediaType.Application.Json

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/BulkInterceptorScopeTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/BulkInterceptorScopeTest.kt
@@ -49,8 +49,10 @@ class BulkInterceptorScopeTest {
     }
 
     /** Records what it saw, then delegates. Shared by both interceptor kinds below. */
+    context(runtime: ServerRuntime)
     private fun record(into: MutableList<Seen>, request: HttpRequest<*>) {
-        into.add(Seen("/" + request.path.pathSegments.toString(), request.requestId, request.parentRequestId))
+        val initiator = runtime.initiator
+        into.add(Seen("/" + request.path.pathSegments.toString(), initiator.executionId, initiator.causedBy))
     }
 
     private inner class LogicalRecorder : HttpLogicalInterceptor {
@@ -125,9 +127,9 @@ class BulkInterceptorScopeTest {
                     domain = "example.com",
                     protocol = "https",
                     sourceIp = "local",
-                    requestId = outerRequestId,
                     body = TypedData.text(body, MediaType.Application.Json),
-                )
+                ),
+                outerRequestId,
             )
         }
         block()
@@ -165,12 +167,12 @@ class BulkInterceptorScopeTest {
     }
 
     /**
-     * The guard exists because a sub-request that kept the outer ID, or carried no parent at all,
-     * would be either indistinguishable from the request that carried it or unattributable to it —
-     * and both corrupt the audit trail silently rather than failing.
+     * The guard exists because a sub-request dispatched from outside an HTTP execution has nothing to
+     * be a sub-request *of*: it would be unattributable to the request that carried it, which corrupts
+     * the audit trail silently rather than failing.
      */
     @Test
-    fun `handleSubRequest rejects a request that was not derived as a sub-request`() =
+    fun `handleSubRequest rejects a dispatch from outside an http execution`() =
         TestServer.test(settings = {}) {
             val notASubRequest = HttpRequest<PathSpec>(
                 path = RawHttpEndpoint(asString = "/alpha", method = HttpMethod.GET),
@@ -179,14 +181,13 @@ class BulkInterceptorScopeTest {
                 domain = "example.com",
                 protocol = "https",
                 sourceIp = "local",
-                requestId = Uuid.random(),
             )
             val failure = assertFailsWith<IllegalArgumentException> {
                 runBlocking { serverRuntime.handleSubRequest(notASubRequest) }
             }
             assertTrue(
-                failure.message.orEmpty().contains("subRequest"),
-                "the message should name the correct way to build one; was: ${failure.message}",
+                failure.message.orEmpty().contains("HTTP execution"),
+                "the message should say why there is nothing to parent to; was: ${failure.message}",
             )
         }
 

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/BulkSpanTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/BulkSpanTest.kt
@@ -141,7 +141,6 @@ class BulkSpanTest {
                         domain = "example.com",
                         protocol = "https",
                         sourceIp = "local",
-                        requestId = generateRequestId(),
                         body = TypedData.text(
                             """
                             {
@@ -151,7 +150,8 @@ class BulkSpanTest {
                             """.trimIndent(),
                             MediaType.Application.Json,
                         ),
-                    )
+                    ),
+                    generateRequestId(),
                 )
             }
 

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/ErrorCaseWarningTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/ErrorCaseWarningTest.kt
@@ -56,15 +56,14 @@ class ErrorCaseWarningTest {
         domain = "example.com",
         protocol = "https",
         sourceIp = "local",
-        requestId = generateRequestId(),
     )
 
     @Test
     fun undeclaredErrorStillSurfacesAs400() = runBlocking {
         TestServer.test({}) {
             // Warning is logged for /boom; both still return 400 (response unchanged by W6).
-            assertEquals(400, serverRuntime.handle(request("/boom")).status.code)
-            assertEquals(400, serverRuntime.handle(request("/declared")).status.code)
+            assertEquals(400, serverRuntime.handle(request("/boom"), generateRequestId()).status.code)
+            assertEquals(400, serverRuntime.handle(request("/declared"), generateRequestId()).status.code)
         }
     }
 }

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/TypedOutputInterceptorTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/TypedOutputInterceptorTest.kt
@@ -37,8 +37,8 @@ import kotlin.uuid.Uuid
 class TypedOutputInterceptorTest {
 
     private data class Seen(
-        val requestId: Uuid,
-        val parentRequestId: Uuid?,
+        val executionId: Uuid,
+        val causedBy: Uuid?,
         val serialName: String,
         val value: Any?,
     )
@@ -62,7 +62,12 @@ class TypedOutputInterceptorTest {
         context(runtime: ServerRuntime)
         override suspend fun <T> outputProduced(request: Request<*>, serializer: KSerializer<T>, value: T) {
             Observed.seen.add(
-                Seen(request.requestId, request.parentRequestId, serializer.descriptor.serialName, value)
+                Seen(
+                    runtime.initiator.executionId,
+                    runtime.initiator.causedBy,
+                    serializer.descriptor.serialName,
+                    value,
+                )
             )
             if (Observed.failOn != null && Observed.failOn == value) {
                 throw IllegalStateException("audit sink unavailable")
@@ -115,7 +120,6 @@ class TypedOutputInterceptorTest {
             domain = "example.com",
             protocol = "https",
             sourceIp = "local",
-            requestId = outerRequestId,
             body = body?.let { TypedData.text(it, MediaType.Application.Json) },
         )
 
@@ -129,12 +133,12 @@ class TypedOutputInterceptorTest {
 
     @Test
     fun `an http response is observed with its serializer and value`() = onServer {
-        serverRuntime.handle(request("/alpha"))
+        serverRuntime.handle(request("/alpha"), outerRequestId)
 
         assertEquals(1, Observed.seen.size, "expected exactly one observation, saw ${Observed.seen}")
         val seen = Observed.seen.single()
         assertEquals("alpha", seen.value)
-        assertEquals(outerRequestId, seen.requestId)
+        assertEquals(outerRequestId, seen.executionId)
         assertTrue(seen.serialName.contains("String"), "expected the output serializer; was ${seen.serialName}")
     }
 
@@ -149,7 +153,8 @@ class TypedOutputInterceptorTest {
                 "/meta/bulk",
                 HttpMethod.POST,
                 """{"a":{"path":"/alpha","method":"GET"},"b":{"path":"/beta","method":"GET"}}""",
-            )
+            ),
+            outerRequestId,
         )
 
         val values = Observed.seen.map { it.value }
@@ -157,8 +162,8 @@ class TypedOutputInterceptorTest {
         assertTrue("beta" in values, "sub-response from /beta was not observed; saw $values")
 
         val subs = Observed.seen.filter { it.value == "alpha" || it.value == "beta" }
-        subs.forEach { assertEquals(outerRequestId, it.parentRequestId, "sub-response lost its parent") }
-        assertEquals(2, subs.map { it.requestId }.toSet().size, "sub-responses must be separately attributable")
+        subs.forEach { assertEquals(outerRequestId, it.causedBy, "sub-response lost its parent") }
+        assertEquals(2, subs.map { it.executionId }.toSet().size, "sub-responses must be separately attributable")
     }
 
     /**
@@ -168,7 +173,7 @@ class TypedOutputInterceptorTest {
     @Test
     fun `a failing interceptor prevents the response`() = onServer {
         Observed.failOn = "alpha"
-        val response = serverRuntime.handle(request("/alpha"))
+        val response = serverRuntime.handle(request("/alpha"), outerRequestId)
 
         assertEquals(HttpStatus.InternalServerError, response.status, "the response was sent anyway")
     }

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/validation/AnnotationValidatorsTests.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/validation/AnnotationValidatorsTests.kt
@@ -105,7 +105,6 @@ class AnnotationValidatorsTests {
                             domain = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
                             protocol = generalSettings().publicUrl.substringBefore("://"),
                             sourceIp = "localhost",
-                            requestId = generateRequestId(),
                             body = TypedData.text(
                                 serverRuntime.externalSerialization.json.encodeToString(
                                     endpoint.inputType,


### PR DESCRIPTION
**Stack: 3 of 16.** Based on `split/e2` — review that one first.
`Initiator` is a sealed interface carried by every execution, naming what
started it and what it descends from: `executionId`, `causedBy`,
`rootExecutionId` and `attributedTo`, with subtypes for Http, WebSocket,
Task, Schedule, Startup, PreDeploy and Direct.

The motivating case is indirect work. Before this, a task or a schedule tick
that wrote a row was attributable to nothing — there was a request id for
request-shaped work and silence for everything else. `rootExecutionId` is
what lets a change made three hops deep be traced back to the request that
set it off.

## Why there are two ids and not one

`rootExecutionId` answers "what set this off". `attributedTo` answers "who
did it". For a plain request or socket they name the same execution, which is
why one field looks like enough — but the framework creates *inner*
executions that carry their own credentials, and there the two come apart:

- a `/meta/bulk` sub-request takes per-sub-request query parameters, and
  `SessionManager.read` falls back to the `Authorization` and `jwt` query
  parameters
- a multiplexed sub-socket takes per-sub-socket query parameters the same way

So an anonymous carrier can dispatch an authenticated inner execution. When
that inner execution launches a task, the task has no request row of its own
and `rootExecutionId` leads to the *carrier's* row, which names nobody: the
change becomes untraceable to the person who made it. Both shapes are pinned
by tests in the audit module later in this stack.

The rule is uniform. An execution with a request-log row of its own
attributes to that row; one without — a task, a schedule tick — inherits the
anchor of whatever launched it. Derived where it is derivable (Http from its
execution id, WebSocket from its socket id) and carried only where it must
be, so only a task's queued payload grows a field. It is required there, with
no default: a task that invented its own anchor would attribute a change to
an execution that never authenticated anyone.

## subConnection mints one id, not two

A multiplexed sub-socket was given a fresh `executionId` *and* a separate
fresh `socketId`, while all three engines mint them equal at connect. Since a
socket's request-log row is keyed by `socketId`, that left the sub-socket's
own row unreachable from its execution id. Now one id, as everywhere else.

Wire-format note for reviewers: the AWS serverless engine puts these values
on the lambda payload and in DynamoDB, so this commit changes formats that
outlive a deploy. The rolling-deploy consequences are handled later in the
stack; that PR is worth reading against this one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd