### PR TITLE
Split Engine from ServerRuntime, and intercept every execution

### DIFF
--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AuthRequirement.ext.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AuthRequirement.ext.kt
@@ -4,6 +4,7 @@ import com.lightningkite.lightningserver.ForbiddenException
 import com.lightningkite.lightningserver.auth.AuthRequirement.Options
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.definition.set
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.services.database.HasId
 import kotlin.time.Duration
@@ -107,7 +108,7 @@ public var AuthRequirement.Companion.isDeveloper: AuthRequirement<HasId<*>>
     }
 
 
-context(_: ServerRuntime)
+context(_: Engine)
 public fun AuthRequirement<*>.naturalLanguage(markdown: Boolean = false): String = when (this) {
     is AuthRequirement.Options -> options.joinToString(if (markdown) " *or* " else " or ") { it.naturalLanguage(markdown) }
     is AuthRequirement.AuthSetting -> setting()?.let { "$this (${it.naturalLanguage(markdown)})" } ?: this.toString()

--- a/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AuthRequirement.kt
+++ b/auth/src/main/kotlin/com/lightningkite/lightningserver/auth/AuthRequirement.kt
@@ -3,6 +3,7 @@ package com.lightningkite.lightningserver.auth
 import com.lightningkite.lightningserver.DelicateLightningServerApi
 import com.lightningkite.lightningserver.definition.MutableExtensions
 import com.lightningkite.lightningserver.definition.Runtime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.now
 import com.lightningkite.services.database.HasId
@@ -181,7 +182,7 @@ public interface AuthRequirement<out SUBJECT : HasId<*>?> {
     public abstract class AuthSetting<SUBJECT : HasId<*>?>(
         public val default: AuthRequirement<SUBJECT>? = null,
     ) : AuthRequirement<SUBJECT>, MutableExtensions.Key<AuthRequirement<SUBJECT>> {
-        context(server: ServerRuntime)
+        context(server: Engine)
         public fun setting(): AuthRequirement<SUBJECT>? = server.server.extensions[this]
 
         override val requiredScopes: Runtime<Set<RequiredScope>> = Runtime { setting()?.requiredScopes() ?: default?.requiredScopes() ?: emptySet() }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/data/Request.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/data/Request.kt
@@ -3,6 +3,7 @@ package com.lightningkite.lightningserver.data
 import com.lightningkite.lightningserver.http.HttpHeaders
 import com.lightningkite.lightningserver.http.QueryParameters
 import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 
 /**
@@ -53,7 +54,7 @@ public abstract class Request<out PATH : PathSpec> : HasContextualPath<PATH>, Ca
      */
     public abstract val engineRequestId: String?
 
-    context(serverRuntime: ServerRuntime)
+    context(engine: Engine)
     override val pathInContext: ResolvedPath<PATH>
         get() = path.pathInContext
 }

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
@@ -4,6 +4,8 @@ import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.definition.builder.*
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.ExecutionInterceptor
+import com.lightningkite.lightningserver.runtime.compileAndInstrument
 import com.lightningkite.lightningserver.serialization.*
 import com.lightningkite.lightningserver.typedoutput.TypedOutputInterceptor
 import com.lightningkite.lightningserver.websockets.*
@@ -37,6 +39,7 @@ public data class ServerDefinition(
         public val annotationValidators: Runtime<AnnotationValidators>,
 
         public val endpoints: PathSpecMap<ServerPathEndpoints>,
+        public val executionInterceptors: List<ExecutionInterceptor>,
         public val httpConnectionInterceptors: List<HttpConnectionInterceptor>,
         public val httpLogicalInterceptors: List<HttpLogicalInterceptor>,
         public val webSocketConnectionInterceptors: List<WebSocketConnectionInterceptor>,
@@ -67,6 +70,11 @@ public data class ServerDefinition(
     public val annotationValidators: Runtime<AnnotationValidators> get() = flattened.annotationValidators
 
     public val endpoints: PathSpecMap<ServerPathEndpoints> get() = flattened.endpoints
+
+    /** Interceptors wrapping every execution the server runs, of every kind. See [ExecutionInterceptor]. */
+    public val executionInterceptors: List<ExecutionInterceptor> get() = flattened.executionInterceptors
+    public val compiledExecutionInterceptors: ExecutionInterceptor by lazy { executionInterceptors.compileAndInstrument() }
+
     /** Interceptors wrapping the whole physical request. See [HttpConnectionInterceptor]. */
     public val httpConnectionInterceptors: List<HttpConnectionInterceptor> get() = flattened.httpConnectionInterceptors
     public val compiledHttpConnectionInterceptors: HttpInterceptor by lazy { httpConnectionInterceptors.compileAndInstrument() }
@@ -126,6 +134,7 @@ public data class ServerDefinition(
         internalSerializersModule = Runtime.Cached(internalSerializersModule),
         externalSerializersModule = Runtime.Cached(externalSerializersModule),
         annotationValidators = Runtime.Cached(annotationValidators),
+        executionInterceptors = executionInterceptors.toSealedList(),
         httpConnectionInterceptors = httpConnectionInterceptors.toSealedList(),
         httpLogicalInterceptors = httpLogicalInterceptors.toSealedList(),
         webSocketConnectionInterceptors = webSocketConnectionInterceptors.toSealedList(),
@@ -190,6 +199,7 @@ public data class ServerDefinition(
             internalSerializersModule = { flattenedModuleItems.fold(thisLayer.internalSerializersModule()) { acc, module -> acc + module.internalSerializersModule() } },
             externalSerializersModule = { flattenedModuleItems.fold(thisLayer.externalSerializersModule()) { acc, module -> acc + module.externalSerializersModule() } },
             annotationValidators = { flattenedModuleItems.fold(thisLayer.annotationValidators()) { acc, module -> acc + module.annotationValidators() } },
+            executionInterceptors = flattenList { it.executionInterceptors },
             httpConnectionInterceptors = flattenList { it.httpConnectionInterceptors },
             httpLogicalInterceptors = flattenList { it.httpLogicalInterceptors },
             webSocketConnectionInterceptors = flattenList { it.webSocketConnectionInterceptors },

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerSetting.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerSetting.kt
@@ -1,6 +1,6 @@
 package com.lightningkite.lightningserver.definition
 
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.services.Setting
 import com.lightningkite.services.SettingContext
 import com.lightningkite.services.terraform.TerraformNeed
@@ -24,7 +24,7 @@ public fun interface RuntimeDeferred<out T> {
      *
      * @return The computed value
      */
-    context(server: ServerRuntime)
+    context(server: Engine)
     public suspend fun await(): T
 
     /**
@@ -42,7 +42,7 @@ public fun interface RuntimeDeferred<out T> {
         private var cache: NullWrapper<T>? = null
         private val mutex = Mutex()
 
-        context(server: ServerRuntime)
+        context(server: Engine)
         override suspend fun await(): T =
             cache?.value ?: mutex.withLock {
                 cache?.value?.let { return@withLock it }
@@ -57,8 +57,10 @@ public fun interface RuntimeDeferred<out T> {
  * Represents a computation that can be deferred until runtime and executed synchronously.
  *
  * Runtime is the core abstraction for lazy initialization and dependency injection in Lightning Server.
- * It allows values to be computed on-demand within a [ServerRuntime] context, providing access to
- * settings, services, and other runtime resources.
+ * It allows values to be computed on-demand within an [Engine] context, providing access to
+ * settings, services, and other runtime resources. Resolving one is process-wide work with no
+ * execution behind it, which is why it takes an engine rather than a
+ * [com.lightningkite.lightningserver.runtime.ServerRuntime].
  *
  * Example:
  * ```kotlin
@@ -77,10 +79,10 @@ public fun interface Runtime<out T> : RuntimeDeferred<T> {
      *
      * @return The computed value
      */
-    context(server: ServerRuntime)
+    context(server: Engine)
     public operator fun invoke(): T
 
-    context(server: ServerRuntime)
+    context(server: Engine)
     override suspend fun await(): T = invoke()
 
     /**
@@ -95,7 +97,7 @@ public fun interface Runtime<out T> : RuntimeDeferred<T> {
     public data class Cached<out T>(private val wraps: Runtime<T>) : Runtime<T> {
 
         private class Computed<T>(
-            val runtime: WeakReference<ServerRuntime>,
+            val runtime: WeakReference<Engine>,
             val result: T,
         )
 
@@ -103,12 +105,16 @@ public fun interface Runtime<out T> : RuntimeDeferred<T> {
         private var cache: Computed<T>? = null
         private val lock = Any()
 
-        context(server: ServerRuntime)
+        context(server: Engine)
         override operator fun invoke(): T {
+            // Keyed on the process-wide engine, never on the context handed in. A fresh
+            // ServerRuntime is minted per execution, so keying on the receiver would compare two
+            // different objects on every call and recompute what is by definition process-wide work.
+            val key = server.processEngine
             synchronized(lock) {
                 val c = cache
-                if (c != null && c.runtime.get() == server) return c.result
-                return wraps.invoke().also { cache = Computed(WeakReference(server), it) }
+                if (c != null && c.runtime.get() == key) return c.result
+                return wraps.invoke().also { cache = Computed(WeakReference(key), it) }
             }
         }
     }
@@ -116,11 +122,11 @@ public fun interface Runtime<out T> : RuntimeDeferred<T> {
     /**
      * A Runtime wrapper for a constant value.
      *
-     * Always returns the same value without requiring a ServerRuntime context.
+     * Always returns the same value without requiring an Engine context.
      * Useful for testing or when a value is known at compile time.
      */
     public data class Constant<out T>(public val value: T) : Runtime<T> {
-        context(server: ServerRuntime)
+        context(server: Engine)
         override operator fun invoke(): T = value
 
 //        public operator fun invoke(): T = value
@@ -133,7 +139,7 @@ public fun interface Runtime<out T> : RuntimeDeferred<T> {
  * @param transform Function to apply to the Runtime's value
  * @return A new Runtime that applies the transformation
  */
-public fun <T, R> Runtime<T>.map(transform: context(ServerRuntime) (T) -> R): Runtime<R> = Runtime { transform(this()) }
+public fun <T, R> Runtime<T>.map(transform: context(Engine) (T) -> R): Runtime<R> = Runtime { transform(this()) }
 
 /**
  * Transforms the result of this RuntimeDeferred using an async function.
@@ -141,7 +147,7 @@ public fun <T, R> Runtime<T>.map(transform: context(ServerRuntime) (T) -> R): Ru
  * @param transform Suspend function to apply to the RuntimeDeferred's value
  * @return A new RuntimeDeferred that applies the transformation
  */
-public fun <T, R> RuntimeDeferred<T>.mapSuspending(transform: suspend context(ServerRuntime) (T) -> R): RuntimeDeferred<R> =
+public fun <T, R> RuntimeDeferred<T>.mapSuspending(transform: suspend context(Engine) (T) -> R): RuntimeDeferred<R> =
     RuntimeDeferred { transform(this.await()) }
 
 /**
@@ -199,7 +205,7 @@ public interface ServerSetting<SETTING, RESULT> : Runtime<RESULT>, TerraformNeed
         override fun get(setting: Setting): Setting = setting
     }
 
-    context(server: ServerRuntime)
+    context(server: Engine)
     override fun invoke(): RESULT = server.settings.get(this)
 }
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/Task.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/Task.kt
@@ -1,6 +1,7 @@
 package com.lightningkite.lightningserver.definition
 
 import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.invoke
 import com.lightningkite.lightningserver.serialization.serializerOrContextual
 import kotlinx.serialization.KSerializer
 import kotlin.time.Duration
@@ -81,7 +82,7 @@ public fun <INPUT> Task(
  * @param input The input data for the task
  */
 context(server: ServerRuntime)
-public suspend fun <INPUT> Task<INPUT>.launch(input: INPUT): Unit = with(server) { invoke(input) }
+public suspend fun <INPUT> Task<INPUT>.launch(input: INPUT): Unit = invoke(input)
 
 /*
  * TODO: API Recommendations for Task.kt

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/builder/ServerBuilder.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/builder/ServerBuilder.kt
@@ -4,6 +4,7 @@ import com.lightningkite.lightningserver.*
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.ExecutionInterceptor
 import com.lightningkite.lightningserver.serialization.*
 import com.lightningkite.lightningserver.typedoutput.TypedOutputInterceptor
 import com.lightningkite.lightningserver.websockets.*
@@ -85,6 +86,8 @@ public abstract class ServerBuilder : Extendable {
     private val settings: ListRegistry<ServerSetting<*, *>> = ListRegistry()
     private val settingOverrides: MapRegistry<ServerSetting<*, *>, Runtime<*>> = MapRegistry()
 
+    private val executionInterceptors: ListRegistry<ExecutionInterceptor> = ListRegistry()
+
     private val httpConnectionInterceptors: ListRegistry<HttpConnectionInterceptor> = ListRegistry()
     private val httpLogicalInterceptors: ListRegistry<HttpLogicalInterceptor> = ListRegistry()
     private val httpHandlers: PathSpecRegistry<MapRegistry<HttpMethod, HttpHandler<*>>> = PathSpecRegistry()
@@ -110,6 +113,10 @@ public abstract class ServerBuilder : Extendable {
 
     private val imports: ListRegistry<Locationed<PathSpec0, ServerDefinition>> = ListRegistry()
     private val modules: ListRegistry<Locationed<PathSpec0, ServerBuilder>> = ListRegistry()
+
+    @JvmName("installExecutionInterceptor")
+    public fun <T : ExecutionInterceptor> install(interceptor: T): T =
+        interceptor.also { executionInterceptors.register(it) }
 
     @JvmName("installHttpConnectionInterceptor")
     public fun <T : HttpConnectionInterceptor> install(interceptor: T): T =
@@ -333,6 +340,7 @@ public abstract class ServerBuilder : Extendable {
             internalSerializersModule = internalSerialization,
             externalSerializersModule = externalSerialization,
             annotationValidators = annotationValidators,
+            executionInterceptors = executionInterceptors.toSealedList(),
             httpConnectionInterceptors = httpConnectionInterceptors.toSealedList(),
             httpLogicalInterceptors = httpLogicalInterceptors.toSealedList(),
             webSocketConnectionInterceptors = webSocketConnectionInterceptors.toSealedList(),

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/logging.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/logging.kt
@@ -3,7 +3,7 @@ package com.lightningkite.lightningserver
 import com.lightningkite.lightningserver.definition.MutableExtensions
 import com.lightningkite.lightningserver.definition.ServerDefinition
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 
@@ -33,6 +33,6 @@ public val ServerDefinition.logger: KLogger
     get() = extensions[LoggerKey] ?: LoggerKey.default()
 
 /**
- * Gets the logger for this ServerRuntime, delegating to the underlying server definition's logger.
+ * Gets the logger for this Engine, delegating to the underlying server definition's logger.
  */
-public val ServerRuntime.logger: KLogger get() = server.logger
+public val Engine.logger: KLogger get() = server.logger

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/RawHttpEndpoint.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/RawHttpEndpoint.kt
@@ -4,7 +4,7 @@ import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.RouteNotFoundException
 import com.lightningkite.lightningserver.http.HttpHandler
 import com.lightningkite.lightningserver.http.PathSegments
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
@@ -14,13 +14,13 @@ public data class RawHttpEndpoint<out PATH : PathSpec>(val pathSegments: PathSeg
     public constructor(asString: String, method: HttpMethod) : this(PathSegments.parse(asString), method)
 
     @Suppress("UNCHECKED_CAST")
-    context(server: ServerRuntime)
+    context(server: Engine)
     override val pathInContext: ResolvedPath<PATH> get() = match.path as ResolvedPath<PATH>
 
     @Transient
     private var matchIfPresent: PathSpecMap.Match<HttpHandler<*>>? = null
 
-    context(server: ServerRuntime)
+    context(server: Engine)
     public val match: PathSpecMap.Match<HttpHandler<*>>
         get() {
             if (this.matchIfPresent == null) {
@@ -47,18 +47,18 @@ public data class RawHttpEndpoint<out PATH : PathSpec>(val pathSegments: PathSeg
     override fun toString(): String = "$method /$pathSegments"
 }
 
-context(server: ServerRuntime)
+context(server: Engine)
 public fun <PATH : PathSpec> RawHttpEndpoint(path: ResolvedPath<PATH>, method: HttpMethod): RawHttpEndpoint<PATH> =
     RawHttpEndpoint(path.pathSegments(server.internalSerialization.stringArrayFormat), method = method)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun RawHttpEndpoint(
     spec: PathSpec0,
     method: HttpMethod,
     trailingSegments: PathSegments? = null,
 ): RawHttpEndpoint<PathSpec0> = RawHttpEndpoint(ResolvedPath(spec, trailingSegments), method)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun <A> RawHttpEndpoint(
     spec: PathSpec1<A>,
     path1: A,
@@ -67,7 +67,7 @@ public fun <A> RawHttpEndpoint(
 ): RawHttpEndpoint<PathSpec1<A>> =
     RawHttpEndpoint(ResolvedPath(spec, path1, trailingSegments), method)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun <A, B> RawHttpEndpoint(
     spec: PathSpec2<A, B>,
     path1: A,
@@ -77,7 +77,7 @@ public fun <A, B> RawHttpEndpoint(
 ): RawHttpEndpoint<PathSpec2<A, B>> =
     RawHttpEndpoint(ResolvedPath(spec, path1, path2, trailingSegments), method)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun <A, B, C> RawHttpEndpoint(
     spec: PathSpec3<A, B, C>,
     path1: A,

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/RawWebsocketPath.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/RawWebsocketPath.kt
@@ -1,7 +1,7 @@
 package com.lightningkite.lightningserver.pathing
 
 import com.lightningkite.lightningserver.http.PathSegments
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.*
@@ -31,7 +31,7 @@ public class PathSerializer<T : PathSpec>(ignored: KSerializer<T>) : KSerializer
  * Represents an unresolved WebSocket path that will be matched against registered endpoints.
  *
  * Similar to [RawHttpEndpoint] but for WebSocket connections. The path is parsed into segments
- * and matched against the server's registered WebSocket handlers when accessed in a ServerRuntime context.
+ * and matched against the server's registered WebSocket handlers when accessed in an Engine context.
  *
  * **Usage:**
  * ```kotlin
@@ -53,12 +53,12 @@ public class RawWebSocketPath<out PATH : PathSpec>(public val pathSegments: Path
     public constructor(path: String) : this(PathSegments.parse(path))
 
     @Suppress("UNCHECKED_CAST")
-    context(server: ServerRuntime)
+    context(server: Engine)
     override val pathInContext: ResolvedPath<PATH> get() = match.path as ResolvedPath<PATH>
 
     private var matchIfPresent: PathSpecMap.Match<*>? = null
 
-    context(server: ServerRuntime)
+    context(server: Engine)
     public val match: PathSpecMap.Match<*>
         get() {
             if (this.matchIfPresent == null) {
@@ -83,15 +83,15 @@ public class RawWebSocketPath<out PATH : PathSpec>(public val pathSegments: Path
     override fun toString(): String = "/$pathSegments"
 }
 
-context(server: ServerRuntime)
+context(server: Engine)
 public fun <PATH : PathSpec> RawWebSocketPath(path: ResolvedPath<PATH>): RawWebSocketPath<PATH> =
     RawWebSocketPath(path.pathSegments(server.internalSerialization.stringArrayFormat))
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun RawWebSocketPath(spec: PathSpec0, trailingSegments: PathSegments? = null): RawWebSocketPath<PathSpec0> =
     RawWebSocketPath(ResolvedPath(spec, trailingSegments))
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun <A> RawWebSocketPath(
     spec: PathSpec1<A>,
     path1: A,
@@ -99,7 +99,7 @@ public fun <A> RawWebSocketPath(
 ): RawWebSocketPath<PathSpec1<A>> =
     RawWebSocketPath(ResolvedPath(spec, path1, trailingSegments))
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun <A, B> RawWebSocketPath(
     spec: PathSpec2<A, B>,
     path1: A,
@@ -108,7 +108,7 @@ public fun <A, B> RawWebSocketPath(
 ): RawWebSocketPath<PathSpec2<A, B>> =
     RawWebSocketPath(ResolvedPath(spec, path1, path2, trailingSegments))
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun <A, B, C> RawWebSocketPath(
     spec: PathSpec3<A, B, C>,
     path1: A,

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/ResolvedPath.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/pathing/ResolvedPath.kt
@@ -4,7 +4,7 @@ package com.lightningkite.lightningserver.pathing
 
 import com.lightningkite.lightningserver.definition.generalSettings
 import com.lightningkite.lightningserver.http.PathSegments
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.services.data.StringArrayFormat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.StringFormat
@@ -92,21 +92,21 @@ public data class ResolvedPath<out PATH : PathSpec> internal constructor(
     public fun toString(stringArrayFormat: StringArrayFormat): String = path(stringArrayFormat)
 }
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun ResolvedPath<*>.pathSegments(): PathSegments =
-    pathSegments(serverRuntime.externalSerialization.stringArrayFormat)
+    pathSegments(engine.externalSerialization.stringArrayFormat)
 
-context(serverRuntime: ServerRuntime)
-public fun ResolvedPath<*>.path(): String = path(serverRuntime.externalSerialization.stringArrayFormat)
+context(engine: Engine)
+public fun ResolvedPath<*>.path(): String = path(engine.externalSerialization.stringArrayFormat)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun ResolvedPath<*>.fullUrl(): String = generalSettings().publicUrl + path()
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun ResolvedPath<*>.wsFullUrl(): String = generalSettings().wsUrl + path()
 
 /**
- * Interface for objects that can provide a [ResolvedPath] when given a [ServerRuntime] context.
+ * Interface for objects that can provide a [ResolvedPath] when given an [Engine] context.
  *
  * This is used for lazy path resolution where the path cannot be determined until runtime context is available.
  * Common use cases include paths that depend on server settings or need to look up endpoints.
@@ -114,7 +114,7 @@ public fun ResolvedPath<*>.wsFullUrl(): String = generalSettings().wsUrl + path(
  * @param PATH The PathSpec type
  */
 public interface HasContextualPath<out PATH : PathSpec> {
-    context(server: ServerRuntime)
+    context(server: Engine)
     public val pathInContext: ResolvedPath<PATH>
 }
 
@@ -168,17 +168,17 @@ public fun HasResolvedPath<*>.pathSegments(stringArrayFormat: StringArrayFormat)
 
 public fun HasResolvedPath<*>.path(stringArrayFormat: StringArrayFormat): String = path.path(stringArrayFormat)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun HasResolvedPath<*>.pathSegments(): PathSegments =
-    path.pathSegments(serverRuntime.externalSerialization.stringArrayFormat)
+    path.pathSegments(engine.externalSerialization.stringArrayFormat)
 
-context(serverRuntime: ServerRuntime)
-public fun HasResolvedPath<*>.path(): String = path.path(serverRuntime.externalSerialization.stringArrayFormat)
+context(engine: Engine)
+public fun HasResolvedPath<*>.path(): String = path.path(engine.externalSerialization.stringArrayFormat)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun HasResolvedPath<*>.fullUrl(): String = generalSettings().publicUrl + path()
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun HasResolvedPath<*>.wsFullUrl(): String = generalSettings().wsUrl + path()
 
 @get:JvmName("arg1_1")
@@ -221,43 +221,43 @@ public val <A, B, C> HasResolvedPath<PathSpec3<A, B, C>>.arg2: B get() = path.ar
 public val <A, B, C> HasResolvedPath<PathSpec3<A, B, C>>.arg3: C get() = path.arg3
 
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public val HasContextualPath<*>.trailingSegments: PathSegments? get() = pathInContext.trailingSegments
 
 @get:JvmName("arg1_1")
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public val <A> HasContextualPath<PathSpec1<A>>.arg1: A get() = pathInContext.arg1
 
 @get:JvmName("arg1_2")
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public val <A, B> HasContextualPath<PathSpec2<A, B>>.arg1: A get() = pathInContext.arg1
 
 @get:JvmName("arg2_2")
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public val <A, B> HasContextualPath<PathSpec2<A, B>>.arg2: B get() = pathInContext.arg2
 
 @get:JvmName("arg1_3")
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public val <A, B, C> HasContextualPath<PathSpec3<A, B, C>>.arg1: A get() = pathInContext.arg1
 
 @get:JvmName("arg2_3")
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public val <A, B, C> HasContextualPath<PathSpec3<A, B, C>>.arg2: B get() = pathInContext.arg2
 
 @get:JvmName("arg3_3")
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public val <A, B, C> HasContextualPath<PathSpec3<A, B, C>>.arg3: C get() = pathInContext.arg3
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun HasContextualPath<*>.pathSegments(): PathSegments =
-    pathInContext.pathSegments(serverRuntime.externalSerialization.stringArrayFormat)
+    pathInContext.pathSegments(engine.externalSerialization.stringArrayFormat)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun HasContextualPath<*>.path(): String =
-    pathInContext.path(serverRuntime.externalSerialization.stringArrayFormat)
+    pathInContext.path(engine.externalSerialization.stringArrayFormat)
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun HasContextualPath<*>.fullUrl(): String = generalSettings().publicUrl + path()
 
-context(serverRuntime: ServerRuntime)
+context(engine: Engine)
 public fun HasContextualPath<*>.wsFullUrl(): String = generalSettings().wsUrl + path()

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Engine.ext.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Engine.ext.kt
@@ -5,7 +5,8 @@ import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.http.HttpEndpoint
 import com.lightningkite.lightningserver.http.HttpHandler
 import com.lightningkite.lightningserver.pathing.*
-import com.lightningkite.lightningserver.websockets.*
+import com.lightningkite.lightningserver.websockets.WebSocketHandler
+import com.lightningkite.lightningserver.websockets.WebSocketTopic
 import kotlin.time.Instant
 
 /**
@@ -23,82 +24,9 @@ import kotlin.time.Instant
  *
  * @return The configured value of this setting
  */
-context(server: ServerRuntime)
+context(server: Engine)
 public operator fun <SERIALIZABLE, GOAL> ServerSetting<SERIALIZABLE, GOAL>.invoke(): GOAL =
     server.settings.get(this)
-
-/**
- * Sends a message to all WebSocket connections subscribed to this topic (no path parameters).
- *
- * @param value The message to send
- */
-context(serverRuntime: ServerRuntime)
-public suspend fun <T> WebSocketTopic<PathSpec0, T>.send(value: T): Unit =
-    serverRuntime.sendWebSocketSubscriptionMessage(
-        WebSocketSubscriptionMessage(this, listOf(), value)
-    )
-
-/**
- * Sends a message to all WebSocket connections subscribed to this topic with one path parameter.
- *
- * @param path1 The first path parameter value
- * @param value The message to send
- */
-context(serverRuntime: ServerRuntime)
-public suspend fun <A, T> WebSocketTopic<PathSpec1<A>, T>.send(
-    path1: A,
-    value: T,
-): Unit = serverRuntime.sendWebSocketSubscriptionMessage(
-    WebSocketSubscriptionMessage(this, listOf(path1), value)
-)
-
-/**
- * Sends a message to all WebSocket connections subscribed to this topic with two path parameters.
- *
- * @param path1 The first path parameter value
- * @param path2 The second path parameter value
- * @param value The message to send
- */
-context(serverRuntime: ServerRuntime)
-public suspend fun <A, B, T> WebSocketTopic<PathSpec2<A, B>, T>.send(
-    path1: A,
-    path2: B,
-    value: T,
-): Unit = serverRuntime.sendWebSocketSubscriptionMessage(
-    WebSocketSubscriptionMessage(this, listOf(path1, path2), value)
-)
-
-/**
- * Sends a message to all WebSocket connections subscribed to this topic with three path parameters.
- *
- * @param path1 The first path parameter value
- * @param path2 The second path parameter value
- * @param path3 The third path parameter value
- * @param value The message to send
- */
-context(serverRuntime: ServerRuntime)
-public suspend fun <A, B, C, T> WebSocketTopic<PathSpec3<A, B, C>, T>.send(
-    path1: A,
-    path2: B,
-    path3: C,
-    value: T,
-): Unit = serverRuntime.sendWebSocketSubscriptionMessage(
-    WebSocketSubscriptionMessage(this, listOf(path1, path2, path3), value)
-)
-
-/**
- * Queues a task for asynchronous execution.
- *
- * The task will be executed in the background. The exact execution mechanism depends
- * on the engine implementation (e.g., GlobalScope.launch for single-machine engines).
- *
- * @param input The input parameter for the task
- */
-context(serverRuntime: ServerRuntime)
-public suspend operator fun <T> Task<T>.invoke(input: T): Unit =
-    with(serverRuntime) {
-        this@invoke.invoke(input)
-    }
 
 /**
  * Returns the current time according to the server's clock.
@@ -107,63 +35,63 @@ public suspend operator fun <T> Task<T>.invoke(input: T): Unit =
  *
  * @return The current instant
  */
-context(server: ServerRuntime)
+context(server: Engine)
 public fun now(): Instant = server.clock.now()
 
 /**
- * Provides access to the ServerRuntime instance from a context receiver.
+ * Provides access to the Engine instance from a context receiver.
  *
- * This allows nested functions to access the runtime without explicit parameter passing.
+ * This allows nested functions to access the engine without explicit parameter passing.
  */
-context(runner: ServerRuntime)
-public val serverRuntime: ServerRuntime get() = runner
+context(inContext: Engine)
+public val engine: Engine get() = inContext
 
 /**
  * Gets the location of an HTTP handler, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val <P : PathSpec> HttpHandler<P>.locationOrNull: HttpEndpoint<P>? get() = runner.server.location(this)
 
 /**
  * Gets the location of a WebSocket handler, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val <P : PathSpec> WebSocketHandler<P, *>.locationOrNull: P? get() = runner.server.location(this)
 
 /**
  * Gets the location of a WebSocket topic, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val <P : PathSpec> WebSocketTopic<P, *>.locationOrNull: P? get() = runner.server.location(this)
 
 /**
  * Gets the location of a task, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val Task<*>.locationOrNull: PathSpec0? get() = runner.server.location(this)
 
 /**
  * Gets the location of a startup task, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val StartupTask.locationOrNull: PathSpec0? get() = runner.server.location(this)
 
 /**
  * Gets the location of a scheduled task, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val ScheduledTask.locationOrNull: PathSpec0? get() = runner.server.location(this)
 
 /**
  * Gets the location of a server module, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val ServerDefinition.locationOrNull: PathSpec0? get() = runner.server.location(this)
 
 /**
  * Gets the location of a server module, or null if it's not registered.
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val ServerBuilder.locationOrNull: PathSpec0? get() = runner.server.location(this)
 
 /**
@@ -180,7 +108,7 @@ public class UnregisteredException internal constructor(item: Any) :
  *
  * @throws UnregisteredException if the handler is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val <P : PathSpec> HttpHandler<P>.location: HttpEndpoint<P>
     get() = runner.server.location(this) ?: throw UnregisteredException(this)
 
@@ -189,7 +117,7 @@ val <P : PathSpec> HttpHandler<P>.location: HttpEndpoint<P>
  *
  * @throws UnregisteredException if the handler is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val <P : PathSpec> WebSocketHandler<P, *>.location: P
     get() = runner.server.location(this) ?: throw UnregisteredException(this)
 
@@ -198,7 +126,7 @@ val <P : PathSpec> WebSocketHandler<P, *>.location: P
  *
  * @throws UnregisteredException if the topic is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val <P : PathSpec> WebSocketTopic<P, *>.location: P
     get() = runner.server.location(this) ?: throw UnregisteredException(
         this
@@ -209,7 +137,7 @@ val <P : PathSpec> WebSocketTopic<P, *>.location: P
  *
  * @throws UnregisteredException if the task is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val Task<*>.location: PathSpec0 get() = runner.server.location(this) ?: throw UnregisteredException(this)
 
 /**
@@ -217,7 +145,7 @@ val Task<*>.location: PathSpec0 get() = runner.server.location(this) ?: throw Un
  *
  * @throws UnregisteredException if the task is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val StartupTask.location: PathSpec0 get() = runner.server.location(this) ?: throw UnregisteredException(this)
 
 /**
@@ -225,7 +153,7 @@ val StartupTask.location: PathSpec0 get() = runner.server.location(this) ?: thro
  *
  * @throws UnregisteredException if the task is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val PreDeployTask.location: PathSpec0 get() = runner.server.location(this) ?: throw UnregisteredException(this)
 
 /**
@@ -233,7 +161,7 @@ val PreDeployTask.location: PathSpec0 get() = runner.server.location(this) ?: th
  *
  * @throws UnregisteredException if the task is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val ScheduledTask.location: PathSpec0 get() = runner.server.location(this) ?: throw UnregisteredException(this)
 
 /**
@@ -241,7 +169,7 @@ val ScheduledTask.location: PathSpec0 get() = runner.server.location(this) ?: th
  *
  * @throws UnregisteredException if the module is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val ServerDefinition.location: PathSpec0 get() = runner.server.location(this) ?: throw UnregisteredException(this)
 
 /**
@@ -249,6 +177,6 @@ val ServerDefinition.location: PathSpec0 get() = runner.server.location(this) ?:
  *
  * @throws UnregisteredException if the module is not registered with the server
  */
-public context(runner: ServerRuntime)
+public context(runner: Engine)
 val ServerBuilder.location: PathSpec0 get() = runner.server.location(this) ?: throw UnregisteredException(this)
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Engine.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Engine.kt
@@ -1,0 +1,174 @@
+package com.lightningkite.lightningserver.runtime
+
+import com.lightningkite.lightningserver.definition.*
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.serialization.Serialization
+import com.lightningkite.lightningserver.settings.ServerSettings
+import com.lightningkite.lightningserver.websockets.DirectWebSocketSender
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
+import com.lightningkite.services.Namespaced
+import com.lightningkite.services.SettingContext
+import kotlinx.serialization.modules.SerializersModule
+import kotlin.time.Clock
+
+/**
+ * Core interface representing a running Lightning Server instance: one per server process.
+ *
+ * An engine provides everything that is process-wide and shared, including:
+ * - Access to the server definition (routes, handlers, settings)
+ * - Serialization configuration for external (API) and internal (storage) use
+ * - Settings management and access
+ * - WebSocket subscription messaging
+ * - Task execution
+ * - Telemetry and clock access
+ * - Reading settings
+ *
+ * Implementations of this interface are responsible for:
+ * - Managing the server lifecycle
+ * - Routing HTTP requests to appropriate handlers
+ * - Executing scheduled and startup tasks
+ * - Handling WebSocket connections and subscriptions
+ *
+ * An engine is not running on anyone's behalf, and deliberately has no [Initiator]. Code that needs
+ * to know what started the work it is doing takes a [ServerRuntime] instead — one is minted per
+ * execution, and is an engine plus that attribution.
+ */
+public interface Engine : SettingContext, Namespaced {
+    /**
+     * The process-wide engine underneath this context. An engine is its own; a [ServerRuntime]
+     * resolves to the engine it was minted from.
+     *
+     * Anything caching at process scope must key on this rather than on the context it was handed. A
+     * fresh runtime is minted for every execution, so a cache keyed on the received context compares
+     * two different objects every time, misses, and recomputes per request.
+     */
+    public val processEngine: Engine get() = this
+
+    /** Fixed namespace used when naming spans in the metrics backend. */
+    override val name: String get() = "lightningserver"
+
+    /** This engine is the SettingContext for all its services. */
+    override val context: SettingContext get() = this
+
+    /**
+     * The server definition containing all routes, handlers, settings, and tasks.
+     */
+    public val server: ServerDefinition
+
+    /**
+     * Whether the different parts of the webSocket handler (willConnect, didConnect, messageFromClient,
+     * messageFromSubscription, disconnect) all occur in the same process.  If they do, you can use RAM to store
+     * information between those events.
+     */
+    public val webSocketHandlersRunOnSameMachine: Boolean get() = true
+
+    /**
+     * The public URL at which this server is accessible.
+     *
+     * Defaults to the value from general settings.
+     */
+    override val publicUrl: String
+        get() = generalSettings().publicUrl
+
+    /**
+     * Serialization configuration for external API communication (HTTP bodies, etc.).
+     */
+    public val externalSerialization: Serialization
+
+    /**
+     * Serialization configuration for internal use (database storage, caching, etc.).
+     */
+    public val internalSerialization: Serialization
+
+    /**
+     * Clock used for time-based operations.
+     *
+     * Defaults to system clock but can be overridden for testing.
+     */
+    override val clock: Clock get() = Clock.System
+
+    /**
+     * Settings manager for accessing configured server settings.
+     */
+    public val settings: ServerSettings
+
+    /**
+     * Sends a WebSocket subscription message to all connections subscribed to the topic.
+     *
+     * The message will be delivered to all WebSocket connections that have subscribed
+     * to the topic with matching path parameters.
+     *
+     * @param event The subscription message to send, including topic, path args, and value
+     */
+    public suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(event: WebSocketSubscriptionMessage<PATH, T>)
+
+    /**
+     * Optional direct WebSocket sender for engines that support it (e.g., AWS).
+     *
+     * When available, allows bypassing the pub/sub mechanism for direct message sending
+     * to specific sockets. Used by [com.lightningkite.lightningserver.websockets.CoroutineWebSocketHandler]
+     * to optimize message delivery.
+     *
+     * @return DirectWebSocketSender implementation if supported, null otherwise
+     */
+    public val directWebSocketSender: DirectWebSocketSender? get() = null
+
+    /**
+     * Invokes a task for asynchronous execution.
+     *
+     * The exact execution mechanism (background thread, coroutine, queue, etc.)
+     * depends on the runtime implementation.
+     *
+     * @param input The input parameter for the task
+     * @param cause The execution launching this task, or null when nothing is launching it — boot,
+     *   or a manual invocation. Engines must carry it into the queued payload: a serverless engine's
+     *   launching process is gone by the time the task runs, so parentage that is not serialized is
+     *   parentage that does not exist.
+     */
+    public suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?)
+
+    /**
+     * Serializers module used for internal serialization.
+     */
+    override val internalSerializersModule: SerializersModule get() = internalSerialization.serializersModule
+
+    /**
+     * Unique identifier for this server instance.
+     *
+     * For single-machine engines, typically derived from network interface MAC address.
+     * For serverless deployments, may be a Lambda function ID or similar.
+     */
+    public val serverId: String
+
+    /**
+     * Version identifier for the running server.
+     *
+     * May be "Unknown" if version information is not available.
+     */
+    public val serverVersion: String
+}
+
+/*
+ * TODO: API Recommendations for Engine.kt
+ *
+ * 1. The openTelemetry property returns null by default with a TODO comment. This should either be
+ *    implemented or the TODO removed if telemetry is truly optional. Document the expected behavior.
+ *
+ * 2. No lifecycle methods for server startup/shutdown. Consider adding:
+ *    - suspend fun start()
+ *    - suspend fun stop()
+ *    - val isRunning: Boolean
+ *
+ * 3. The Task.invoke() method doesn't provide any feedback about task execution status or errors.
+ *    Consider returning a result or providing a callback mechanism for task completion/failure.
+ *
+ * 4. sendWebSocketSubscriptionMessage doesn't document what happens if no connections are subscribed.
+ *    Does it silently succeed? Document this behavior.
+ *
+ * 5. No way to query the server state (number of active connections, running tasks, etc.).
+ *    Consider adding health/metrics accessors for observability.
+ *
+ * 6. The serverId and serverVersion have no validation. Consider validating that these are set
+ *    properly during initialization or providing defaults.
+ */
+

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/EngineBase.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/EngineBase.kt
@@ -1,6 +1,5 @@
 package com.lightningkite.lightningserver.runtime
 
-import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.serialization.Serialization
@@ -8,10 +7,9 @@ import com.lightningkite.lightningserver.settings.ServerSettings
 import com.lightningkite.services.telemetry.TelemetryBackend
 import com.lightningkite.services.SharedResources
 import kotlinx.coroutines.*
-import kotlin.uuid.Uuid
 
 /**
- * Base implementation of [ServerRuntime] providing common functionality.
+ * Base implementation of [Engine] providing common functionality.
  *
  * This abstract class handles:
  * - Settings initialization and management (including automatic addition of system settings)
@@ -21,24 +19,16 @@ import kotlin.uuid.Uuid
  * - Startup task execution with dependency resolution
  *
  * Subclasses should implement:
- * - [ServerRuntime.sendWebSocketSubscriptionMessage]
- * - [ServerRuntime.Task.invoke]
- * - [ServerRuntime.serverId]
- * - [ServerRuntime.serverVersion]
+ * - [Engine.sendWebSocketSubscriptionMessage]
+ * - [Engine.Task.invoke]
+ * - [Engine.serverId]
+ * - [Engine.serverVersion]
  * - HTTP request handling (typically via an engine)
  * - Scheduled task execution
  *
  * @param server The server definition to run
  */
-public abstract class ServerRuntimeBase(override val server: ServerDefinition) : ServerRuntime {
-    /**
-     * The engine itself is not running on anyone's behalf — executions get their own runtime from
-     * [forExecution] at the seam. Work done directly on the engine, such as boot, is attributed to
-     * this one [Initiator.Direct] rather than to nothing at all.
-     */
-    @OptIn(InternalLightningServerApi::class)
-    override val initiator: Initiator = Initiator.Direct(Uuid.random())
-
+public abstract class EngineBase(override val server: ServerDefinition) : Engine {
     /**
      * Settings manager with automatically included system settings.
      *
@@ -145,7 +135,7 @@ public abstract class ServerRuntimeBase(override val server: ServerDefinition) :
 }
 
 /*
- * TODO: API Recommendations for ServerRuntimeBase.kt
+ * TODO: API Recommendations for EngineBase.kt
  *
  * 2. The runStartupTasks() method launches all tasks concurrently but doesn't limit concurrency.
  *    For servers with many startup tasks, this could create resource contention.

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ExecutionInterceptor.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ExecutionInterceptor.kt
@@ -1,0 +1,114 @@
+package com.lightningkite.lightningserver.runtime
+
+/**
+ * Wraps one whole execution, whatever kind of execution it is.
+ *
+ * The HTTP and WebSocket interceptors each see one kind of work; this one sees every kind — an HTTP
+ * request, each WebSocket lifecycle phase, a task, a schedule tick, a startup task, a pre-deploy
+ * task. That uniformity is the reason it exists: a concern that must hold for *everything the server
+ * runs* — a tenant context, a unit of work, a top-level audit record — cannot be expressed by
+ * installing the same logic into three chains that between them still miss tasks and schedules.
+ *
+ * It wraps outside the HTTP and WebSocket chains, which run inside the execution this one wraps, and
+ * inside the execution's own telemetry span, so that whatever an interceptor does is recorded as part
+ * of the execution it belongs to rather than as a detached trace of its own.
+ *
+ * Install on a `ServerBuilder`; the first installed is the outermost, as with the other two chains.
+ *
+ * ```kotlin
+ * object Server : ServerBuilder() {
+ *     init {
+ *         install(object : ExecutionInterceptor {
+ *             override suspend fun <T> intercept(
+ *                 runtime: ServerRuntime,
+ *                 cont: suspend context(ServerRuntime) () -> T,
+ *             ): T {
+ *                 val start = TimeSource.Monotonic.markNow()
+ *                 try { return with(runtime) { cont() } }
+ *                 finally { println("${runtime.initiator} took ${start.elapsedNow()}") }
+ *             }
+ *         })
+ *     }
+ * }
+ * ```
+ */
+public interface ExecutionInterceptor {
+    /**
+     * The name of this interceptor, used for instrumentation and debugging.
+     * Defaults to the simple class name or "anonymous" for lambdas.
+     */
+    public val name: String get() = this::class.simpleName ?: "anonymous"
+
+    /**
+     * Wraps [cont], which is the rest of the chain and then the execution itself.
+     *
+     * @param runtime The runtime for the execution being wrapped, naming what initiated it.
+     * @param cont The continuation, invoked as `with(runtime) { cont() }`. Skipping it skips the
+     *   execution entirely, so an interceptor that means to let the work happen must call it.
+     */
+    public suspend fun <T> intercept(
+        runtime: ServerRuntime,
+        cont: suspend context(ServerRuntime) () -> T,
+    ): T
+
+    /**
+     * The compiled chain for "nothing installed" — it runs the execution untouched.
+     *
+     * Chain machinery, not something to install; a chain link around a pass-through would only cost a
+     * span. [compileAndInstrument] drops these rather than wrapping them.
+     */
+    public object NoOp : ExecutionInterceptor {
+        override suspend fun <T> intercept(
+            runtime: ServerRuntime,
+            cont: suspend context(ServerRuntime) () -> T,
+        ): T = with(runtime) { cont() }
+    }
+}
+
+/**
+ * Wraps the intercept call in its own instrumentation span, so time spent in each interceptor is
+ * attributable.
+ *
+ * Unlike the HTTP counterpart this does not recover from exceptions: an execution's result type is
+ * whatever that kind of execution returns, so there is no response to fabricate here. Failures
+ * propagate to the kind-specific handling at the seam.
+ */
+private suspend fun <T> ExecutionInterceptor.interceptInstrumented(
+    runtime: ServerRuntime,
+    cont: suspend context(ServerRuntime) () -> T,
+): T = with(runtime) { instrument(name) { intercept(runtime, cont) } }
+
+/** One link of a compiled chain, wrapping [interceptor] in its own instrumentation span. */
+private fun instrumentedLink(interceptor: ExecutionInterceptor): ExecutionInterceptor =
+    object : ExecutionInterceptor {
+        override val name: String get() = interceptor.name
+
+        override suspend fun <T> intercept(
+            runtime: ServerRuntime,
+            cont: suspend context(ServerRuntime) () -> T,
+        ): T = interceptor.interceptInstrumented(runtime, cont)
+    }
+
+/** Nests [inner] inside [outer], so [outer] runs first and can post-process what [inner] returns. */
+private fun composeLinks(outer: ExecutionInterceptor, inner: ExecutionInterceptor): ExecutionInterceptor =
+    object : ExecutionInterceptor {
+        override val name: String get() = "${outer.name} -> ${inner.name}"
+
+        override suspend fun <T> intercept(
+            runtime: ServerRuntime,
+            cont: suspend context(ServerRuntime) () -> T,
+        ): T = outer.intercept(runtime) { inner.interceptInstrumented(serverRuntime, cont) }
+    }
+
+/**
+ * Compiles a list of interceptors into a single chained interceptor with instrumentation.
+ *
+ * The first interceptor in the list executes first and so wraps everything the rest of the chain
+ * wraps, matching the HTTP and WebSocket chains. [ExecutionInterceptor.NoOp] entries are dropped
+ * rather than wrapped, since a chain link around a pass-through only costs a span.
+ */
+internal fun List<ExecutionInterceptor>.compileAndInstrument(): ExecutionInterceptor {
+    val effective = filter { it !== ExecutionInterceptor.NoOp }
+    if (effective.isEmpty()) return ExecutionInterceptor.NoOp
+    return effective.drop(1).fold(instrumentedLink(effective.first()), ::composeLinks)
+}

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ExecutionRuntime.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ExecutionRuntime.kt
@@ -3,21 +3,21 @@ package com.lightningkite.lightningserver.runtime
 import com.lightningkite.lightningserver.InternalLightningServerApi
 
 /**
- * This runtime, attributed to [initiator].
+ * This engine, running one execution attributed to [initiator].
  *
  * Everything a runtime offers — settings, serialization, telemetry, task dispatch — is process-wide
- * and shared; only the attribution differs per execution, so this delegates the whole of it and
- * overrides one property. Minted at the single seam every engine funnels through
- * ([handle] and the `*WithMetrics` helpers), never by user code, so that "who initiated this?" is
- * answerable from the runtime alone rather than reconstructed from whatever happens to be in scope.
+ * and shared; only the attribution differs per execution, so this delegates the whole of it and adds
+ * one property. Minted at the single seam every engine funnels through ([handle] and the
+ * `*WithMetrics` helpers), never by user code, so that "who initiated this?" is answerable from the
+ * runtime alone rather than reconstructed from whatever happens to be in scope.
  */
 @InternalLightningServerApi
-public fun ServerRuntime.forExecution(initiator: Initiator): ServerRuntime = ExecutionRuntime(this, initiator)
+public fun Engine.forExecution(initiator: Initiator): ServerRuntime = ExecutionRuntime(this, initiator)
 
 private class ExecutionRuntime(
-    engine: ServerRuntime,
+    engine: Engine,
     override val initiator: Initiator,
-) : ServerRuntime by engine
+) : ServerRuntime, Engine by engine
 
 /**
  * The socket this execution is a phase of.

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Initiator.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Initiator.kt
@@ -266,3 +266,30 @@ public fun Initiator.WebSocket.subConnection(path: RawWebSocketPath<PathSpec>): 
  */
 @InternalLightningServerApi
 public fun Initiator.WebSocket.rewritePath(path: RawWebSocketPath<PathSpec>): Initiator.WebSocket = copy(path = path)
+
+/**
+ * The parentage a launched execution inherits from the one that launched it.
+ *
+ * Just the two ids, because this is what has to survive a queue: an engine serializes it into the
+ * task's payload, and the task run on the other side builds its own [Initiator] from it. The
+ * launched execution's own id is minted where it runs, as every other initiator's is.
+ */
+@Serializable
+public data class ExecutionCause @InternalLightningServerApi constructor(
+    val causedBy: Uuid,
+    val rootExecutionId: Uuid,
+    /**
+     * The launcher's [Initiator.attributedTo], so the launched execution attributes to whoever the
+     * launcher did rather than to whatever sits at the head of the causal chain.
+     *
+     * This is the field that has to survive the queue for an indirect change to remain traceable to
+     * a person: a task has no request-log row of its own, so without this its only handle is
+     * [rootExecutionId], which names the outermost execution — and that one can be anonymous while
+     * an inner one holds the credentials.
+     */
+    val attributedTo: Uuid,
+)
+
+/** This execution, as the parentage of anything it launches. */
+@InternalLightningServerApi
+public val Initiator.cause: ExecutionCause get() = ExecutionCause(executionId, rootExecutionId, attributedTo)

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ServerRuntime.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/ServerRuntime.kt
@@ -1,47 +1,31 @@
 package com.lightningkite.lightningserver.runtime
 
-import com.lightningkite.lightningserver.definition.*
-import com.lightningkite.lightningserver.pathing.PathSpec
-import com.lightningkite.lightningserver.serialization.Serialization
-import com.lightningkite.lightningserver.settings.ServerSettings
-import com.lightningkite.lightningserver.websockets.DirectWebSocketSender
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.definition.Task
+import com.lightningkite.lightningserver.pathing.PathSpec0
+import com.lightningkite.lightningserver.pathing.PathSpec1
+import com.lightningkite.lightningserver.pathing.PathSpec2
+import com.lightningkite.lightningserver.pathing.PathSpec3
 import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
-import com.lightningkite.services.Namespaced
-import com.lightningkite.services.SettingContext
-import kotlinx.serialization.modules.SerializersModule
-import kotlin.time.Clock
+import com.lightningkite.lightningserver.websockets.WebSocketTopic
 
 /**
- * Core interface representing a running Lightning Server instance.
+ * An [Engine], running one execution on behalf of an [initiator].
  *
- * ServerRuntime provides the execution context for a server, including:
- * - Access to the server definition (routes, handlers, settings)
- * - Serialization configuration for external (API) and internal (storage) use
- * - Settings management and access
- * - WebSocket subscription messaging
- * - Task execution
- * - Telemetry and clock access
- * - Reading settings
+ * An "execution" is one run of anything the server can run: an HTTP request, one WebSocket lifecycle
+ * phase, a task, a schedule tick, a startup task, or a pre-deploy task. Everything an execution needs
+ * beyond its attribution — settings, serialization, telemetry, task dispatch — is process-wide, so a
+ * runtime is an engine plus one extra property.
  *
- * Implementations of this interface are responsible for:
- * - Managing the server lifecycle
- * - Routing HTTP requests to appropriate handlers
- * - Executing scheduled and startup tasks
- * - Handling WebSocket connections and subscriptions
+ * ## Why this is a type rather than a convention
+ * Declaring `context(server: ServerRuntime)` says the work being done is attributable, and declaring
+ * `context(engine: Engine)` says it is not. That makes "who initiated this?" a question the compiler
+ * answers: work that must be audited cannot accidentally be written somewhere no initiator exists.
  *
+ * Runtimes are minted by the framework at the seam every engine funnels through
+ * ([com.lightningkite.lightningserver.runtime.forExecution]), never by user code.
  */
-public interface ServerRuntime : SettingContext, Namespaced {
-    /** Fixed namespace used when naming spans in the metrics backend. */
-    override val name: String get() = "lightningserver"
-
-    /** This runtime is the SettingContext for all its services. */
-    override val context: SettingContext get() = this
-
-    /**
-     * The server definition containing all routes, handlers, settings, and tasks.
-     */
-    public val server: ServerDefinition
-
+public interface ServerRuntime : Engine {
     /**
      * What started the execution this runtime is serving.
      *
@@ -52,122 +36,92 @@ public interface ServerRuntime : SettingContext, Namespaced {
      * `ApiHttpHandler` and `ApiWebSocketHandler`. Reaching that by parameter would mean adding one to
      * `HttpHandler.handle`, and so to every endpoint handler in the framework and in user code. The
      * runtime context is the only carrier already threaded to all three.
-     *
-     * A runtime obtained outside any execution — the engine itself, during boot — carries
-     * [Initiator.Direct].
      */
     public val initiator: Initiator
-
-    /**
-     * Whether the different parts of the webSocket handler (willConnect, didConnect, messageFromClient,
-     * messageFromSubscription, disconnect) all occur in the same process.  If they do, you can use RAM to store
-     * information between those events.
-     */
-    public val webSocketHandlersRunOnSameMachine: Boolean get() = true
-
-    /**
-     * The public URL at which this server is accessible.
-     *
-     * Defaults to the value from general settings.
-     */
-    override val publicUrl: String
-        get() = generalSettings().publicUrl
-
-    /**
-     * Serialization configuration for external API communication (HTTP bodies, etc.).
-     */
-    public val externalSerialization: Serialization
-
-    /**
-     * Serialization configuration for internal use (database storage, caching, etc.).
-     */
-    public val internalSerialization: Serialization
-
-    /**
-     * Clock used for time-based operations.
-     *
-     * Defaults to system clock but can be overridden for testing.
-     */
-    override val clock: Clock get() = Clock.System
-
-    /**
-     * Settings manager for accessing configured server settings.
-     */
-    public val settings: ServerSettings
-
-    /**
-     * Sends a WebSocket subscription message to all connections subscribed to the topic.
-     *
-     * The message will be delivered to all WebSocket connections that have subscribed
-     * to the topic with matching path parameters.
-     *
-     * @param event The subscription message to send, including topic, path args, and value
-     */
-    public suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(event: WebSocketSubscriptionMessage<PATH, T>)
-
-    /**
-     * Optional direct WebSocket sender for engines that support it (e.g., AWS).
-     *
-     * When available, allows bypassing the pub/sub mechanism for direct message sending
-     * to specific sockets. Used by [com.lightningkite.lightningserver.websockets.CoroutineWebSocketHandler]
-     * to optimize message delivery.
-     *
-     * @return DirectWebSocketSender implementation if supported, null otherwise
-     */
-    public val directWebSocketSender: DirectWebSocketSender? get() = null
-
-    /**
-     * Invokes a task for asynchronous execution.
-     *
-     * The exact execution mechanism (background thread, coroutine, queue, etc.)
-     * depends on the runtime implementation.
-     *
-     * @param input The input parameter for the task
-     */
-    public suspend fun <T> Task<T>.invoke(input: T)
-
-    /**
-     * Serializers module used for internal serialization.
-     */
-    override val internalSerializersModule: SerializersModule get() = internalSerialization.serializersModule
-
-    /**
-     * Unique identifier for this server instance.
-     *
-     * For single-machine engines, typically derived from network interface MAC address.
-     * For serverless deployments, may be a Lambda function ID or similar.
-     */
-    public val serverId: String
-
-    /**
-     * Version identifier for the running server.
-     *
-     * May be "Unknown" if version information is not available.
-     */
-    public val serverVersion: String
 }
 
-/*
- * TODO: API Recommendations for ServerRuntime.kt
+/**
+ * Sends a message to all WebSocket connections subscribed to this topic (no path parameters).
  *
- * 1. The openTelemetry property returns null by default with a TODO comment. This should either be
- *    implemented or the TODO removed if telemetry is truly optional. Document the expected behavior.
- *
- * 2. No lifecycle methods for server startup/shutdown. Consider adding:
- *    - suspend fun start()
- *    - suspend fun stop()
- *    - val isRunning: Boolean
- *
- * 3. The Task.invoke() method doesn't provide any feedback about task execution status or errors.
- *    Consider returning a result or providing a callback mechanism for task completion/failure.
- *
- * 4. sendWebSocketSubscriptionMessage doesn't document what happens if no connections are subscribed.
- *    Does it silently succeed? Document this behavior.
- *
- * 5. No way to query the server state (number of active connections, running tasks, etc.).
- *    Consider adding health/metrics accessors for observability.
- *
- * 6. The serverId and serverVersion have no validation. Consider validating that these are set
- *    properly during initialization or providing defaults.
+ * @param value The message to send
  */
+context(serverRuntime: ServerRuntime)
+public suspend fun <T> WebSocketTopic<PathSpec0, T>.send(value: T): Unit =
+    serverRuntime.sendWebSocketSubscriptionMessage(
+        WebSocketSubscriptionMessage(this, listOf(), value)
+    )
 
+/**
+ * Sends a message to all WebSocket connections subscribed to this topic with one path parameter.
+ *
+ * @param path1 The first path parameter value
+ * @param value The message to send
+ */
+context(serverRuntime: ServerRuntime)
+public suspend fun <A, T> WebSocketTopic<PathSpec1<A>, T>.send(
+    path1: A,
+    value: T,
+): Unit = serverRuntime.sendWebSocketSubscriptionMessage(
+    WebSocketSubscriptionMessage(this, listOf(path1), value)
+)
+
+/**
+ * Sends a message to all WebSocket connections subscribed to this topic with two path parameters.
+ *
+ * @param path1 The first path parameter value
+ * @param path2 The second path parameter value
+ * @param value The message to send
+ */
+context(serverRuntime: ServerRuntime)
+public suspend fun <A, B, T> WebSocketTopic<PathSpec2<A, B>, T>.send(
+    path1: A,
+    path2: B,
+    value: T,
+): Unit = serverRuntime.sendWebSocketSubscriptionMessage(
+    WebSocketSubscriptionMessage(this, listOf(path1, path2), value)
+)
+
+/**
+ * Sends a message to all WebSocket connections subscribed to this topic with three path parameters.
+ *
+ * @param path1 The first path parameter value
+ * @param path2 The second path parameter value
+ * @param path3 The third path parameter value
+ * @param value The message to send
+ */
+context(serverRuntime: ServerRuntime)
+public suspend fun <A, B, C, T> WebSocketTopic<PathSpec3<A, B, C>, T>.send(
+    path1: A,
+    path2: B,
+    path3: C,
+    value: T,
+): Unit = serverRuntime.sendWebSocketSubscriptionMessage(
+    WebSocketSubscriptionMessage(this, listOf(path1, path2, path3), value)
+)
+
+/**
+ * Queues a task for asynchronous execution, parented to the execution launching it.
+ *
+ * The task will be executed in the background. The exact execution mechanism depends
+ * on the engine implementation (e.g., GlobalScope.launch for single-machine engines).
+ *
+ * This takes a [ServerRuntime] rather than an [Engine] so that a launched task always has something
+ * to be caused by: parentage across a queue is the one thing the serializable initiator exists for,
+ * and a task launched from nowhere could not be joined back to the work that wanted it.
+ *
+ * @param input The input parameter for the task
+ */
+@OptIn(InternalLightningServerApi::class)
+context(serverRuntime: ServerRuntime)
+public suspend operator fun <T> Task<T>.invoke(input: T): Unit =
+    with(serverRuntime) {
+        this@invoke.invoke(input, serverRuntime.initiator.cause)
+    }
+
+/**
+ * Provides access to the ServerRuntime instance from a context receiver.
+ *
+ * This allows nested functions to access the runtime without explicit parameter passing.
+ */
+context(runner: ServerRuntime)
+public val serverRuntime: ServerRuntime get() = runner

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
@@ -54,23 +54,35 @@ private val errorType = TelemetryKey.OfString("error.type")
  * @return The HTTP response
  */
 @OptIn(InternalLightningServerApi::class)
-public suspend fun ServerRuntime.handle(
+public suspend fun Engine.handle(
     request: HttpRequest<PathSpec>,
     executionId: Uuid,
 ): HttpResponse = forExecution(
     Initiator.Http(executionId = executionId, endpoint = request.path)
 ).handleInExecution(request)
 
+/**
+ * Runs [body] as the whole of this execution, through every installed [ExecutionInterceptor].
+ *
+ * Sits inside the execution's telemetry span and outside the HTTP/WebSocket chains: an execution
+ * interceptor wraps the whole of what ran, and what it does belongs to that execution's trace.
+ */
+@OptIn(InternalLightningServerApi::class)
+private suspend fun <T> ServerRuntime.inExecution(body: suspend context(ServerRuntime) () -> T): T =
+    server.compiledExecutionInterceptors.intercept(this, body)
+
 private suspend fun ServerRuntime.handleInExecution(request: HttpRequest<PathSpec>): HttpResponse =
     instrumentHttpRequest(request) {
         var errorType: String? = null
 
         val response = try {
-            server.compiledHttpConnectionInterceptors.intercept(request) { req ->
-                @Suppress("UNCHECKED_CAST")
-                val outcome = this@handleInExecution.dispatchLogicalRequest(req as HttpRequest<PathSpec>)
-                errorType = outcome.errorType
-                outcome.response
+            inExecution {
+                this@handleInExecution.server.compiledHttpConnectionInterceptors.intercept(request) { req ->
+                    @Suppress("UNCHECKED_CAST")
+                    val outcome = this@handleInExecution.dispatchLogicalRequest(req as HttpRequest<PathSpec>)
+                    errorType = outcome.errorType
+                    outcome.response
+                }
             }
         } catch (e: Exception) {
             // Last-resort safety net. Exceptions thrown by an interceptor itself are now recovered
@@ -114,9 +126,10 @@ public suspend fun ServerRuntime.handleSubRequest(request: HttpRequest<PathSpec>
         "Sub-requests may only be dispatched from inside an HTTP execution, so that they can be " +
             "parented to the request that carried them; ${request.path} was dispatched from $outer."
     }
-    return with(forExecution(outer.subRequest(request.path))) {
+    val runtime = forExecution(outer.subRequest(request.path))
+    return with(runtime) {
         instrumentHttpRequest(request) {
-            val outcome = dispatchLogicalRequest(request)
+            val outcome = runtime.inExecution { runtime.dispatchLogicalRequest(request) }
             HttpInstrumentationResult(outcome.response, outcome.response.status.code, outcome.errorType)
         }
     }
@@ -229,7 +242,7 @@ private suspend fun ServerRuntime.dispatchLogicalRequest(request: HttpRequest<Pa
  * Wraps a WebSocket willConnect handler invocation with telemetry metrics.
  *
  * @param location The path specification for this WebSocket endpoint
- * @param serverRuntime The server runtime context
+ * @param engine The engine minting this execution
  * @param initiator The socket's connect initiator, minted by the engine and kept with the connection
  *   so that every later phase can derive its own from it with [phase].
  * @param request The WebSocket connection request
@@ -238,16 +251,17 @@ private suspend fun ServerRuntime.dispatchLogicalRequest(request: HttpRequest<Pa
 @OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.willConnectWithMetrics(
     location: PATH,
-    serverRuntime: ServerRuntime,
+    engine: Engine,
     initiator: Initiator.WebSocket,
     request: WebSocketConnectRequest<PATH>,
 ): STORAGE {
-    return with(serverRuntime.forExecution(initiator)) {
+    val runtime = engine.forExecution(initiator)
+    return with(runtime) {
         instrument("willConnect", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, request.sourceIp)
         }) {
-            willConnect(request)
+            runtime.inExecution { willConnect(request) }
         }
     }
 }
@@ -256,7 +270,7 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.wi
  * Wraps a WebSocket didConnect handler invocation with telemetry metrics.
  *
  * @param location The path specification for this WebSocket endpoint
- * @param serverRuntime The runtime this phase runs on
+ * @param engine The engine minting this execution
  * @param initiator This phase's initiator, derived from the socket's connect initiator with
  *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The established WebSocket connection
@@ -264,16 +278,17 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.wi
 @OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.didConnectWithMetrics(
     location: PATH,
-    serverRuntime: ServerRuntime,
+    engine: Engine,
     initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
 ) {
-    return with(serverRuntime.forExecution(initiator)) {
+    val runtime = engine.forExecution(initiator)
+    return with(runtime) {
         instrument("didConnect", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
         }) {
-            didConnect(connection)
+            runtime.inExecution { didConnect(connection) }
         }
     }
 }
@@ -284,7 +299,7 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.di
  * Records the frame type (text/binary) and size in telemetry.
  *
  * @param location The path specification for this WebSocket endpoint
- * @param serverRuntime The runtime this phase runs on
+ * @param engine The engine minting this execution
  * @param initiator This phase's initiator, derived from the socket's connect initiator with
  *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The WebSocket connection
@@ -293,12 +308,13 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.di
 @OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.messageFromClientWithMetrics(
     location: PATH,
-    serverRuntime: ServerRuntime,
+    engine: Engine,
     initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
     frame: WebSocketFrame,
 ) {
-    return with(serverRuntime.forExecution(initiator)) {
+    val runtime = engine.forExecution(initiator)
+    return with(runtime) {
         instrument("messageFromClient", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
@@ -315,7 +331,7 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
                 }
             )
         }) {
-            messageFromClient(connection, frame)
+            runtime.inExecution { messageFromClient(connection, frame) }
         }
     }
 }
@@ -324,7 +340,7 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
  * Wraps a WebSocket messageFromSubscription handler invocation with telemetry metrics.
  *
  * @param location The path specification for this WebSocket endpoint
- * @param serverRuntime The runtime this phase runs on
+ * @param engine The engine minting this execution
  * @param initiator This phase's initiator, derived from the socket's connect initiator with
  *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The WebSocket connection
@@ -333,18 +349,19 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
 @OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.messageFromSubscriptionWithMetrics(
     location: PATH,
-    serverRuntime: ServerRuntime,
+    engine: Engine,
     initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
     topic: WebSocketSubscriptionMessage<*, *>,
 ) {
-    return with(serverRuntime.forExecution(initiator)) {
+    val runtime = engine.forExecution(initiator)
+    return with(runtime) {
         instrument("messageFromSubscription", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
             put(wsSubscriptionTopic, topic.topic.location.toString())
         }) {
-            messageFromSubscription(connection, topic)
+            runtime.inExecution { messageFromSubscription(connection, topic) }
         }
     }
 }
@@ -353,7 +370,7 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
  * Wraps a WebSocket disconnect handler invocation with telemetry metrics.
  *
  * @param location The path specification for this WebSocket endpoint
- * @param serverRuntime The runtime this phase runs on
+ * @param engine The engine minting this execution
  * @param initiator This phase's initiator, derived from the socket's connect initiator with
  *   [phase] so that the phase is its own execution while the socket's identity carries over
  * @param connection The WebSocket connection being closed
@@ -362,19 +379,20 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.me
 @OptIn(InternalLightningServerApi::class)
 public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.disconnectWithMetrics(
     location: PATH,
-    serverRuntime: ServerRuntime,
+    engine: Engine,
     initiator: Initiator.WebSocket,
     connection: WebSocketConnection<PATH, STORAGE>,
     reason: WebSocketClose,
 ) {
-    return with(serverRuntime.forExecution(initiator)) {
+    val runtime = engine.forExecution(initiator)
+    return with(runtime) {
         instrument("disconnect", TelemetryAttributes {
             put(wsRoute, location.toString())
             put(TelemetryKeys.Net.peerIp, connection.request.sourceIp)
             put(wsDisconnectCode, reason.code.toLong())
             put(wsDisconnectReason, reason.name)
         }) {
-            disconnect(connection, reason)
+            runtime.inExecution { disconnect(connection, reason) }
         }
     }
 }
@@ -388,106 +406,112 @@ public suspend fun <PATH : PathSpec, STORAGE> WebSocketHandler<PATH, STORAGE>.di
 private fun PathSpec0.asPathSegments(): PathSegments = PathSegments.parse(toString())
 
 /**
- * Executes a task with telemetry metrics.
- *
- * @param location The path specification for this task
- * @param input The input parameter for the task
+ * The facts that keep one kind of task-like execution distinguishable from another: how its span is
+ * named and labelled, and which [Initiator] it is attributed to. Everything else about running one is
+ * identical, and lives in [executeTaskLike].
  */
 @OptIn(InternalLightningServerApi::class)
-context(serverRuntime: ServerRuntime)
-public suspend fun <T> Task<T>.executeWithMetrics(location: PathSpec0, input: T) {
-    // Anchors to itself: nothing launched it that this call site can see. Tasks inherit their
-    // launcher's parentage — and with it the anchor — where that is threaded through.
+private enum class TaskKind(
+    val label: String,
+    val telemetryType: String,
+    val initiator: (
+        executionId: Uuid,
+        causedBy: Uuid?,
+        rootExecutionId: Uuid,
+        attributedTo: Uuid,
+        location: PathSegments,
+    ) -> Initiator,
+) {
+    Task("task", "TASK", { id, by, root, who, at -> Initiator.Task(id, by, root, who, at) }),
+    Schedule("schedule", "SCHEDULE", { id, by, root, who, at -> Initiator.Schedule(id, by, root, who, at) }),
+    // Startup and pre-deploy have no launcher and no request anywhere in their ancestry, so they
+    // derive their own anchor and there is nothing to pass.
+    Startup("startup", "STARTUP", { id, by, root, _, at -> Initiator.Startup(id, by, root, at) }),
+    PreDeploy("predeploy", "PREDEPLOY", { id, by, root, _, at -> Initiator.PreDeploy(id, by, root, at) }),
+}
+
+/**
+ * Mints the execution for one task-like run, instruments it, and runs [body] inside it.
+ *
+ * The four kinds differ only in the three facts [TaskKind] holds and in what they invoke, so this is
+ * the whole of what "run a task" means; the public entry points below exist to name the receiver each
+ * kind is invoked on.
+ *
+ * @param cause The execution that launched this one, as the engine received it — over a queue for a
+ *   serverless engine, in memory for a single-process one. Only a queued [Task] can have one; the
+ *   other three kinds are started by the server itself and pass null.
+ */
+@OptIn(InternalLightningServerApi::class)
+private suspend fun Engine.executeTaskLike(
+    kind: TaskKind,
+    location: PathSpec0,
+    cause: ExecutionCause?,
+    body: suspend context(ServerRuntime) () -> Unit,
+) {
     val executionId = Uuid.random()
-    val runtime = serverRuntime.forExecution(
-        Initiator.Task(
-            executionId = executionId,
-            attributedTo = executionId,
-            location = location.asPathSegments(),
+    val runtime = forExecution(
+        kind.initiator(
+            executionId,
+            cause?.causedBy,
+            // With no launcher this execution heads its own causal chain, so it is its own root.
+            cause?.rootExecutionId ?: executionId,
+            // And attributes to itself, which resolves to no request row — the honest answer for a
+            // schedule tick or a startup task. A launched task inherits its launcher's anchor.
+            cause?.attributedTo ?: executionId,
+            location.asPathSegments(),
         )
     )
     // Span name includes the location so traces distinguish one task from another, the same way
     // HTTP root spans are named "$method $route". Locations are a fixed, static set, so this is
     // low-cardinality.
     return with(runtime) {
-        instrument("task $location", TelemetryAttributes {
-            put(taskType, "TASK")
+        instrument("${kind.label} $location", TelemetryAttributes {
+            put(taskType, kind.telemetryType)
             put(taskRoute, location.toString())
         }) {
-            this@executeWithMetrics.executeInline(input)
+            runtime.inExecution(body)
         }
     }
 }
+
+/**
+ * Executes a task with telemetry metrics.
+ *
+ * @param location The path specification for this task
+ * @param input The input parameter for the task
+ * @param cause The execution that launched this task, or null when nothing launched it, such as a
+ *   manual invocation.
+ */
+context(engine: Engine)
+public suspend fun <T> Task<T>.executeWithMetrics(location: PathSpec0, input: T, cause: ExecutionCause?): Unit =
+    engine.executeTaskLike(TaskKind.Task, location, cause) { executeInline(input) }
 
 /**
  * Executes a scheduled task with telemetry metrics.
  *
  * @param location The path specification for this scheduled task
  */
-@OptIn(InternalLightningServerApi::class)
-context(serverRuntime: ServerRuntime)
-public suspend fun ScheduledTask.executeWithMetrics(location: PathSpec0) {
-    // Anchors to itself: nothing launched it that this call site can see. Tasks inherit their
-    // launcher's parentage — and with it the anchor — where that is threaded through.
-    val executionId = Uuid.random()
-    val runtime = serverRuntime.forExecution(
-        Initiator.Schedule(
-            executionId = executionId,
-            attributedTo = executionId,
-            location = location.asPathSegments(),
-        )
-    )
-    return with(runtime) {
-        instrument("schedule $location", TelemetryAttributes {
-            put(taskType, "SCHEDULE")
-            put(taskRoute, location.toString())
-        }) {
-            this@executeWithMetrics.execute()
-        }
-    }
-}
+context(engine: Engine)
+public suspend fun ScheduledTask.executeWithMetrics(location: PathSpec0): Unit =
+    engine.executeTaskLike(TaskKind.Schedule, location, cause = null) { execute() }
 
 /**
  * Executes a startup task with telemetry metrics.
  *
  * @param location The path specification for this startup task
  */
-@OptIn(InternalLightningServerApi::class)
-context(serverRuntime: ServerRuntime)
-public suspend fun StartupTask.executeWithMetrics(location: PathSpec0) {
-    val runtime = serverRuntime.forExecution(
-        Initiator.Startup(executionId = Uuid.random(), location = location.asPathSegments())
-    )
-    return with(runtime) {
-        instrument("startup $location", TelemetryAttributes {
-            put(taskType, "STARTUP")
-            put(taskRoute, location.toString())
-        }) {
-            execute()
-        }
-    }
-}
+context(engine: Engine)
+public suspend fun StartupTask.executeWithMetrics(location: PathSpec0): Unit =
+    engine.executeTaskLike(TaskKind.Startup, location, cause = null) { execute() }
 
 /**
  * Executes a pre-deploy task with telemetry metrics.
  *
  * @param location The path specification for this pre-deploy task
  */
-@OptIn(InternalLightningServerApi::class)
-context(serverRuntime: ServerRuntime)
-public suspend fun PreDeployTask.executeWithMetrics(location: PathSpec0) {
-    val runtime = serverRuntime.forExecution(
-        Initiator.PreDeploy(executionId = Uuid.random(), location = location.asPathSegments())
-    )
-    return with(runtime) {
-        instrument("predeploy $location", TelemetryAttributes {
-            put(taskType, "PREDEPLOY")
-            put(taskRoute, location.toString())
-        }) {
-            execute()
-        }
-    }
-}
+context(engine: Engine)
+public suspend fun PreDeployTask.executeWithMetrics(location: PathSpec0): Unit =
+    engine.executeTaskLike(TaskKind.PreDeploy, location, cause = null) { execute() }
 
 /**
  * Instruments a suspend block with the metrics backend, creating a named child span.
@@ -500,7 +524,7 @@ public suspend fun PreDeployTask.executeWithMetrics(location: PathSpec0) {
  * @param action The code to run inside the span
  * @return The result of [action]
  */
-context(runtime: ServerRuntime)
+context(runtime: Engine)
 public suspend fun <T> instrument(
     name: String,
     attributes: TelemetryAttributes = emptyTelemetryAttributes(),
@@ -532,7 +556,7 @@ public data class HttpInstrumentationResult<out T>(
  * Used by [handle] for top-level requests and by bulk-endpoint handlers that re-dispatch inner
  * requests, giving each sub-request the same observability treatment as a normal request.
  */
-context(runtime: ServerRuntime)
+context(runtime: Engine)
 public suspend fun <T> instrumentHttpRequest(
     request: HttpRequest<*>,
     action: suspend () -> HttpInstrumentationResult<T>,

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/index.md
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/index.md
@@ -6,15 +6,28 @@ This package contains the core runtime system for Lightning Server applications.
 
 ### Core Runtime Interfaces
 
-- **[ServerRuntime.kt](ServerRuntime.kt)** - Primary interface for a running server instance. Defines the contract for
-  server execution including settings access, serialization, task execution, and WebSocket messaging.
+- **[Engine.kt](Engine.kt)** - Primary interface for a running server instance, one per process. Defines the contract
+  for server execution including settings access, serialization, task execution, and WebSocket messaging.
 
-- **[ServerRuntimeBase.kt](ServerRuntimeBase.kt)** - Abstract base implementation providing common functionality for all
-  runtimes including settings initialization, serialization setup, shared resources management, and startup task
+- **[EngineBase.kt](EngineBase.kt)** - Abstract base implementation providing common functionality for all
+  engines including settings initialization, serialization setup, shared resources management, and startup task
   orchestration.
 
-- **[ServerRuntime.ext.kt](ServerRuntime.ext.kt)** - Extension functions for convenient runtime operations including
-  setting access via `invoke()`, WebSocket topic messaging, task execution, and location lookups for handlers and tasks.
+- **[ServerRuntime.kt](ServerRuntime.kt)** - An engine running one execution, attributed to an [Initiator]. Declaring
+  `context(ServerRuntime)` rather than `context(Engine)` is how a declaration says its work is attributable. Also holds
+  the runtime-scoped extensions: WebSocket topic messaging and task launching.
+
+- **[Initiator.kt](Initiator.kt)** - What started one execution, and what caused it to start. Serializable, so
+  parentage survives a task queue.
+
+- **[ExecutionRuntime.kt](ExecutionRuntime.kt)** - Mints a [ServerRuntime] from an engine plus an initiator.
+
+- **[ExecutionInterceptor.kt](ExecutionInterceptor.kt)** - Wraps every execution the server runs, of every kind — HTTP,
+  each WebSocket phase, tasks, schedules, startup and pre-deploy — rather than one kind each, as the HTTP and WebSocket
+  interceptors do. Installed on a `ServerBuilder`; first installed is outermost.
+
+- **[Engine.ext.kt](Engine.ext.kt)** - Extension functions for convenient engine operations including
+  setting access via `invoke()`, the clock, and location lookups for handlers and tasks.
 
 ### Request Handling
 
@@ -43,8 +56,9 @@ This package contains the core runtime system for Lightning Server applications.
 
 ### Context Receivers
 
-This package makes extensive use of Kotlin context receivers to provide implicit access to the ServerRuntime. This
-allows clean code like:
+This package makes extensive use of Kotlin context parameters to provide implicit access to the engine or runtime.
+Take a `ServerRuntime` when the work is done on someone's behalf and could be audited; take an `Engine` when it is not,
+such as boot or settings resolution. This allows clean code like:
 
 ```kotlin
 context(serverRuntime: ServerRuntime)

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
@@ -7,7 +7,8 @@ import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.runtime.Initiator
 import com.lightningkite.lightningserver.runtime.ServerRuntime
-import com.lightningkite.lightningserver.runtime.ServerRuntimeBase
+import com.lightningkite.lightningserver.runtime.EngineBase
+import com.lightningkite.lightningserver.runtime.ExecutionCause
 import com.lightningkite.lightningserver.runtime.forExecution
 import com.lightningkite.lightningserver.runtime.phase
 import com.lightningkite.lightningserver.settings.ServerSettings
@@ -17,6 +18,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Clock
+import kotlin.uuid.Uuid
 
 /**
  * Test runtime for Lightning Server applications.
@@ -54,7 +56,14 @@ import kotlin.time.Clock
 public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.test() instead.") constructor(
     public val serverBuilder: SERVER,
     private val clockGet: () -> Clock = { Clock.System },  // TODO: always use mock clock, build in advancement features
-) : ServerRuntimeBase(serverBuilder.build()) {
+) : EngineBase(serverBuilder.build()), ServerRuntime {
+
+    /**
+     * A test has no server-side execution behind it, so it is the one place besides manual
+     * invocation that mints [Initiator.Direct] — see its documentation for why that hole exists.
+     */
+    @OptIn(InternalLightningServerApi::class)
+    override val initiator: Initiator = Initiator.Direct(Uuid.random())
 
     public companion object {
         internal val logger = KotlinLogging.logger("com.lightningkite.lightningserver.TestRunner")
@@ -84,9 +93,10 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
      * Executes tasks inline (synchronously) for testing.
      *
      * Unlike production runtimes, tasks don't run in the background but complete
-     * immediately, making tests deterministic.
+     * immediately, making tests deterministic. That also means the task body runs inside the
+     * launching execution rather than as one of its own, so there is nothing for [cause] to parent.
      */
-    override suspend fun <T> Task<T>.invoke(input: T) {
+    override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?) {
         this.executeInline(input)
     }
 

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/serialization/registerBasicMediaTypeCoders.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/serialization/registerBasicMediaTypeCoders.kt
@@ -5,7 +5,7 @@ import com.lightningkite.lightningserver.LightningServerDsl
 import com.lightningkite.lightningserver.definition.Runtime
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.runtime.ServerRuntime
-import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.engine
 import com.lightningkite.lightningserver.websockets.WebSocketFrame
 import com.lightningkite.services.data.*
 import com.lightningkite.services.serializers.KotlinBytesFormat
@@ -202,7 +202,7 @@ public class JsonMediaTypeCoder(
 @OptIn(ExperimentalSerializationApi::class)
 @Suppress("DSL_MARKER_APPLIED_TO_WRONG_TARGET")
 @LightningServerDsl
-public fun ServerBuilder.registerBasicMediaTypeCoders(serializersModule: Runtime<SerializersModule> = Runtime { serverRuntime.externalSerialization.serializersModule }) {
+public fun ServerBuilder.registerBasicMediaTypeCoders(serializersModule: Runtime<SerializersModule> = Runtime { engine.externalSerialization.serializersModule }) {
     register(JsonMediaTypeCoder {
         Json {
             this.serializersModule = serializersModule()

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/serialization/validation.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/serialization/validation.kt
@@ -2,19 +2,19 @@ package com.lightningkite.lightningserver.serialization
 
 import com.lightningkite.lightningserver.BadRequestException
 import com.lightningkite.lightningserver.definition.Runtime
-import com.lightningkite.lightningserver.runtime.ServerRuntime
-import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.Engine
+import com.lightningkite.lightningserver.runtime.engine
 import com.lightningkite.services.database.validation.AnnotationValidators
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
 public val AnnotationValidators.Companion.StandardWithInternalModule: Runtime<AnnotationValidators>
-    get() = Runtime { AnnotationValidators(serverRuntime.externalSerialization.serializersModule) }
+    get() = Runtime { AnnotationValidators(engine.externalSerialization.serializersModule) }
 
 public val AnnotationValidators.Companion.StandardWithExternalModule: Runtime<AnnotationValidators>
-    get() = Runtime { AnnotationValidators(serverRuntime.internalSerialization.serializersModule) }
+    get() = Runtime { AnnotationValidators(engine.internalSerialization.serializersModule) }
 
-public val ServerRuntime.validators: AnnotationValidators get() = server.annotationValidators()
+public val Engine.validators: AnnotationValidators get() = server.annotationValidators()
 
 public suspend fun <T> AnnotationValidators.assertValidOrBadRequest(serializer: KSerializer<T>, value: T) {
     val issues = validate(serializer, value)

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/settings/ServerSettings.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/settings/ServerSettings.kt
@@ -3,7 +3,7 @@ package com.lightningkite.lightningserver.settings
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.definition.builder.*
 import com.lightningkite.lightningserver.logger
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.services.otel.applyToLogback
 import kotlin.contracts.*
 
@@ -208,11 +208,11 @@ public class ServerSettings private constructor(
      * **Important**: After this function succeeds, settings can be accessed via [get] but
      * can no longer be modified via [set], [setStatic], or [include].
      *
-     * @receiver A [ServerRuntime] context required for logging and setting transformation
+     * @receiver An [Engine] context required for logging and setting transformation
      * @throws IllegalStateException if any required settings are missing
      * @throws Error if any settings fail to transform (includes detailed logging of all failures)
      */
-    context(server: ServerRuntime)
+    context(server: Engine)
     public fun ready() {
         val missing = settings.minus(serializable.keys + goal.keys + overrides.keys)
         if (missing.isNotEmpty()) throw IllegalStateException("Settings ${missing.joinToString { it.name }} are missing.")
@@ -255,12 +255,12 @@ public class ServerSettings private constructor(
      *
      * @param key The setting to retrieve
      * @return The transformed result value for this setting
-     * @receiver A [ServerRuntime] context required for the setting's transformation
+     * @receiver An [Engine] context required for the setting's transformation
      * @throws IllegalStateException if settings are not ready yet (call [ready] first)
      * @throws CircularOverrideException if a circular dependency is detected during resolution
      */
     @Suppress("UNCHECKED_CAST")
-    context(_: ServerRuntime)
+    context(_: Engine)
     public fun <SERIALIZABLE, RESULT> get(key: ServerSetting<SERIALIZABLE, RESULT>): RESULT {
         if (!ready) throw IllegalStateException("Settings not ready yet.")
 
@@ -344,10 +344,10 @@ public class ServerSettings private constructor(
      * Useful for pre-warming all settings or debugging the complete configuration state.
      *
      * @return A map of all settings to their transformed result values
-     * @receiver A [ServerRuntime] context required for transformation
+     * @receiver An [Engine] context required for transformation
      * @throws IllegalStateException if settings are not ready yet
      */
-    context(_: ServerRuntime)
+    context(_: Engine)
     public fun allGoals(): Map<ServerSetting<*, *>, Any?> = settings.associateWith { get(it) }
 
     private fun copy(

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/settings/webhook-helpers.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/settings/webhook-helpers.kt
@@ -6,6 +6,7 @@ import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.pathing.fullUrl
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.location
 import com.lightningkite.services.webhooksubservice.HttpAdapter
@@ -73,7 +74,7 @@ public operator fun <Input, Output> Runtime<HttpAdapter<Input, Output>>.invoke(h
  * Creates a webhook server module for a particular WebhookAdapterWithResponse.
  */
 public fun <Input, Output> serviceWebhook(
-    forThing: context(ServerRuntime) () -> WebhookAdapterWithResponse<Input, Output>,
+    forThing: context(Engine) () -> WebhookAdapterWithResponse<Input, Output>,
     frequency: Duration = 1.minutes,
     handler: suspend context(ServerRuntime) (Input) -> Output,
 ): WebhookServer<Input, Output> =

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocket.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/websockets/WebSocket.kt
@@ -5,6 +5,7 @@ import com.lightningkite.lightningserver.data.SerializableCache
 import com.lightningkite.lightningserver.http.HttpHeaders
 import com.lightningkite.lightningserver.http.QueryParameters
 import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.location
 import kotlinx.serialization.KSerializer
@@ -42,7 +43,7 @@ public data class WebSocketSubscriptionRequest<PATH : PathSpec, T>(
     val topic: WebSocketTopic<PATH, T>,
     val rawPathArguments: List<Any?>,
 ) : HasContextualPath<PATH> {
-    context(server: ServerRuntime)
+    context(server: Engine)
     override val pathInContext: ResolvedPath<PATH> get() = ResolvedPath(topic.location, rawPathArguments)
 }
 
@@ -63,7 +64,7 @@ public data class WebSocketSubscriptionMessage<PATH : PathSpec, T>(
     val rawPathArguments: List<Any?>,
     val value: T,
 ) : HasContextualPath<PATH> {
-    context(server: ServerRuntime)
+    context(server: Engine)
     override val pathInContext: ResolvedPath<PATH> get() = ResolvedPath(topic.location, rawPathArguments)
 }
 

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/definition/RuntimeCachedScopeTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/definition/RuntimeCachedScopeTest.kt
@@ -1,0 +1,78 @@
+package com.lightningkite.lightningserver.definition
+
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.runtime.Engine
+import com.lightningkite.lightningserver.runtime.ExecutionCause
+import com.lightningkite.lightningserver.runtime.EngineBase
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+private object EmptyServer : ServerBuilder()
+
+private class BareEngine : EngineBase(EmptyServer.build()) {
+    override val serverId: String = "bare"
+    override val serverVersion: String = "test"
+
+    override suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(
+        event: WebSocketSubscriptionMessage<PATH, T>,
+    ): Nothing = throw NotImplementedError()
+
+    override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?): Nothing =
+        throw NotImplementedError()
+}
+
+/**
+ * [Runtime.Cached] must cache at engine scope even when it is resolved from inside an execution.
+ *
+ * Resolving a [Runtime] is process-wide work — settings, serializer modules, validators — so it is
+ * keyed on the engine. But the context actually in scope inside a handler is a per-execution
+ * runtime, freshly minted for every request, so keying on whatever was handed in silently recomputes
+ * on every call. Nothing else catches this: the cache stays correct, it just stops being a cache,
+ * and the only symptom is the work being redone. `ApiHttpHandler` resolves the annotation validators
+ * through exactly this path on every typed request.
+ */
+@OptIn(InternalLightningServerApi::class)
+class RuntimeCachedScopeTest {
+    @Test
+    fun `cached resolves once across many executions`() {
+        var computations = 0
+        val cached = Runtime.Cached(Runtime { computations++ })
+        val engine: Engine = BareEngine()
+
+        with(engine) { cached() }
+        repeat(5) { with(engine.forExecution(Initiator.Direct(Uuid.random()))) { cached() } }
+
+        assertEquals(1, computations, "a process-wide value was recomputed per execution")
+    }
+
+    @Test
+    fun `an execution sees what the engine already resolved`() {
+        var computations = 0
+        val cached = Runtime.Cached(Runtime { computations++ })
+        val engine: Engine = BareEngine()
+
+        val fromEngine = with(engine) { cached() }
+        val fromExecution = with(engine.forExecution(Initiator.Direct(Uuid.random()))) { cached() }
+
+        assertEquals(fromEngine, fromExecution)
+        assertEquals(1, computations)
+    }
+
+    /** Two engines are genuinely different scopes, so the cache must not leak between them. */
+    @Test
+    fun `separate engines resolve separately`() {
+        var computations = 0
+        val cached = Runtime.Cached(Runtime { computations++ })
+
+        with(BareEngine()) { cached() }
+        with(BareEngine()) { cached() }
+
+        assertEquals(2, computations)
+    }
+}

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/definition/ServerSettingThreadSafetyTest.kt
@@ -1,6 +1,7 @@
 package com.lightningkite.lightningserver.definition
 
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
+import com.lightningkite.lightningserver.runtime.ExecutionCause
 import com.lightningkite.lightningserver.settings.ServerSettings
 import kotlinx.coroutines.*
 import kotlinx.serialization.builtins.serializer
@@ -29,9 +30,8 @@ class ServerSettingThreadSafetyTest {
         val cached = Runtime.Cached(runtime)
 
         // Create a minimal test runtime context
-        val testRuntime = object : com.lightningkite.lightningserver.runtime.ServerRuntime {
+        val testRuntime = object : com.lightningkite.lightningserver.runtime.Engine {
             override val server get() = throw NotImplementedError()
-            override val initiator get() = throw NotImplementedError()
             override val settings get() = throw NotImplementedError()
             override val internalSerialization get() = throw NotImplementedError()
             override val externalSerialization get() = throw NotImplementedError()
@@ -39,8 +39,10 @@ class ServerSettingThreadSafetyTest {
             override val serverVersion get() = ""
             override val projectName get() = ""
             override val sharedResources get() = throw NotImplementedError()
-            override suspend fun <T> com.lightningkite.lightningserver.definition.Task<T>.invoke(input: T) =
-                throw NotImplementedError()
+            override suspend fun <T> com.lightningkite.lightningserver.definition.Task<T>.invoke(
+                input: T,
+                cause: com.lightningkite.lightningserver.runtime.ExecutionCause?,
+            ) = throw NotImplementedError()
 
             override suspend fun <PATH : com.lightningkite.lightningserver.pathing.PathSpec, T> sendWebSocketSubscriptionMessage(
                 event: com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage<PATH, T>,
@@ -96,10 +98,9 @@ class ServerSettingThreadSafetyTest {
         }
     }
 
-    /** Minimal [ServerRuntime] stub whose only usable capability is acting as the settings/transformation context. */
-    private fun stubRuntime(): ServerRuntime = object : ServerRuntime {
+    /** Minimal [Engine] stub whose only usable capability is acting as the settings/transformation context. */
+    private fun stubRuntime(): Engine = object : Engine {
         override val server get() = throw NotImplementedError()
-        override val initiator get() = throw NotImplementedError()
         override val settings get() = throw NotImplementedError()
         override val internalSerialization get() = throw NotImplementedError()
         override val externalSerialization get() = throw NotImplementedError()
@@ -107,7 +108,7 @@ class ServerSettingThreadSafetyTest {
         override val serverVersion get() = ""
         override val projectName get() = ""
         override val sharedResources get() = throw NotImplementedError()
-        override suspend fun <T> Task<T>.invoke(input: T) = throw NotImplementedError()
+        override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?) = throw NotImplementedError()
         override suspend fun <PATH : com.lightningkite.lightningserver.pathing.PathSpec, T> sendWebSocketSubscriptionMessage(
             event: com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage<PATH, T>,
         ) = throw NotImplementedError()

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ExecutionInterceptorTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/ExecutionInterceptorTest.kt
@@ -1,0 +1,159 @@
+package com.lightningkite.lightningserver.runtime
+
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.definition.GeneralServerSettings
+import com.lightningkite.lightningserver.definition.PreDeployTask
+import com.lightningkite.lightningserver.definition.ScheduledTask
+import com.lightningkite.lightningserver.definition.StartupTask
+import com.lightningkite.lightningserver.definition.Task
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.definition.generalSettings
+import com.lightningkite.lightningserver.http.HttpConnectionInterceptor
+import com.lightningkite.lightningserver.http.HttpHandler
+import com.lightningkite.lightningserver.http.HttpResponse
+import com.lightningkite.lightningserver.http.get
+import com.lightningkite.lightningserver.pathing.PathSpec0
+import com.lightningkite.lightningserver.pathing.RawWebSocketPath
+import com.lightningkite.lightningserver.plainText
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.websockets.WebSocketConnectRequest
+import com.lightningkite.lightningserver.websockets.WebSocketHandler
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.builtins.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+import kotlin.uuid.Uuid
+
+/**
+ * An [ExecutionInterceptor] is the only chain that claims to see *everything the server runs*, so
+ * these tests check that claim directly: one interceptor, every kind of entry point, and an assertion
+ * that each one arrived.
+ */
+class ExecutionInterceptorTest {
+
+    private class Recorder : ExecutionInterceptor {
+        val seen = ArrayList<Initiator>()
+        override suspend fun <T> intercept(
+            runtime: ServerRuntime,
+            cont: suspend context(ServerRuntime) () -> T,
+        ): T {
+            seen.add(runtime.initiator)
+            return with(runtime) { cont() }
+        }
+    }
+
+    /** Records when it starts and finishes, so nesting order is visible in one flat list. */
+    private class Marker(override val name: String, val log: MutableList<String>) : ExecutionInterceptor {
+        override suspend fun <T> intercept(
+            runtime: ServerRuntime,
+            cont: suspend context(ServerRuntime) () -> T,
+        ): T {
+            log.add("$name in")
+            try {
+                return with(runtime) { cont() }
+            } finally {
+                log.add("$name out")
+            }
+        }
+    }
+
+    @OptIn(InternalLightningServerApi::class)
+    @Test
+    fun `every kind of execution passes through the chain`() {
+        val recorder = Recorder()
+        val server = object : ServerBuilder() {
+            init {
+                registerBasicMediaTypeCoders()
+                install(recorder)
+            }
+
+            val endpoint = path.path("test").get bind HttpHandler { HttpResponse.plainText("hi") }
+            val socket = path.path("socket") bind WebSocketHandler<PathSpec0, Unit>(willConnect = {})
+            val task = path.path("task") bind Task(Unit.serializer()) {}
+            val schedule = path.path("schedule") bind ScheduledTask(frequency = 1.hours) {}
+            val startup = path.path("startup") bind StartupTask {}
+            val preDeploy = path.path("preDeploy") bind PreDeployTask {}
+        }
+        server.test(settings = { generalSettings set GeneralServerSettings() }) {
+            runBlocking {
+                server.endpoint.test()
+                server.task.executeWithMetrics(server.task.location, Unit, cause = null)
+                server.schedule.executeWithMetrics(server.schedule.location)
+                server.startup.executeWithMetrics(server.startup.location)
+                server.preDeploy.executeWithMetrics(server.preDeploy.location)
+                // The test runner drives sockets without the metrics helpers, so the socket seam is
+                // exercised the way an engine does it.
+                server.socket.willConnectWithMetrics(
+                    location = server.socket.location,
+                    engine = engine,
+                    initiator = Initiator.WebSocket(
+                        executionId = Uuid.random(),
+                        socketId = Uuid.random(),
+                        path = RawWebSocketPath("socket"),
+                        phase = Initiator.WebSocket.Phase.Connect,
+                    ),
+                    request = WebSocketConnectRequest(RawWebSocketPath("socket")),
+                )
+            }
+        }
+
+        assertEquals(
+            listOf("Http", "Task", "Schedule", "Startup", "PreDeploy", "WebSocket"),
+            recorder.seen.map { it::class.simpleName },
+        )
+    }
+
+    @Test
+    fun `the first installed interceptor is the outermost`() {
+        val log = ArrayList<String>()
+        val server = object : ServerBuilder() {
+            init {
+                registerBasicMediaTypeCoders()
+                install(Marker("first", log))
+                install(Marker("second", log))
+            }
+
+            val endpoint = path.path("test").get bind HttpHandler { HttpResponse.plainText("hi") }
+        }
+        server.test(settings = { generalSettings set GeneralServerSettings() }) {
+            runBlocking { server.endpoint.test() }
+        }
+
+        assertEquals(listOf("first in", "second in", "second out", "first out"), log)
+    }
+
+    @Test
+    fun `execution interceptors wrap the HTTP chain`() {
+        val log = ArrayList<String>()
+        val server = object : ServerBuilder() {
+            init {
+                registerBasicMediaTypeCoders()
+                install(Marker("execution", log))
+                install(HttpConnectionInterceptor { request, cont ->
+                    log.add("http in")
+                    try {
+                        cont(request)
+                    } finally {
+                        log.add("http out")
+                    }
+                })
+            }
+
+            val endpoint = path.path("test").get bind HttpHandler {
+                log.add("handler")
+                HttpResponse.plainText("hi")
+            }
+        }
+        server.test(settings = { generalSettings set GeneralServerSettings() }) {
+            runBlocking { server.endpoint.test() }
+        }
+
+        assertEquals(
+            listOf("execution in", "http in", "handler", "http out", "execution out"),
+            log,
+        )
+    }
+}

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/TaskParentageTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/runtime/TaskParentageTest.kt
@@ -1,0 +1,130 @@
+package com.lightningkite.lightningserver.runtime
+
+import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.definition.Task
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.pathing.PathSpec0
+import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
+import com.lightningkite.lightningserver.pathing.path
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.uuid.Uuid
+
+/** Every initiator a task run under [QueueingEngine] saw, in the order the tasks ran. */
+private val recorded = mutableListOf<Initiator>()
+
+private object TestServer : ServerBuilder() {
+    val second: Task<Unit> = path.path("second") bind Task(Unit.serializer()) {
+        recorded += serverRuntime.initiator
+    }
+    val first: Task<Unit> = path.path("first") bind Task(Unit.serializer()) {
+        recorded += serverRuntime.initiator
+        second(Unit)
+    }
+}
+
+/**
+ * An engine whose task queue is a real queue: launching serializes the payload to a string and drops
+ * every live object, the way a Lambda invocation does. Nothing reaches the task run except what was
+ * written into that string.
+ *
+ * This is the only way to test parentage honestly. `TestRunner` runs tasks inline for determinism, so
+ * a task there never leaves the launching execution and would appear to inherit parentage no matter
+ * what the engines actually serialize.
+ */
+@OptIn(InternalLightningServerApi::class)
+private class QueueingEngine : EngineBase(TestServer.build()) {
+    override val serverId: String = "queueing"
+    override val serverVersion: String = "test"
+
+    override suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(
+        event: WebSocketSubscriptionMessage<PATH, T>,
+    ): Nothing = throw NotImplementedError()
+
+    /** The queued form. Tasks here take [Unit], so parentage is the whole of the payload. */
+    @Serializable
+    private data class Queued(val location: String, val cause: ExecutionCause?)
+
+    private val queue = ArrayDeque<String>()
+
+    override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?) {
+        queue.addLast(Json.encodeToString(Queued.serializer(), Queued(location.toString(), cause)))
+    }
+
+    /** Runs everything queued, reading each payload back the way a fresh process would. */
+    suspend fun drain() {
+        while (queue.isNotEmpty()) {
+            val queued = Json.decodeFromString(Queued.serializer(), queue.removeFirst())
+            val location = PathSpec0.fromString(queued.location)
+            @Suppress("UNCHECKED_CAST")
+            val task = server.tasks.getValue(location) as Task<Unit>
+            task.executeWithMetrics(location, Unit, queued.cause)
+        }
+    }
+}
+
+/**
+ * A task launched from an execution must be able to name that execution after crossing a queue —
+ * the one thing §2.2 of the refactor makes the initiator serializable for.
+ */
+@OptIn(InternalLightningServerApi::class)
+class TaskParentageTest {
+    @Test
+    fun `parentage survives the queue, and the root survives two hops`() {
+        recorded.clear()
+        val engine = QueueingEngine()
+        with(engine) { settings.readyUsingDefaults() }
+
+        val requestId = Uuid.random()
+        runBlocking {
+            val request = engine.forExecution(
+                Initiator.Http(
+                    executionId = requestId,
+                    endpoint = RawHttpEndpoint<PathSpec>(asString = "/thing", method = HttpMethod.GET),
+                )
+            )
+            with(request) { TestServer.first(Unit) }
+            // `first` queues `second` while it runs, so one drain covers both hops.
+            engine.drain()
+        }
+
+        assertEquals(2, recorded.size, "Expected both tasks to run. Got: $recorded")
+
+        val first = recorded[0] as Initiator.Task
+        assertEquals(requestId, first.causedBy, "The task should name the request that launched it.")
+        assertEquals(requestId, first.rootExecutionId)
+        assertNotEquals(requestId, first.executionId, "A task is its own execution, not the request's.")
+
+        val second = recorded[1] as Initiator.Task
+        assertEquals(first.executionId, second.causedBy, "A task launched from a task names that task.")
+        assertEquals(
+            requestId,
+            second.rootExecutionId,
+            "The root must survive every hop, or \"everything caused by request X\" needs a recursive walk.",
+        )
+    }
+
+    @Test
+    fun `a task with nothing behind it heads its own chain`() {
+        recorded.clear()
+        val engine = QueueingEngine()
+        with(engine) { settings.readyUsingDefaults() }
+
+        runBlocking {
+            with(engine) { TestServer.second.invoke(Unit, cause = null) }
+            engine.drain()
+        }
+
+        val only = recorded.single() as Initiator.Task
+        assertEquals(null, only.causedBy)
+        assertEquals(only.executionId, only.rootExecutionId)
+    }
+}

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/TaskSpanTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/telemetry/TaskSpanTest.kt
@@ -49,7 +49,7 @@ class TaskSpanTest {
         ) {
             cleanup.executeWithMetrics(cleanup.location)
             reindex.executeWithMetrics(reindex.location)
-            sendEmail.executeWithMetrics(sendEmail.location, Unit)
+            sendEmail.executeWithMetrics(sendEmail.location, Unit, cause = null)
             migrate.executeWithMetrics(migrate.location)
             warmup.executeWithMetrics(warmup.location)
 

--- a/demo/src/main/kotlin/com/lightningkite/lightningserver/demo/main.kt
+++ b/demo/src/main/kotlin/com/lightningkite/lightningserver/demo/main.kt
@@ -6,7 +6,7 @@ import com.lightningkite.lightningserver.engine.ktor.KtorEngine
 import com.lightningkite.lightningserver.engine.netty.NettyEngine
 import com.lightningkite.lightningserver.settings.loadFromFile
 import com.lightningkite.lightningserver.typed.contract.ApiAllowlist
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.typed.LightningServerKSchema
 import com.lightningkite.lightningserver.typed.contract.apiBaselineJson
 import com.lightningkite.lightningserver.typed.contract.diffApiContract
@@ -123,7 +123,7 @@ fun settingsSchema(output: File = File("settings.schema.json")) {
     println("Writing settings schema to ${output.absolutePath}")
     // Resolve the serializers module offline (default settings, no port, no service connections), then JSONify.
     val schema = SDK.withDefaultRuntime(Server) {
-        Server.settingsSchemaJson(contextOf<ServerRuntime>().internalSerializersModule)
+        Server.settingsSchemaJson(contextOf<Engine>().internalSerializersModule)
     }
     output.writeText(Json { prettyPrint = true }.encodeToString(JsonObject.serializer(), schema))
     println("Finished")

--- a/docs-guide/guide/overview.md
+++ b/docs-guide/guide/overview.md
@@ -44,6 +44,14 @@ scheduled task body, or a `.test {}` block.  That is why you can call `cache()`,
 `auth.fetch()`, and similar service accessors anywhere in those contexts without threading a
 parameter through your code.
 
+You will also see `context(engine: Engine)` on parts of the API.  An `Engine` is the process-wide
+server — settings, serialization, telemetry, task dispatch — and a `ServerRuntime` is an engine
+running one execution, carrying an `Initiator` that says what started that execution.  Since every
+`ServerRuntime` is an `Engine`, anything declaring `context(Engine)` is callable from a handler body
+too; the distinction matters when you write your own declarations.  Take a `ServerRuntime` when the
+work is done on someone's behalf, and an `Engine` when it is not — boot, settings resolution, SDK
+generation.
+
 If you call a context-requiring function outside of one of these provided contexts — e.g. during
 object initialization — the compiler will tell you a required context is missing.  The fix is
 always to move the call inside a handler, task, test, or other framework-managed scope.

--- a/docs-guide/guide/running.md
+++ b/docs-guide/guide/running.md
@@ -70,7 +70,7 @@ here as illustrative rather than as a drift-checked sample region.
 
 The `internalSerializersModule` property on the engine provides the
 serializers module that `loadFromFile` needs to parse custom settings types.
-It is a property of the engine (a `ServerRuntime`), not of `built` directly.
+It is a property of the engine (an `Engine`), not of `built` directly.
 
 ```kotlin
 // Illustrative — verified against demo/src/main/kotlin/.../main.kt.
@@ -84,7 +84,7 @@ fun main() {
     val built = Server.build()
     KtorEngine(built).apply {
         // loadFromFile reads settings.json and populates all declared ServerSetting values.
-        // internalSerializersModule is on the engine (a ServerRuntime) — it supplies the
+        // internalSerializersModule is on the engine (an Engine) — it supplies the
         // serializers needed to parse custom setting types registered by your ServerBuilder.
         settings.loadFromFile(KFile("settings.json"), internalSerializersModule)
         // start(Netty) blocks until the process is stopped.

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapter.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapter.kt
@@ -8,7 +8,8 @@ import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.path
-import com.lightningkite.lightningserver.runtime.ServerRuntimeBase
+import com.lightningkite.lightningserver.runtime.EngineBase
+import com.lightningkite.lightningserver.runtime.ExecutionCause
 import com.lightningkite.lightningserver.runtime.location
 import com.lightningkite.lightningserver.settings.*
 import com.lightningkite.lightningserver.websockets.*
@@ -41,7 +42,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 private val awsApiGatewayWsEndpointSetting = ServerSetting("awsApiGatewayWsEndpointSetting", "", String.serializer())
 
-public open class AwsAdapter(server: ServerDefinition) : ServerRuntimeBase(server), RequestStreamHandler, Resource {
+public open class AwsAdapter(server: ServerDefinition) : EngineBase(server), RequestStreamHandler, Resource {
 
     internal val logger: KLogger = KotlinLogging.logger("com.lightningkite.lightningserver.engine.awsserverless")
     internal var preventLambdaTimeoutReuse: Boolean = false
@@ -160,8 +161,8 @@ public open class AwsAdapter(server: ServerDefinition) : ServerRuntimeBase(serve
             .build()
     }
 
-    override suspend fun <T> Task<T>.invoke(input: T) {
-        tasks.launchTask(location, this, input)
+    override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?) {
+        tasks.launchTask(location, this, input, cause)
     }
 
     override val serverId: String

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterTask.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterTask.kt
@@ -3,6 +3,7 @@ package com.lightningkite.lightningserver.engine.awsserverless
 import com.lightningkite.lightningserver.AnonType
 import com.lightningkite.lightningserver.definition.Task
 import com.lightningkite.lightningserver.pathing.PathSpec0
+import com.lightningkite.lightningserver.runtime.ExecutionCause
 import com.lightningkite.lightningserver.runtime.executeWithMetrics
 import com.lightningkite.services.serializers.KotlinBytesFormat
 import kotlinx.coroutines.coroutineScope
@@ -16,10 +17,19 @@ internal class AwsAdapterTask(val root: AwsAdapter) {
     val json: Json get() = root.internalSerialization.json
     val format: KotlinBytesFormat get() = root.internalSerialization.kotlinBytesFormat
 
+    /**
+     * The queued payload, and the only thing that survives to the invocation that runs the task.
+     * [cause] rides along because on Lambda the launching invocation is gone by then: parentage that
+     * is not serialized here cannot be recovered on the other side at all.
+     */
     @Serializable
-    data class TaskInvoke(val taskName: String, val input: AnonType) : AwsLambdaInput
+    data class TaskInvoke(
+        val taskName: String,
+        val input: AnonType,
+        val cause: ExecutionCause? = null,
+    ) : AwsLambdaInput
 
-    suspend fun <T> launchTask(location: PathSpec0, task: Task<T>, input: T) {
+    suspend fun <T> launchTask(location: PathSpec0, task: Task<T>, input: T, cause: ExecutionCause?) {
         try {
             root.invokeLambda(InvokeRequest.builder().also {
                 it.functionName(System.getenv("AWS_LAMBDA_FUNCTION_NAME"))
@@ -29,7 +39,7 @@ internal class AwsAdapterTask(val root: AwsAdapter) {
                     SdkBytes.fromUtf8String(
                         json.encodeToString(
                             TaskInvoke.serializer(),
-                            TaskInvoke(location.toString(), AnonType(format, input, task.serializer))
+                            TaskInvoke(location.toString(), AnonType(format, input, task.serializer), cause)
                         )
                     )
                 )
@@ -52,7 +62,8 @@ internal class AwsAdapterTask(val root: AwsAdapter) {
                 with(root) {
                     task.executeWithMetrics(
                         p,
-                        event.input.value(root.internalSerialization.kotlinBytesFormat, task.serializer)
+                        event.input.value(root.internalSerialization.kotlinBytesFormat, task.serializer),
+                        event.cause,
                     )
                 }
                 APIGatewayV2HTTPResponse(statusCode = 204)

--- a/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/extensions.kt
+++ b/engine-ktor/src/main/kotlin/com/lightningkite/lightningserver/engine/ktor/extensions.kt
@@ -6,7 +6,7 @@ import com.lightningkite.lightningserver.http.HttpHeaders
 import com.lightningkite.lightningserver.logger
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
-import com.lightningkite.lightningserver.runtime.ServerRuntimeBase
+import com.lightningkite.lightningserver.runtime.EngineBase
 import kotlin.uuid.Uuid
 import com.lightningkite.services.data.MediaType
 import com.lightningkite.services.data.TypedData
@@ -34,7 +34,7 @@ internal fun Headers.adapt(): HttpHeaders = HttpHeaders(flattenEntries())
  * Extracts the real client IP from the configured proxy header if available.
  * Falls back to the origin remote address if the header is not present.
  */
-context(server: ServerRuntimeBase)
+context(server: EngineBase)
 internal suspend fun ApplicationCall.adapt(maxBody: Long): Pair<HttpRequest<PathSpec>, Uuid> {
     val adaptedHeaders = request.headers.adapt()
     val identity = adaptedHeaders.requestIdentity(ktorRunConfig().requestIdHeader) {

--- a/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalEngine.kt
+++ b/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalEngine.kt
@@ -75,7 +75,7 @@ public val forceWebSocketPubSub: ServerSetting.Direct<Boolean> = ServerSetting(
  *
  * @param server The server definition to run
  */
-public abstract class LocalEngine(server: ServerDefinition) : ServerRuntimeBase(server) {
+public abstract class LocalEngine(server: ServerDefinition) : EngineBase(server) {
     /**
      * The coroutine scope used for launching background tasks and schedules.
      * Defaults to GlobalScope but can be overridden for testing or custom lifecycle management.
@@ -163,12 +163,14 @@ public abstract class LocalEngine(server: ServerDefinition) : ServerRuntimeBase(
      * The task is launched in the engine's coroutine scope and errors are caught and reported.
      *
      * @param input The input value for the task
+     * @param cause The execution launching it, carried straight through: a single-process engine
+     *   hands the task to a coroutine rather than a queue, but the parentage recorded is the same.
      */
-    override suspend fun <T> Task<T>.invoke(input: T) {
+    override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?) {
         scope.launch {
             try {
                 logger.debug { "Handling task: $location" }
-                executeWithMetrics(location, input)
+                executeWithMetrics(location, input, cause)
             } catch (e: Exception) {
                 /*squish; already reported*/
             }

--- a/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
+++ b/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
@@ -4,7 +4,7 @@ import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.path
 import com.lightningkite.lightningserver.runtime.Initiator
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.runtime.forExecution
 import com.lightningkite.lightningserver.runtime.phase
 import com.lightningkite.lightningserver.websockets.*
@@ -29,7 +29,7 @@ public abstract class LocalWebSocketConnection<PATH : PathSpec, STORAGE>(
     private val handler: WebSocketHandler<PATH, STORAGE>,
     private val scope: CoroutineScope,
     /** Needed to deliver a subscription message, which is a fresh execution rather than part of one. */
-    private val server: ServerRuntime,
+    private val server: Engine,
     private val pubSub: (request: WebSocketSubscriptionRequest<*, Any?>) -> PubSubChannel<Any?>,
 ) : WebSocketConnection<PATH, STORAGE> {
 

--- a/engine-netty/src/main/kotlin/com/lightningkite/lightningserver/engine/netty/NettyEngine.kt
+++ b/engine-netty/src/main/kotlin/com/lightningkite/lightningserver/engine/netty/NettyEngine.kt
@@ -634,11 +634,14 @@ public class NettyEngine(
                 // Standard pub/sub mode
                 val mid = ctx.channel().attr(MID_KEY).get()
                 val handler = ctx.channel().attr(HANDLER_KEY).get()
-                if (mid != null && handler != null) {
+                val socketInitiator = ctx.channel().attr(INITIATOR_KEY).get()
+                if (mid != null && handler != null && socketInitiator != null) {
                     try {
                         scope.launch {
                             logger.error { "Disconnected because channel is inactive " }
-                            with(this@NettyEngine) { handler.disconnect(mid, WebSocketClose.GOING_AWAY) }
+                            with(this@NettyEngine.forExecution(socketInitiator.phase(Initiator.WebSocket.Phase.Disconnect))) {
+                                handler.disconnect(mid, WebSocketClose.GOING_AWAY)
+                            }
                         }
                     } catch (_: Throwable) {
                     }

--- a/files/src/main/kotlin/com/lightningkite/lightningserver/files/UploadEarlyEndpoints.kt
+++ b/files/src/main/kotlin/com/lightningkite/lightningserver/files/UploadEarlyEndpoints.kt
@@ -9,7 +9,7 @@ import com.lightningkite.lightningserver.http.get
 import com.lightningkite.lightningserver.http.post
 import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.runtime.now
-import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.engine
 import com.lightningkite.lightningserver.typed.ApiHttpHandler
 import com.lightningkite.lightningserver.typed.registerTable
 import com.lightningkite.lightningserver.typed.sdk.*
@@ -56,7 +56,7 @@ public class UploadEarlyEndpoint(
      */
     public val serializer: Runtime<ExternalServerFileSerializer> = Runtime.Cached {
         ExternalServerFileSerializer(
-            clock = serverRuntime.clock,
+            clock = engine.clock,
             scanners = fileScanner(),
             jail = files().root.then(jailFilePath),
             ready = files().root.then(filePath),

--- a/files/src/main/kotlin/com/lightningkite/lightningserver/files/helpers.kt
+++ b/files/src/main/kotlin/com/lightningkite/lightningserver/files/helpers.kt
@@ -1,6 +1,6 @@
 package com.lightningkite.lightningserver.files
 
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.services.files.*
 import kotlinx.serialization.ExperimentalSerializationApi
 
@@ -9,11 +9,11 @@ import kotlinx.serialization.ExperimentalSerializationApi
  *
  * Gotchas:
  * - fileObject conversion relies on a contextual ExternalServerFileSerializer being registered in the
- *   current ServerRuntime.externalSerialization serializers module. If it's missing or a different
+ *   current Engine.externalSerialization serializers module. If it's missing or a different
  *   serializer is registered, a ClassCastException/IllegalStateException will occur.
  */
 @Deprecated("Replace with 'externalFile'", ReplaceWith("externalFile", "com.lightningkite.lightningserver.files.externalFile"))
-context(runtime: ServerRuntime)
+context(runtime: Engine)
 public val ServerFile.fileObject: ExternalFile get() = externalFile
 
 /**
@@ -21,11 +21,11 @@ public val ServerFile.fileObject: ExternalFile get() = externalFile
  *
  * Gotchas:
  * - fileObject conversion relies on a contextual ExternalServerFileSerializer being registered in the
- *   current ServerRuntime.externalSerialization serializers module. If it's missing or a different
+ *   current Engine.externalSerialization serializers module. If it's missing or a different
  *   serializer is registered, a ClassCastException/IllegalStateException will occur.
  */
 @OptIn(ExperimentalSerializationApi::class)
-context(runtime: ServerRuntime)
+context(runtime: Engine)
 public val ServerFile.externalFile: ExternalFile
     get() {
         val ext =

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/DatabaseTableRegistration.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/DatabaseTableRegistration.kt
@@ -2,7 +2,7 @@ package com.lightningkite.lightningserver.typed
 
 import com.lightningkite.lightningserver.definition.builder.*
 import com.lightningkite.lightningserver.definition.*
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.services.data.toSealedMap
 import com.lightningkite.services.database.Database
 import com.lightningkite.services.database.DatabaseTableDefinition
@@ -16,7 +16,7 @@ import kotlinx.serialization.serializer
  * [tableDefinition], and the [preDeployTask] that reconciles it (creates the collection/indexes)
  * once per deploy.
  *
- * The registration is itself a [Runtime]<[Table]> — invoke it inside a [ServerRuntime] to get the
+ * The registration is itself a [Runtime]<[Table]> — invoke it inside an [Engine] to get the
  * live table (`myTable()`). All registrations are enumerable at runtime through
  * [ServerDefinition.allRegisteredTables], keyed by table name.
  */
@@ -25,7 +25,7 @@ public data class DatabaseTableRegistration<T : Any>(
     val tableDefinition: DatabaseTableDefinition<T>,
     val preDeployTask: PreDeployTask,
 ) : Runtime<Table<T>> {
-    context(server: ServerRuntime)
+    context(server: Engine)
     override fun invoke(): Table<T> = database().table(tableDefinition)
 }
 

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/kschema/LightningServerKSchemaGenerator.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/kschema/LightningServerKSchemaGenerator.kt
@@ -6,7 +6,7 @@ import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.definition.generalSettings
 import com.lightningkite.lightningserver.pathing.plus
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.typed.*
 import com.lightningkite.lightningserver.typed.contract.diffApiContract
 import com.lightningkite.lightningserver.typed.sdk.*
@@ -30,7 +30,7 @@ private fun InterfaceInfo.virtualTypeReference(registry: SerializationRegistry):
 public val ServerBuilder.lightningServerKSchemaFromDefaultRuntime: LightningServerKSchema get() = SDK.withDefaultRuntime(this) { lightningServerKSchema }
 
 
-public context(runtime: ServerRuntime)
+public context(runtime: Engine)
 val lightningServerKSchema: LightningServerKSchema
     get() {
         val registry = SerializationRegistry(runtime.externalSerialization.serializersModule).apply {

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/FetcherSdk.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/FetcherSdk.kt
@@ -3,7 +3,7 @@ package com.lightningkite.lightningserver.typed.sdk
 import com.lightningkite.lightningserver.auth.naturalLanguage
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.plus
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.typed.LiveVersion
 import com.lightningkite.lightningserver.typed.sdk.SDK.processToModules
 import com.lightningkite.lightningserver.typed.sdk.SDK.sdk
@@ -114,7 +114,7 @@ public class FetcherSdk(
      *
      * @param archive The archive where generated files will be written
      */
-    context(server: ServerRuntime)
+    context(server: Engine)
     override fun write(archive: Archive) {
         val processed = server.server.sdk(rootInfo).processToModules().ensureUniqueNames()
 
@@ -169,7 +169,7 @@ public class FetcherSdk(
             .joinTo(this, "\n", prefix = "\n", postfix = "\n") { "import $it" }
     }
 
-    context(_: ServerRuntime)
+    context(_: Engine)
     private fun Appendable.writeInterface(module: SDK.Module) {
         fun SDK.Module.writeInterface(depth: Int) {
 
@@ -227,7 +227,7 @@ public class FetcherSdk(
         module.writeInterface(0)
     }
 
-    context(server: ServerRuntime)
+    context(server: Engine)
     private fun Appendable.writeLive(module: SDK.Module) {
         fun PathSpec.toCodeString() = segments.joinToString("/", prefix = "\"", postfix = "\"") {
             when (it) {

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/KSerializer.ext.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/KSerializer.ext.kt
@@ -1,6 +1,6 @@
 package com.lightningkite.lightningserver.typed.sdk
 
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.services.data.serialNameFQN
 import com.lightningkite.services.database.*
 import kotlinx.serialization.*
@@ -25,7 +25,7 @@ public fun KSerializer<*>.kotlinTypeString(): String {
 }
 
 @OptIn(ExperimentalSerializationApi::class)
-context(server: ServerRuntime)
+context(server: Engine)
 public fun KSerializer<*>.kotlinSerializer(): String {
     nullElement()?.let { return it.kotlinSerializer() + ".nullable" }
 
@@ -103,7 +103,7 @@ public fun KSerializer<*>.subAndChildSerializers(): Array<KSerializer<*>> = null
     ?: arrayOf()
 
 @OptIn(ExperimentalSerializationApi::class)
-context(runtime: ServerRuntime)
+context(runtime: Engine)
 public fun KSerializer<*>.decontextualize(): KSerializer<*> =
     if (descriptor.kind == SerialKind.CONTEXTUAL)
         runtime.internalSerialization.serializersModule.getContextual(

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/SDK.ext.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/SDK.ext.kt
@@ -4,7 +4,7 @@ import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.definition.mapItems
 import com.lightningkite.lightningserver.http.HttpEndpoint
 import com.lightningkite.lightningserver.pathing.buildPathSpecMap
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.typed.ApiHttpHandler
 import com.lightningkite.lightningserver.typed.ApiWebSocketHandler
 import com.lightningkite.services.database.nullElement
@@ -72,7 +72,7 @@ public class TypingGenerationException internal constructor(
     cause
 )
 
-public fun ServerRuntime.usedTypes(): Collection<KSerializer<*>> {
+public fun Engine.usedTypes(): Collection<KSerializer<*>> {
     val seen = HashMap<SerialDescriptor, KSerializer<*>>()
 
     fun registerRecursive(serializer: KSerializer<*>) {

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/SDK.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/SDK.kt
@@ -5,8 +5,9 @@ import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.http.HttpEndpoint
 import com.lightningkite.lightningserver.pathing.*
-import com.lightningkite.lightningserver.runtime.ServerRuntime
-import com.lightningkite.lightningserver.runtime.ServerRuntimeBase
+import com.lightningkite.lightningserver.runtime.Engine
+import com.lightningkite.lightningserver.runtime.EngineBase
+import com.lightningkite.lightningserver.runtime.ExecutionCause
 import com.lightningkite.lightningserver.typed.ApiHttpHandler
 import com.lightningkite.lightningserver.typed.ApiWebSocketHandler
 import com.lightningkite.lightningserver.typed.sdk.SDK.sdk
@@ -106,7 +107,7 @@ public object SDK {
      * ## Creating a Custom Format
      *
      * To create a custom SDK format, implement the [Format] interface and override the [write] method.
-     * Your implementation will have access to the [ServerRuntime] context, which provides all the
+     * Your implementation will have access to the [Engine] context, which provides all the
      * information needed to generate client code.
      *
      * ### Step-by-Step Guide
@@ -163,7 +164,7 @@ public object SDK {
      *
      * ```kotlin
      * class SimpleJsonFormat(private val rootInfo: SdkModule.Info) : SDK.Format {
-     *     context(server: ServerRuntime)
+     *     context(server: Engine)
      *     override fun write(archive: Archive) {
      *         // Extract and process API structure
      *         val apiData = server.server.sdk(rootInfo)
@@ -232,7 +233,7 @@ public object SDK {
          * implementations, etc.) and writes them to the archive using the [Archive] API.
          *
          * The implementation should:
-         * 1. Analyze the server's API structure via the [ServerRuntime] context
+         * 1. Analyze the server's API structure via the [Engine] context
          * 2. Generate appropriate client code for the target language/platform
          * 3. Write all files to the archive using `Archive.entry()` and `Archive.sub()`
          *
@@ -241,7 +242,7 @@ public object SDK {
          * LightningServer provides several helper methods to assist with creating your
          * own [SDK.Format] implementations.
          *
-         * All [ServerRuntime] data is provided when `write` is called, but this data can be
+         * All [Engine] data is provided when `write` is called, but this data can be
          * difficult to parse into client code with proper api module structure defined during
          * the server-definition phase.
          *
@@ -257,13 +258,13 @@ public object SDK {
          *                directory, ZIP file, or single output stream depending on the
          *                [Archive] implementation used.
          *
-         * @receiver server The [ServerRuntime] providing access to API definitions,
+         * @receiver server The [Engine] providing access to API definitions,
          *                  type serializers, and server metadata
          *
          * @sample
          * ```kotlin
          * class MyCustomFormat : SDK.Format {
-         *     context(server: ServerRuntime)
+         *     context(server: Engine)
          *     override fun write(archive: Archive) {
          *         val apiData = server.server.sdk()
          *         archive.sink("api-client.txt") {
@@ -273,7 +274,7 @@ public object SDK {
          * }
          * ```
          */
-        context(server: ServerRuntime)
+        context(server: Engine)
         public fun write(archive: Archive)
     }
 
@@ -573,11 +574,11 @@ public object SDK {
      */
     public open class GenerationException(override val message: String) : Exception()
 
-    private class Runtime(server: ServerBuilder) : ServerRuntimeBase(server.build()) {
+    private class Runtime(server: ServerBuilder) : EngineBase(server.build()) {
         override val serverId: String = "SDK Runtime"
         override val serverVersion: String = "0.0.0"
 
-        override suspend fun <T> Task<T>.invoke(input: T): Nothing =
+        override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?): Nothing =
             throw NotImplementedError("SDK Runner only exists to retrieve serialization information")
 
         override suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(event: WebSocketSubscriptionMessage<PATH, T>): Nothing =
@@ -587,7 +588,7 @@ public object SDK {
     /**
      * Convenience method to generate SDK files using default server settings.
      *
-     * This method creates a temporary [ServerRuntime] from the [ServerBuilder],
+     * This method creates a temporary [Engine] from the [ServerBuilder],
      * initializes all settings with their default values, and then calls the
      * [Format.write] method to generate the SDK.
      *
@@ -605,7 +606,7 @@ public object SDK {
     /**
      * Convenience method to generate SDK files using default server settings.
      *
-     * This method creates a temporary [ServerRuntime] from the [ServerBuilder],
+     * This method creates a temporary [Engine] from the [ServerBuilder],
      * initializes all settings with their default values, and then calls the
      * [Format.write] method to generate the SDK.
      *
@@ -628,7 +629,7 @@ public object SDK {
      * stable in future versions.
      * */
     @OptIn(ExperimentalLightningServer::class)
-    context(server: ServerRuntime)
+    context(server: Engine)
     public fun Format.write(folder: KFile): Unit = write(Archive.folder(folder))
 
     /**
@@ -637,12 +638,12 @@ public object SDK {
      *
      * Like [Format.writeUsingDefaultSettings], this spins up a throwaway [Runtime] and initializes all settings with
      * their defaults via [com.lightningkite.lightningserver.settings.ServerSettings.readyUsingDefaults], so it is safe
-     * to run in CI. The provided [block] is executed with the temporary [ServerRuntime] as context.
+     * to run in CI. The provided [block] is executed with the temporary [Engine] as context.
      *
      * This lives inside [SDK] because it must access the package-private [Runtime] used by the SDK-generation path.
      */
     @OptIn(ExperimentalLightningServer::class)
-    public fun <T> withDefaultRuntime(server: ServerBuilder, block: context(ServerRuntime) () -> T): T {
+    public fun <T> withDefaultRuntime(server: ServerBuilder, block: context(Engine) () -> T): T {
         val runtime = Runtime(server)
         runtime.settings.readyUsingDefaults()
         return context(runtime) { block() }

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/TypescriptFetcherSdk.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/sdk/TypescriptFetcherSdk.kt
@@ -3,7 +3,7 @@ package com.lightningkite.lightningserver.typed.sdk
 import com.lightningkite.lightningserver.auth.naturalLanguage
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.plus
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.typed.sdk.SDK.processToModules
 import com.lightningkite.lightningserver.typed.sdk.SDK.sdk
 import com.lightningkite.services.data.ExperimentalLightningServer
@@ -142,7 +142,7 @@ public class TypescriptFetcherSdk(
      *
      * @param archive The archive where generated files will be written
      */
-    context(server: ServerRuntime)
+    context(server: Engine)
     override fun write(archive: Archive): Unit = when (fileStructure) {
         is Structure.SingleFile -> {
             val processed = server.server.sdk(rootInfo).processToModules().ensureUniqueNames()
@@ -200,7 +200,7 @@ public class TypescriptFetcherSdk(
 
 
     @OptIn(ExperimentalSerializationApi::class)
-    context(server: ServerRuntime)
+    context(server: Engine)
     private fun Appendable.writeTypeDefinitions(types: List<KSerializer<*>> = server.models()) {
         val stringSerialNames = HashSet<String>()
         // TypeScript merges declarations with the same exported name, so nested Kotlin types
@@ -391,7 +391,7 @@ public class TypescriptFetcherSdk(
      *
      * @param root The root module to generate an interface for
      */
-    context(server: ServerRuntime)
+    context(server: Engine)
     private fun Appendable.writeInterface(root: SDK.Module) {
         fun Appendable.appendInterface(module: SDK.Module, depth: Int) {
             if (depth == 0) appendLine("export interface ${module.info.interfaceName} {")
@@ -442,7 +442,7 @@ public class TypescriptFetcherSdk(
         appendInterface(root, 0)
     }
 
-    context(server: ServerRuntime)
+    context(server: Engine)
     private fun Appendable.writeLive(root: SDK.Module) {
         fun PathSpec.ts() = segments.joinToString("/", prefix = "`/", postfix = "`") {
             when (it) {
@@ -521,7 +521,7 @@ public class TypescriptFetcherSdk(
 
 
     @OptIn(ExperimentalSerializationApi::class)
-    private fun ServerRuntime.models() = usedTypes()
+    private fun Engine.models() = usedTypes()
         .filter { it.descriptor.simpleSerialName !in skipFromLsPackage }
         .sortedBy { it.descriptor.simpleSerialName }
         .distinctBy { it.tsType().substringBefore("<") } // Distinct by generics
@@ -537,13 +537,13 @@ public class TypescriptFetcherSdk(
         }
 
 
-    context(runtime: ServerRuntime)
+    context(runtime: Engine)
     private fun KSerializer<*>.tsTopLevelTypeName(): String = tsType()
         .substringBefore('<')
         .substringBefore('.')
 
     @OptIn(ExperimentalSerializationApi::class)
-    context(runtime: ServerRuntime)
+    context(runtime: Engine)
     private fun KSerializer<*>.tsType(): String = nullElement()?.let { it.tsType() + " | null | undefined" } ?: when {
         this.isUnit() -> "void"
         else -> buildString {

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/SettingsSchemaTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/SettingsSchemaTest.kt
@@ -1,7 +1,7 @@
 package com.lightningkite.lightningserver.typed
 
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
-import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
 import com.lightningkite.lightningserver.typed.sdk.SDK
 import kotlinx.serialization.json.JsonObject
@@ -27,7 +27,7 @@ class SettingsSchemaTest {
     @Test
     fun generatesValidRootSchema() {
         val root: JsonObject = SDK.withDefaultRuntime(SchemaServer) {
-            SchemaServer.settingsSchemaJson(contextOf<ServerRuntime>().internalSerializersModule)
+            SchemaServer.settingsSchemaJson(contextOf<Engine>().internalSerializersModule)
         }
 
         // additionalProperties:false at root flags typo'd keys


### PR DESCRIPTION
**Stack: 4 of 16.** Based on `split/e3` — review that one first.
Completes the refactor the previous two PRs set up.

- `Engine` separates from `ServerRuntime`: the engine is the process-lifetime
  thing (clock, server id, how to invoke a task), the runtime is per
  execution. Tasks now inherit their parent's `Initiator` rather than
  starting a fresh lineage.
- `Runtime` values cache at engine scope rather than execution scope. They
  were being rebuilt per request, which was both wasteful and wrong for
  anything holding a connection pool.
- `ExecutionInterceptor` covers every executable part of a server — http,
  websockets, tasks, schedules, startup, pre-deploy — rather than only the
  request-shaped ones. The audit layer needs the uniform seam; a request-only
  hook would have left privileged internal work unrecorded.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd