### PR TITLE
Execution ids are version-7 UUIDs minted at the engine's clock

### DIFF
--- a/core/src/main/kotlin/com/lightningkite/lightningserver/http/RequestIdentity.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/http/RequestIdentity.kt
@@ -1,5 +1,7 @@
 package com.lightningkite.lightningserver.http
 
+import com.lightningkite.lightningserver.runtime.Engine
+import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /**
@@ -16,8 +18,18 @@ public data class RequestIdentity(
     val upstreamRequestId: String? = null,
 )
 
-/** Generates a fresh authoritative request identifier. */
-public fun generateRequestId(): Uuid = Uuid.random()
+/**
+ * Generates a fresh authoritative request identifier.
+ *
+ * A version-7 UUID, stamped with the instant given by the [Engine]'s selected clock — the same clock
+ * [com.lightningkite.lightningserver.runtime.now] reads, so a test's injected clock controls the id's
+ * embedded timestamp. Because the id embeds its own mint time, the audit layer can elide a separate
+ * `at` column and derive time from the id. Keep every execution-id minting site on this function so
+ * that derivation stays sound and ids stay roughly time-ordered for index locality.
+ */
+@OptIn(ExperimentalUuidApi::class)
+context(engine: Engine)
+public fun generateRequestId(): Uuid = Uuid.generateV7NonMonotonicAt(engine.clock.now())
 
 /**
  * Determines the [RequestIdentity] for an incoming request.
@@ -38,6 +50,7 @@ public fun generateRequestId(): Uuid = Uuid.random()
  *   proxy, or that proxy does not stamp UUIDs. A fresh ID is generated in that case, so correlation
  *   degrades rather than failing.
  */
+context(engine: Engine)
 public fun HttpHeaders.requestIdentity(
     trustedRequestIdHeader: String?,
     onTrustedHeaderMissing: () -> Unit = {},

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Initiator.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/Initiator.kt
@@ -2,6 +2,7 @@ package com.lightningkite.lightningserver.runtime
 
 import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.http.PathSegments
+import com.lightningkite.lightningserver.http.generateRequestId
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
 import com.lightningkite.lightningserver.pathing.RawWebSocketPath
@@ -197,6 +198,7 @@ public sealed interface Initiator {
     @Serializable
     @SerialName("direct")
     public data class Direct @InternalLightningServerApi constructor(
+        // TODO: Require textual explanation?
         override val executionId: Uuid,
         override val causedBy: Uuid? = null,
         override val rootExecutionId: Uuid = executionId,
@@ -214,8 +216,9 @@ public sealed interface Initiator {
  * to it through [Initiator.causedBy] and to the whole batch through [Initiator.rootExecutionId].
  */
 @InternalLightningServerApi
+context(engine: Engine)
 public fun Initiator.Http.subRequest(endpoint: RawHttpEndpoint<PathSpec>): Initiator.Http = Initiator.Http(
-    executionId = Uuid.random(),
+    executionId = generateRequestId(),
     causedBy = executionId,
     rootExecutionId = rootExecutionId,
     endpoint = endpoint,
@@ -228,8 +231,9 @@ public fun Initiator.Http.subRequest(endpoint: RawHttpEndpoint<PathSpec>): Initi
  * that every phase of a socket names the connect that opened it.
  */
 @InternalLightningServerApi
+context(engine: Engine)
 public fun Initiator.WebSocket.phase(phase: Initiator.WebSocket.Phase): Initiator.WebSocket = copy(
-    executionId = Uuid.random(),
+    executionId = generateRequestId(),
     causedBy = executionId,
     rootExecutionId = rootExecutionId,
     phase = phase,
@@ -242,11 +246,12 @@ public fun Initiator.WebSocket.phase(phase: Initiator.WebSocket.Phase): Initiato
  * subscriptions; the physical connection carrying it stays reachable through [Initiator.causedBy].
  */
 @InternalLightningServerApi
+context(engine: Engine)
 public fun Initiator.WebSocket.subConnection(path: RawWebSocketPath<PathSpec>): Initiator.WebSocket {
     // One id for both, exactly as every engine mints a real connect. Minting two left a sub-socket's
     // own request-log row — which is keyed by socketId — unreachable from its execution id, so
     // nothing descending from it could find the row that names the person who opened it.
-    val id = Uuid.random()
+    val id = generateRequestId()
     return Initiator.WebSocket(
         executionId = id,
         causedBy = executionId,

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/implementationHelpers.kt
@@ -126,7 +126,7 @@ public suspend fun ServerRuntime.handleSubRequest(request: HttpRequest<PathSpec>
         "Sub-requests may only be dispatched from inside an HTTP execution, so that they can be " +
             "parented to the request that carried them; ${request.path} was dispatched from $outer."
     }
-    val runtime = forExecution(outer.subRequest(request.path))
+    val runtime = forExecution(with(this) { outer.subRequest(request.path) })
     return with(runtime) {
         instrumentHttpRequest(request) {
             val outcome = runtime.inExecution { runtime.dispatchLogicalRequest(request) }
@@ -448,7 +448,7 @@ private suspend fun Engine.executeTaskLike(
     cause: ExecutionCause?,
     body: suspend context(ServerRuntime) () -> Unit,
 ) {
-    val executionId = Uuid.random()
+    val executionId = with(this) { generateRequestId() }
     val runtime = forExecution(
         kind.initiator(
             executionId,

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.ext.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.ext.kt
@@ -41,7 +41,7 @@ public suspend fun <STORAGE> WebSocketHandler<PathSpec0, STORAGE>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    socketId: Uuid = Uuid.random(),
+    socketId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec0, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -75,7 +75,7 @@ public suspend fun <STORAGE, A> WebSocketHandler<PathSpec1<A>, STORAGE>.test(
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    socketId: Uuid = Uuid.random(),
+    socketId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec1<A>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -110,7 +110,7 @@ public suspend fun <STORAGE, A, B> WebSocketHandler<PathSpec2<A, B>, STORAGE>.te
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    socketId: Uuid = Uuid.random(),
+    socketId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec2<A, B>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(
@@ -146,7 +146,7 @@ public suspend fun <STORAGE, A, B, C> WebSocketHandler<PathSpec3<A, B, C>, STORA
     domain: String = generalSettings().publicUrl.substringAfter("://").substringBefore("/"),
     protocol: String = generalSettings().publicUrl.substringBefore("://"),
     sourceIp: String = "local",
-    socketId: Uuid = Uuid.random(),
+    socketId: Uuid = generateRequestId(),
 ): TestRunner<*>.TestWebSocket<PathSpec3<A, B, C>, STORAGE> {
     val intercepted = test.server.interceptIncomingSocket(this@test)
     val request = WebSocketConnectRequest(

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/test/TestRunner.kt
@@ -18,6 +18,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Clock
+import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /**
@@ -63,7 +64,9 @@ public class TestRunner<SERVER : ServerBuilder> @Deprecated("Please use SERVER.t
      * invocation that mints [Initiator.Direct] — see its documentation for why that hole exists.
      */
     @OptIn(InternalLightningServerApi::class)
-    override val initiator: Initiator = Initiator.Direct(Uuid.random())
+    override val initiator: Initiator = Initiator.Direct(
+        @OptIn(ExperimentalUuidApi::class) Uuid.generateV7NonMonotonicAt(clock.now())
+    )
 
     public companion object {
         internal val logger = KotlinLogging.logger("com.lightningkite.lightningserver.TestRunner")

--- a/core/src/test/kotlin/com/lightningkite/lightningserver/http/RequestIdentityTest.kt
+++ b/core/src/test/kotlin/com/lightningkite/lightningserver/http/RequestIdentityTest.kt
@@ -4,8 +4,14 @@ import com.lightningkite.lightningserver.runtime.subRequest
 import com.lightningkite.lightningserver.runtime.Initiator
 import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.definition.Task
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.pathing.PathSpec
 import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
+import com.lightningkite.lightningserver.runtime.Engine
+import com.lightningkite.lightningserver.runtime.EngineBase
+import com.lightningkite.lightningserver.runtime.ExecutionCause
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -15,18 +21,97 @@ import kotlin.uuid.Uuid
 
 class RequestIdentityTest {
 
+    private val engine: Engine = object : EngineBase(EmptyServer.build()) {
+        override val serverId: String = "bare"
+        override val serverVersion: String = "test"
+
+        override suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(
+            event: WebSocketSubscriptionMessage<PATH, T>,
+        ): Nothing = throw NotImplementedError()
+
+        override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?): Nothing =
+            throw NotImplementedError()
+    }
+
+    private object EmptyServer : ServerBuilder()
+
+    /** The same bare engine, but with a clock a test controls. */
+    private fun engineAt(instant: kotlin.time.Instant): Engine = object : EngineBase(EmptyServer.build()) {
+        override val serverId: String = "bare"
+        override val serverVersion: String = "test"
+        override val clock: kotlin.time.Clock = object : kotlin.time.Clock {
+            override fun now(): kotlin.time.Instant = instant
+        }
+
+        override suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(
+            event: WebSocketSubscriptionMessage<PATH, T>,
+        ): Nothing = throw NotImplementedError()
+
+        override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?): Nothing =
+            throw NotImplementedError()
+    }
+
+    /**
+     * Reads back the two things a version-7 UUID promises, the way a consumer has to: the version
+     * nibble and the 48-bit big-endian millisecond timestamp.
+     *
+     * Deliberately decoded here rather than reusing the audit module's helper — the point of these
+     * tests is that the minting site satisfies an *independent* reader, and sharing the decoder
+     * would let a wrong shared assumption pass both halves.
+     */
+    @OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+    private fun Uuid.versionAndMillis(): Pair<Int, Long> =
+        toLongs { msb, _ -> ((msb shr 12) and 0xF).toInt() to (msb ushr 16) }
+
+    /**
+     * `generateRequestId`'s documentation promises that "a test's injected clock controls the id's
+     * embedded timestamp", and the audit layer takes that promise seriously enough to have no `at`
+     * column at all — it derives every record's time from the id.
+     *
+     * Nothing tied those two halves together. Both are individually tested: `RequestRecordTest`
+     * covers the derivation by calling `Uuid.generateV7NonMonotonicAt` directly, and the tests above
+     * cover the minting site by asserting only that ids are non-nil and unique — which is equally
+     * true of `Uuid.random()`. Mutation testing confirmed the consequence: replacing this call with
+     * `Uuid.random()` left all 836 core tests green, while collapsing every audit row's derived
+     * timestamp to the Unix epoch, because the audit decoder returns 0 for a non-v7 id.
+     */
+    @Test
+    fun `a generated request id carries the engine clock's instant, not the wall clock`() {
+        val minted = kotlin.time.Instant.fromEpochMilliseconds(1_700_000_000_123)
+
+        val (version, millis) = with(engineAt(minted)) { generateRequestId() }.versionAndMillis()
+
+        assertEquals(7, version, "the audit layer's timestamp decoder returns 0 for any non-v7 id")
+        assertEquals(
+            minted.toEpochMilliseconds(),
+            millis,
+            "the id's embedded timestamp must come from the engine's clock, or an injected clock " +
+                "does not control what the audit log records",
+        )
+    }
+
+    /** The whole request-identity path, not just the generator, has to respect the clock. */
+    @Test
+    fun `a request identity's generated id also carries the engine clock's instant`() {
+        val minted = kotlin.time.Instant.fromEpochMilliseconds(1_700_000_000_456)
+
+        val identity = with(engineAt(minted)) { headers().requestIdentity(trustedRequestIdHeader = null) }
+
+        assertEquals(minted.toEpochMilliseconds(), identity.requestId.versionAndMillis().second)
+    }
+
     private fun headers(vararg pairs: Pair<String, String>) = HttpHeaders(pairs.toList())
 
     @Test
     fun `generates a fresh id when no trusted header is configured`() {
-        val identity = headers().requestIdentity(trustedRequestIdHeader = null)
+        val identity = with(engine) { headers().requestIdentity(trustedRequestIdHeader = null) }
         assertNotEquals(Uuid.NIL, identity.requestId)
         assertNull(identity.upstreamRequestId)
     }
 
     @Test
     fun `generated ids are unique`() {
-        val ids = (1..100).map { headers().requestIdentity(null).requestId }
+        val ids = (1..100).map { with(engine) { headers().requestIdentity(null).requestId } }
         assertEquals(100, ids.toSet().size)
     }
 
@@ -38,8 +123,10 @@ class RequestIdentityTest {
     @Test
     fun `a client supplied id is never adopted when no trusted header is configured`() {
         val claimed = Uuid.parse("00000000-0000-4000-8000-0000000000a1")
-        val identity = headers(HttpHeader.XRequestId to claimed.toString())
-            .requestIdentity(trustedRequestIdHeader = null)
+        val identity = with(engine) {
+            headers(HttpHeader.XRequestId to claimed.toString())
+                .requestIdentity(trustedRequestIdHeader = null)
+        }
 
         assertNotEquals(claimed, identity.requestId)
         assertEquals(claimed.toString(), identity.upstreamRequestId)
@@ -48,8 +135,10 @@ class RequestIdentityTest {
     @Test
     fun `a client supplied id is not adopted when the trusted header is a different header`() {
         val claimed = Uuid.parse("00000000-0000-4000-8000-0000000000a1")
-        val identity = headers(HttpHeader.XRequestId to claimed.toString())
-            .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
+        val identity = with(engine) {
+            headers(HttpHeader.XRequestId to claimed.toString())
+                .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
+        }
 
         assertNotEquals(claimed, identity.requestId)
         assertEquals(claimed.toString(), identity.upstreamRequestId)
@@ -58,8 +147,10 @@ class RequestIdentityTest {
     @Test
     fun `adopts the id from the configured trusted header`() {
         val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000b2")
-        val identity = headers("X-Proxy-Request-Id" to proxyId.toString())
-            .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
+        val identity = with(engine) {
+            headers("X-Proxy-Request-Id" to proxyId.toString())
+                .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
+        }
 
         assertEquals(proxyId, identity.requestId)
     }
@@ -67,10 +158,12 @@ class RequestIdentityTest {
     @Test
     fun `records a separate untrusted claim alongside the trusted id`() {
         val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000b2")
-        val identity = headers(
-            "X-Proxy-Request-Id" to proxyId.toString(),
-            HttpHeader.XRequestId to "attacker-chosen",
-        ).requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
+        val identity = with(engine) {
+            headers(
+                "X-Proxy-Request-Id" to proxyId.toString(),
+                HttpHeader.XRequestId to "attacker-chosen",
+            ).requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id")
+        }
 
         assertEquals(proxyId, identity.requestId)
         assertEquals("attacker-chosen", identity.upstreamRequestId)
@@ -80,8 +173,10 @@ class RequestIdentityTest {
     @Test
     fun `no upstream id is recorded when the trusted header is X-Request-ID itself`() {
         val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000c3")
-        val identity = headers(HttpHeader.XRequestId to proxyId.toString())
-            .requestIdentity(trustedRequestIdHeader = HttpHeader.XRequestId)
+        val identity = with(engine) {
+            headers(HttpHeader.XRequestId to proxyId.toString())
+                .requestIdentity(trustedRequestIdHeader = HttpHeader.XRequestId)
+        }
 
         assertEquals(proxyId, identity.requestId)
         assertNull(identity.upstreamRequestId)
@@ -90,8 +185,10 @@ class RequestIdentityTest {
     @Test
     fun `header matching is case insensitive`() {
         val proxyId = Uuid.parse("00000000-0000-4000-8000-0000000000c3")
-        val identity = headers("x-request-id" to proxyId.toString())
-            .requestIdentity(trustedRequestIdHeader = "X-Request-ID")
+        val identity = with(engine) {
+            headers("x-request-id" to proxyId.toString())
+                .requestIdentity(trustedRequestIdHeader = "X-Request-ID")
+        }
 
         assertEquals(proxyId, identity.requestId)
         assertNull(identity.upstreamRequestId)
@@ -101,8 +198,10 @@ class RequestIdentityTest {
     @Test
     fun `generates an id and reports when the configured trusted header is absent`() {
         var warned = false
-        val identity = headers(HttpHeader.XRequestId to "attacker-chosen")
-            .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id") { warned = true }
+        val identity = with(engine) {
+            headers(HttpHeader.XRequestId to "attacker-chosen")
+                .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id") { warned = true }
+        }
 
         assertTrue(warned)
         assertEquals("attacker-chosen", identity.upstreamRequestId)
@@ -115,8 +214,10 @@ class RequestIdentityTest {
     @Test
     fun `generates an id and reports when the trusted header does not hold a UUID`() {
         var warned = false
-        val identity = headers("X-Proxy-Request-Id" to "not-a-uuid")
-            .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id") { warned = true }
+        val identity = with(engine) {
+            headers("X-Proxy-Request-Id" to "not-a-uuid")
+                .requestIdentity(trustedRequestIdHeader = "X-Proxy-Request-Id") { warned = true }
+        }
 
         assertTrue(warned)
         assertNotEquals(Uuid.NIL, identity.requestId)
@@ -134,7 +235,7 @@ class RequestIdentityTest {
 
     @Test
     fun `subRequest gets its own id parented to the outer request`() {
-        val sub = outer().subRequest(endpoint("/inner"))
+        val sub = with(engine) { outer().subRequest(endpoint("/inner")) }
 
         assertNotEquals(outerId, sub.executionId)
         assertEquals(outerId, sub.causedBy)
@@ -144,8 +245,8 @@ class RequestIdentityTest {
     @Test
     fun `sibling sub-requests get distinct ids and share a parent`() {
         val outer = outer()
-        val a = outer.subRequest(endpoint("/a"))
-        val b = outer.subRequest(endpoint("/b"))
+        val a = with(engine) { outer.subRequest(endpoint("/a")) }
+        val b = with(engine) { outer.subRequest(endpoint("/b")) }
 
         assertNotEquals(a.executionId, b.executionId)
         assertEquals(outerId, a.causedBy)
@@ -154,7 +255,7 @@ class RequestIdentityTest {
 
     @Test
     fun `nesting keeps the root while the parent follows the nesting`() {
-        val inner = outer().subRequest(endpoint("/a")).subRequest(endpoint("/b"))
+        val inner = with(engine) { outer().subRequest(endpoint("/a")).subRequest(endpoint("/b")) }
 
         assertEquals(outerId, inner.rootExecutionId)
         assertNotEquals(outerId, inner.causedBy)

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterHttp.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterHttp.kt
@@ -1,7 +1,6 @@
 package com.lightningkite.lightningserver.engine.awsserverless
 
 import com.lightningkite.lightningserver.pathing.PathSpec
-import kotlin.uuid.Uuid
 import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
@@ -43,7 +42,7 @@ internal class AwsAdapterHttp(val root: AwsAdapter) {
             engineRequestId = event.requestContext.requestId,
         )
         // API Gateway's ID is not a UUID, so we always mint our own execution id.
-        val result = root.handle(request, Uuid.random())
+        val result = with(root) { root.handle(request, generateRequestId()) }
         return result.toAws()
     }
 }

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
@@ -1,6 +1,5 @@
 package com.lightningkite.lightningserver.engine.awsserverless
 
-import kotlin.uuid.Uuid
 import com.lightningkite.lightningserver.AnonType
 import com.lightningkite.lightningserver.HttpStatusException
 import com.lightningkite.lightningserver.definition.generalSettings
@@ -267,7 +266,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                             h.messageFromSubscriptionWithMetrics(
                                 p.pathSpec,
                                 root,
-                                s.initiator.phase(Initiator.WebSocket.Phase.SubscriptionMessage),
+                                with(root) { s.initiator.phase(Initiator.WebSocket.Phase.SubscriptionMessage) },
                                 mid,
                                 WebSocketSubscriptionMessage(
                                     fullTopicMatch.value,
@@ -354,7 +353,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                 rootWs.didConnectWithMetrics(
                     rootPath,
                     root,
-                    event.initiator.phase(Initiator.WebSocket.Phase.Connected),
+                    with(root) { event.initiator.phase(Initiator.WebSocket.Phase.Connected) },
                     mid
                 )
                 return APIGatewayV2HTTPResponse(200)
@@ -408,7 +407,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                 // is one identity across the five separate Lambda invocations its lifetime is made of.
                 // The gateway's connection ID is not a UUID and stays in [engineSocketId], which is where
                 // the join to the gateway's own logs comes from.
-                val socketId = Uuid.random()
+                val socketId = with(root) { generateRequestId() }
                 val connectInitiator = Initiator.WebSocket(
                     executionId = socketId,
                     socketId = socketId,
@@ -474,7 +473,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                         rootWs.disconnectWithMetrics(
                             rootPath,
                             root,
-                            state.initiator.phase(Initiator.WebSocket.Phase.Disconnect),
+                            with(root) { state.initiator.phase(Initiator.WebSocket.Phase.Disconnect) },
                             mid,
                             WebSocketClose.NORMAL
                         )
@@ -519,7 +518,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                         rootWs.messageFromClientWithMetrics(
                             rootPath,
                             root,
-                            state.initiator.phase(Initiator.WebSocket.Phase.ClientMessage),
+                            with(root) { state.initiator.phase(Initiator.WebSocket.Phase.ClientMessage) },
                             mid,
                             WebSocketFrame(event.body)
                         )

--- a/engine-jdk-server/src/main/kotlin/com/lightningkite/lightningserver/engine/jdk/JdkEngine.kt
+++ b/engine-jdk-server/src/main/kotlin/com/lightningkite/lightningserver/engine/jdk/JdkEngine.kt
@@ -298,8 +298,10 @@ private fun HttpExchange.requestToLightningServer(
         }
     } else null
 
-    val identity = headers.requestIdentity(requestIdHeader) {
-        engine.logger.warn { "Request ID header for proxy '$requestIdHeader' was missing from the request." }
+    val identity = with(engine) {
+        headers.requestIdentity(requestIdHeader) {
+            engine.logger.warn { "Request ID header for proxy '$requestIdHeader' was missing from the request." }
+        }
     }
 
     val adapted = HttpRequest(

--- a/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
+++ b/engine-local/src/main/kotlin/com/lightningkite/lightningserver/engine/local/LocalWebSocketConnection.kt
@@ -55,7 +55,7 @@ public abstract class LocalWebSocketConnection<PATH : PathSpec, STORAGE>(
         subscriptions.remove(topic)?.cancel()
         subscriptions[topic] = scope.launch {
             pubSub(topic).collect { value ->
-                with(server.forExecution(connectInitiator.phase(Initiator.WebSocket.Phase.SubscriptionMessage))) {
+                with(server.forExecution(with(server) { connectInitiator.phase(Initiator.WebSocket.Phase.SubscriptionMessage) })) {
                     handler.messageFromSubscription(
                         this@LocalWebSocketConnection,
                         WebSocketSubscriptionMessage(topic.topic, topic.pathInContext.rawPathArguments, value),


### PR DESCRIPTION
**Stack: 6 of 16.** Based on `split/e5` — review that one first.
An execution id now carries its own creation time in its top 48 bits, so
anything holding one knows when it happened without a separate column. The
audit layer relies on this: its records have no `at` field at all.

Minting goes through the engine's clock rather than the wall clock, which is
what makes an injected test clock control the recorded time.

`RequestIdentityTest` decodes the version nibble and the timestamp itself
rather than reusing a shared helper, so a wrong shared assumption cannot pass
both halves. That test is load-bearing: replacing the call with
`Uuid.random()` previously left all 836 core tests green while collapsing
every derived timestamp to the Unix epoch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd