### PR TITLE
Survive a rolling deploy on the AWS websocket engine

### DIFF
--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWs.kt
@@ -43,8 +43,15 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
     data class WebSocketDidConnect(
         val socketId: String,
         val connection: WebSocketConnectRequest<Nothing>,
-        /** `didConnect` is its own Lambda invocation, so the socket's identity has to travel with it. */
-        val initiator: Initiator.WebSocket,
+        /**
+         * `didConnect` is its own Lambda invocation, so the socket's identity has to travel with it.
+         *
+         * Null only for a payload fired by a deployment that predates this field.  It needs the explicit
+         * default as well as the nullable type: kotlinx.serialization treats a field without a default
+         * as required regardless of nullability, so without it the whole payload fails to decode and
+         * `didConnect` is lost in the outer failure handler with no response and no trace.
+         */
+        val initiator: Initiator.WebSocket? = null,
         val storage: AnonType,
     ) : AwsLambdaInput
 
@@ -253,7 +260,19 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                 // TODO: could retrieve more states at once?
                 val states = webSocketDynamo.states(ids)
                 for (socketId in ids) {
-                    val s = states[socketId] ?: continue
+                    // Handled per socket, so one previous-schema row cannot cost the rest of the batch
+                    // its push.  Reading these rows as a group used to throw on the first legacy one and
+                    // abandon the whole page, healthy sockets included.
+                    val s = when (val row = states.getValue(socketId)) {
+                        SocketRow.Absent -> continue
+                        is SocketRow.Legacy -> {
+                            webSocketClose(socketId, WebSocketClose.GOING_AWAY)
+                            webSocketDynamo.clean(socketId)
+                            continue
+                        }
+
+                        is SocketRow.Current -> row
+                    }
                     try {
                         @Suppress("UNCHECKED_CAST")
                         withMid<PathSpec, Any?, Unit>(
@@ -341,6 +360,19 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
     }
 
     suspend fun handleWebSocketDidConnect(event: WebSocketDidConnect): APIGatewayV2HTTPResponse {
+        // The `${'$'}connect` that fired this payload ran under a deployment with no initiator, which
+        // means it also wrote a row this deployment cannot use.  The socket is unattributable for life,
+        // so end it here rather than merely skipping didConnect - skipping only defers the same close to
+        // the socket's first frame, with a broken connection in between.
+        val initiator = event.initiator ?: run {
+            root.logger.warn {
+                "Socket ${event.socketId} was connected by a previous deployment (its didConnect carries " +
+                        "no initiator). Ending it so the client reconnects."
+            }
+            webSocketClose(event.socketId, WebSocketClose.GOING_AWAY)
+            webSocketDynamo.clean(event.socketId)
+            return APIGatewayV2HTTPResponse(204)
+        }
         try {
             @Suppress("UNCHECKED_CAST")
             withMid(
@@ -353,7 +385,7 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
                 rootWs.didConnectWithMetrics(
                     rootPath,
                     root,
-                    with(root) { event.initiator.phase(Initiator.WebSocket.Phase.Connected) },
+                    with(root) { initiator.phase(Initiator.WebSocket.Phase.Connected) },
                     mid
                 )
                 return APIGatewayV2HTTPResponse(200)
@@ -460,8 +492,20 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
 
             "\$disconnect" -> {
                 try {
-                    val state =
-                        webSocketDynamo.state(event.requestContext.connectionId) ?: return APIGatewayV2HTTPResponse(204)
+                    // A previous-schema row cannot have its disconnect attributed to anything, and
+                    // recording the phase against a fabricated initiator would put it in the audit trail
+                    // under an id that never connected.  The socket is already going away, so there is
+                    // nothing to close - just drop the row.  These returns bypass the trailing `also`,
+                    // hence the explicit clean.
+                    val state = when (val row = webSocketDynamo.state(event.requestContext.connectionId)) {
+                        SocketRow.Absent -> return APIGatewayV2HTTPResponse(204)
+                        is SocketRow.Legacy -> {
+                            webSocketDynamo.clean(event.requestContext.connectionId)
+                            return APIGatewayV2HTTPResponse(204)
+                        }
+
+                        is SocketRow.Current -> row
+                    }
                     @Suppress("UNCHECKED_CAST")
                     withMid(
                         rootPath,
@@ -489,8 +533,20 @@ internal class AwsAdapterWs(val root: AwsAdapter) {
             else -> if (body == null || body.isEmpty())
                 APIGatewayV2HTTPResponse(200)
             else {
-                val state =
-                    webSocketDynamo.state(event.requestContext.connectionId) ?: return APIGatewayV2HTTPResponse(204)
+                // A previous-schema row cannot be served or attributed for as long as the socket stays
+                // open, so end it: the client reconnects, `${'$'}connect` writes a current row, and
+                // everything after that is handled normally.  API Gateway's deleteConnection carries no
+                // close code, so the client sees an abrupt close and reconnects on its own.
+                val state = when (val row = webSocketDynamo.state(event.requestContext.connectionId)) {
+                    SocketRow.Absent -> return APIGatewayV2HTTPResponse(204)
+                    is SocketRow.Legacy -> {
+                        webSocketClose(event.requestContext.connectionId, WebSocketClose.GOING_AWAY)
+                        webSocketDynamo.clean(event.requestContext.connectionId)
+                        return APIGatewayV2HTTPResponse(204)
+                    }
+
+                    is SocketRow.Current -> row
+                }
                 try {
                     @Suppress("UNCHECKED_CAST")
                     withMid(

--- a/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsWebSocketDynamoDb.kt
+++ b/engine-aws-serverless/src/main/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsWebSocketDynamoDb.kt
@@ -11,30 +11,56 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.NothingSerializer
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.*
+import java.io.IOException
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.measureTime
+
+/**
+ * The outcome of reading one socket's stored row.
+ *
+ * [Absent] and [Legacy] are separate types rather than one nullable result because they call for
+ * opposite handling: an absent row means the socket is already gone and there is nothing left to do,
+ * while a legacy row means a live socket is still holding data this deployment cannot use, so the
+ * socket has to be ended before it can be forgotten.  Collapsing the two - as a nullable result
+ * invites - silently leaves such a socket open to fail again on its next frame.
+ */
+internal sealed interface SocketRow {
+    /** The socket has no row: it disconnected and was cleaned up already. */
+    data object Absent : SocketRow
+
+    /**
+     * A row written by an earlier deployment, which this one can neither decode nor attribute.
+     *
+     * Nothing later can repair it.  Both the stored connect request and the initiator are written
+     * once, at `${'$'}connect`, by whatever code was deployed then, so the socket is ended and the
+     * client reconnects to get a row in the current shape.
+     */
+    data class Legacy(val reason: String) : SocketRow
+
+    /** A row this deployment can both decode and attribute. */
+    class Current(
+        val state: ByteArray,
+        val connectRequest: WebSocketConnectRequest<*>,
+        /**
+         * The socket's connect initiator.  Persisted beside the request because each of the five
+         * lifecycle phases is a separate Lambda invocation: without it, nothing after
+         * `${'$'}connect` could say which socket it belongs to.
+         */
+        val initiator: Initiator.WebSocket,
+    ) : SocketRow
+}
 
 internal class AwsWebSocketDynamoDb(
     val client: DynamoDbAsyncClient,
     val baseTableName: String,
     val encoding: KotlinBytesFormat,
 ) {
-    class StateAndConnectRequest(
-        val state: ByteArray,
-        val connectRequest: WebSocketConnectRequest<*>,
-        /**
-         * The socket's connect initiator. Persisted beside the request because each of the five
-         * lifecycle phases is a separate Lambda invocation: without it, nothing after `${'$'}connect`
-         * could say which socket it belongs to.
-         */
-        val initiator: Initiator.WebSocket,
-    )
-
     private val socketExpiration = 8.hours
     private val tableSubs = "$baseTableName-ws-subs"
     private val tableSubsReverse = "$baseTableName-ws-subs-reverse"
@@ -216,25 +242,68 @@ internal class AwsWebSocketDynamoDb(
         }.also { logger.debug { "AwsWebSocketDynamoDb.clean took $it" } }
     }
 
-    suspend fun debugStates(): Map<String, StateAndConnectRequest> {
+    /**
+     * Reads one stored row, reporting anything an earlier deployment wrote as [SocketRow.Legacy]
+     * instead of throwing.
+     *
+     * This is not defensive padding.  The stored connect request is a positional blob, and this branch
+     * removed two properties from [WebSocketConnectRequest], so every blob written before that change
+     * carries element indices past the end of the current descriptor.  A row written before the
+     * `wsInitiator` column existed is the same situation with a different symptom.  Neither is a fault
+     * to report; both are simply data this deployment cannot read.
+     *
+     * Only the two failures a schema change produces are absorbed, and only around the decode itself:
+     * [SerializationException] for a missing field or an out-of-range element index, and [IOException]
+     * for a decode that ran off the end of the blob because the layout shifted under it.  Every other
+     * failure, DynamoDB's included, happens outside this block and still propagates.
+     */
+    private fun decodeRow(socketId: String, item: Map<String, AttributeValue>): SocketRow {
+        val initiator = item[initiatorKey]
+            ?: return legacyRow(socketId, "$initiatorKey is absent, so the socket cannot be attributed")
+        return try {
+            SocketRow.Current(
+                state = item[stateKey]!!.b().asByteArray(),
+                connectRequest = encoding.decodeFromByteArray(
+                    WebSocketConnectRequest.serializer(NothingSerializer()),
+                    item[requestKey]!!.b().asByteArray()
+                ),
+                initiator = encoding.decodeFromByteArray(
+                    Initiator.WebSocket.serializer(),
+                    initiator.b().asByteArray()
+                ),
+            )
+        } catch (e: SerializationException) {
+            legacyRow(
+                socketId,
+                "its stored data does not fit this deployment's schema (${e.message ?: e::class.simpleName})"
+            )
+        } catch (e: IOException) {
+            legacyRow(
+                socketId,
+                "its stored data ran out mid-decode, so its layout is another schema's " +
+                        "(${e.message ?: e::class.simpleName})"
+            )
+        }
+    }
+
+    private fun legacyRow(socketId: String, reason: String): SocketRow.Legacy {
+        logger.warn {
+            "Socket $socketId holds a row from a previous deployment: $reason. " +
+                    "The socket will be ended so the client reconnects."
+        }
+        return SocketRow.Legacy(reason)
+    }
+
+    suspend fun debugStates(): Map<String, SocketRow> {
         ensureTables()
-        val out = HashMap<String, StateAndConnectRequest>()
+        val out = HashMap<String, SocketRow>()
         client.scanPaginator {
             it.tableName(tableStates)
             it.projectionExpression("$socketIdKey, $stateKey, $requestKey, $initiatorKey")
         }.asFlow().collect {
             it.items()?.forEach {
-                out[it[socketIdKey]!!.s()] = StateAndConnectRequest(
-                    it[stateKey]!!.b().asByteArray(),
-                    encoding.decodeFromByteArray(
-                        WebSocketConnectRequest.serializer(NothingSerializer()),
-                        it[requestKey]!!.b().asByteArray()
-                    ),
-                    encoding.decodeFromByteArray(
-                        Initiator.WebSocket.serializer(),
-                        it[initiatorKey]!!.b().asByteArray()
-                    )
-                )
+                val id = it[socketIdKey]!!.s()
+                out[id] = decodeRow(id, it)
             }
         }
         return out
@@ -245,9 +314,9 @@ internal class AwsWebSocketDynamoDb(
     // is guaranteed to lose the swap, or omits a row that was written moments ago by the connect handler.
     // Correctness here is worth the doubled read cost.
 
-    suspend fun state(id: String): StateAndConnectRequest? {
+    suspend fun state(id: String): SocketRow {
         ensureTables()
-        val result: StateAndConnectRequest?
+        val result: SocketRow
         measureTime {
             val response = client.getItem {
                 it.tableName(tableStates)
@@ -258,19 +327,7 @@ internal class AwsWebSocketDynamoDb(
             // item() is an SDK auto-construct map: it returns empty rather than null when the socket
             // has no row, so hasItem() is the only way to detect a missing socket.  Testing item() for
             // null instead silently falls through to reading attributes that aren't there.
-            result = if (!response.hasItem()) null else response.item().let {
-                StateAndConnectRequest(
-                    it[stateKey]!!.b().asByteArray(),
-                    encoding.decodeFromByteArray(
-                        WebSocketConnectRequest.serializer(NothingSerializer()),
-                        it[requestKey]!!.b().asByteArray()
-                    ),
-                    encoding.decodeFromByteArray(
-                        Initiator.WebSocket.serializer(),
-                        it[initiatorKey]!!.b().asByteArray()
-                    ),
-                )
-            }
+            result = if (!response.hasItem()) SocketRow.Absent else decodeRow(id, response.item())
         }.also { logger.debug { "AwsWebSocketDynamoDb.state($id) took $it" } }
         return result
     }
@@ -294,9 +351,15 @@ internal class AwsWebSocketDynamoDb(
         return out
     }
 
-    suspend fun states(ids: Iterable<String>): Map<String, StateAndConnectRequest> {
+    /**
+     * Reads several rows at once.  Every requested id is present in the result, defaulting to
+     * [SocketRow.Absent], so a caller walking its own id list has to handle a missing socket
+     * explicitly instead of inferring it from a key that isn't there.
+     */
+    suspend fun states(ids: Iterable<String>): Map<String, SocketRow> {
         ensureTables()
-        val out = HashMap<String, StateAndConnectRequest>()
+        val out = HashMap<String, SocketRow>()
+        ids.forEach { out[it] = SocketRow.Absent }
         measureTime {
             val getState = KeysAndAttributes.builder()
                 .projectionExpression("$socketIdKey, $stateKey, $requestKey, $initiatorKey")
@@ -306,17 +369,8 @@ internal class AwsWebSocketDynamoDb(
                 it.requestItems(mapOf(tableStates to getState))
             }.asFlow().collect {
                 it.responses()?.get(tableStates)?.forEach {
-                    out[it[socketIdKey]!!.s()] = StateAndConnectRequest(
-                        it[stateKey]!!.b().asByteArray(),
-                        encoding.decodeFromByteArray(
-                            WebSocketConnectRequest.serializer(NothingSerializer()),
-                            it[requestKey]!!.b().asByteArray()
-                        ),
-                        encoding.decodeFromByteArray(
-                            Initiator.WebSocket.serializer(),
-                            it[initiatorKey]!!.b().asByteArray()
-                        )
-                    )
+                    val id = it[socketIdKey]!!.s()
+                    out[id] = decodeRow(id, it)
                 }
             }
         }.also { logger.debug { "AwsWebSocketDynamoDb.states(${ids.joinToString()}) took $it" } }

--- a/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWsLegacyStateRowTest.kt
+++ b/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/AwsAdapterWsLegacyStateRowTest.kt
@@ -1,0 +1,381 @@
+package com.lightningkite.lightningserver.engine.awsserverless
+
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.websockets.WebSocketConnectRequest
+import com.lightningkite.lightningserver.websockets.WebSocketFrame
+import com.lightningkite.lightningserver.websockets.WebSocketHandler
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
+import com.lightningkite.lightningserver.websockets.request
+import com.lightningkite.lightningserver.websockets.text
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.NothingSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * A socket row written by an earlier deployment cannot be served or attributed by this one, and no later
+ * phase can repair it: both the stored connect request and the initiator are written once, at
+ * `${'$'}connect`, under whatever code was deployed then.  Every phase after `${'$'}connect` therefore
+ * has to end such a socket rather than fail on it, or a rolling deploy breaks every socket open across
+ * it.
+ *
+ * Two flavours of aged row are covered, because both are real:
+ * - a **genuine legacy row**, written by [putLegacySocketRow] in the fork point's own layout, which the
+ *   current serializer cannot decode at all;
+ * - a **row whose column set is older** than its blob, produced by removing `wsInitiator` from a row this
+ *   deployment wrote.
+ */
+class AwsAdapterWsLegacyStateRowTest {
+
+    object SampleServer : ServerBuilder() {
+        val broadcast = path.path("broadcast").topic(String.serializer())
+
+        /**
+         * Counts disconnect-handler runs so the healthy path can be shown to still reach it.
+         *
+         * A count rather than a socket id because [WebSocketConnectRequest.engineSocketId] is null in
+         * here: QueryParamWebSocketHandler, which every AWS socket goes through, rebuilds the request
+         * without it.  Each test resets this, and only one test disconnects a healthy socket.
+         */
+        val disconnectHandlerRuns: AtomicInteger = AtomicInteger()
+
+        val echo = path.path("echo") bind WebSocketHandler(
+            storageSerializer = Unit.serializer(),
+            willConnect = { Unit },
+            didConnect = { subscribe(broadcast.request()) },
+            topicHandlers = { broadcast bind { send(WebSocketFrame("topic:" + it.value)) } },
+            messageFromClient = { send(WebSocketFrame("echo:" + it.text)) },
+            disconnect = { disconnectHandlerRuns.incrementAndGet() },
+        )
+
+        init {
+            registerBasicMediaTypeCoders()
+        }
+    }
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun adapter(): TestAwsAdapter = TestAwsAdapter(SampleServer.build())
+
+    /** The raw state row, or null if the socket is no longer tracked. */
+    private fun TestAwsAdapter.stateRow(connectionId: String): Map<String, AttributeValue>? = runBlocking {
+        countingDynamo.getItem {
+            it.tableName(stateTableName())
+            it.key(mapOf(socketIdColumn to AttributeValue.fromS(connectionId)))
+            it.consistentRead(true)
+        }.await().takeIf { it.hasItem() }?.item()
+    }
+
+    /** Ages only the column set: the blob stays current, but the initiator column goes away. */
+    private fun TestAwsAdapter.stripInitiator(connectionId: String) {
+        assertTrue(
+            stateRow(connectionId)!!.containsKey(initiatorColumn),
+            "A freshly connected socket must have an initiator, or this fixture is testing nothing"
+        )
+        runBlocking {
+            countingDynamo.updateItem {
+                it.tableName(stateTableName())
+                it.key(mapOf(socketIdColumn to AttributeValue.fromS(connectionId)))
+                it.updateExpression("REMOVE $initiatorColumn")
+            }.await()
+        }
+    }
+
+    private fun baseMessage(connectionId: String) = APIGatewayV2WebSocketRequest(
+        multiValueHeaders = mapOf(),
+        multiValueQueryStringParameters = mapOf(),
+        requestContext = APIGatewayV2WebSocketRequest.RequestContext(
+            routeKey = "",
+            eventType = "",
+            extendedRequestId = "",
+            requestTime = "",
+            messageDirection = "",
+            stage = "",
+            connectedAt = 0L,
+            requestTimeEpoch = 0L,
+            identity = APIGatewayV2WebSocketRequest.RequestContext.Identity("", ""),
+            requestId = "",
+            domainName = "",
+            connectionId = connectionId,
+            apiId = "",
+        ),
+        isBase64Encoded = false,
+        body = ""
+    )
+
+    /**
+     * Decodes one lambda invocation's response.
+     *
+     * A handler that throws instead of returning leaves the output stream empty, which is what reading an
+     * aged row used to do on the client-message route, so an empty response is reported as its own
+     * failure rather than a confusing deserialization error.
+     */
+    private fun decodeResponse(raw: ByteArray, what: String): APIGatewayV2HTTPResponse {
+        val text = raw.decodeToString()
+        assertTrue(text.isNotBlank(), "The lambda produced no response for $what, meaning the handler threw")
+        return json.decodeFromString(APIGatewayV2HTTPResponse.serializer(), text)
+    }
+
+    private fun TestAwsAdapter.invoke(event: APIGatewayV2WebSocketRequest): APIGatewayV2HTTPResponse =
+        decodeResponse(handleRequest(event), "route '${event.requestContext.routeKey}'")
+
+    /**
+     * Connects a socket to /echo and lets the asynchronous didConnect settle, so the row and its
+     * subscription are in place before the test ages them.  Buffers outgoing frames so a send the test
+     * does not expect fails an assertion instead of blocking the engine on a rendezvous channel.
+     */
+    private fun TestAwsAdapter.connect(connectionId: String): Channel<String> {
+        val channel = Channel<String>(Channel.UNLIMITED)
+        webSocketChannels[connectionId] = channel
+        val base = baseMessage(connectionId)
+        val response = invoke(
+            base.copy(
+                multiValueQueryStringParameters = mapOf("path" to listOf("/echo")),
+                requestContext = base.requestContext.copy(routeKey = "\$connect")
+            )
+        )
+        assertEquals(200, response.statusCode, "Connect should have succeeded")
+        awaitPendingInvocations()
+        return channel
+    }
+
+    private fun clientMessage(connectionId: String, body: String) = baseMessage(connectionId).let {
+        it.copy(requestContext = it.requestContext.copy(routeKey = "\$default"), body = body)
+    }
+
+    private fun disconnect(connectionId: String) = baseMessage(connectionId).let {
+        it.copy(requestContext = it.requestContext.copy(routeKey = "\$disconnect"))
+    }
+
+    private fun TestAwsAdapter.publishToBroadcast() {
+        runBlocking {
+            sendWebSocketSubscriptionMessage(WebSocketSubscriptionMessage(SampleServer.broadcast, listOf(), "hello"))
+        }
+        awaitPendingInvocations()
+    }
+
+    /** The socket was ended: closed, its row dropped, and nothing delivered to it. */
+    private fun assertSocketEnded(adapter: TestAwsAdapter, connectionId: String, channel: Channel<String>) {
+        assertTrue(
+            connectionId in adapter.closedConnections,
+            "The socket must be closed so the client reconnects and gets a current row"
+        )
+        assertNull(
+            adapter.stateRow(connectionId),
+            "The row must be cleaned up, or every later phase repeats this"
+        )
+        assertNull(
+            channel.tryReceive().getOrNull(),
+            "Nothing should be delivered to a socket this deployment cannot serve"
+        )
+    }
+
+    /**
+     * The fixture has to be genuinely unreadable, or every test built on it is theatre.  If
+     * [LegacyWebSocketConnectRequest] ever drifts into a layout the current serializer accepts, this
+     * fails here rather than quietly turning the rest of the file green for the wrong reason.
+     */
+    @Test
+    fun legacyBlobCannotBeDecodedByTheCurrentSerializer() {
+        val adapter = adapter()
+        val encoding = adapter.internalSerialization.kotlinBytesFormat
+        val blob = encoding.encodeToByteArray(
+            LegacyWebSocketConnectRequest.serializer(NothingSerializer()),
+            adapter.legacyConnectRequest("fixture-check")
+        )
+        val thrown = assertFails {
+            encoding.decodeFromByteArray(WebSocketConnectRequest.serializer(NothingSerializer()), blob)
+        }
+        assertTrue(
+            thrown is SerializationException || thrown is IOException,
+            "A fork-point blob must fail to decode as a schema mismatch, not as $thrown"
+        )
+    }
+
+    @Test
+    fun clientMessageOnLegacyRowEndsTheSocket() {
+        val adapter = adapter()
+        val connectionId = "legacy-row-client-message"
+        val channel = adapter.connect(connectionId)
+        adapter.putLegacySocketRow(connectionId)
+
+        val response = adapter.invoke(clientMessage(connectionId, "Ping!"))
+        adapter.awaitPendingInvocations()
+
+        assertEquals(
+            204,
+            response.statusCode,
+            "An unusable row is discarded, not reported as a server failure: ${response.body}"
+        )
+        assertSocketEnded(adapter, connectionId, channel)
+    }
+
+    /**
+     * A row whose blob is from the fork point but which does carry an initiator - the case where only the
+     * stored request is stale.  This is the one that reaches the decode failure itself rather than
+     * short-circuiting on the absent column.
+     */
+    @Test
+    fun clientMessageOnLegacyBlobWithCurrentInitiatorEndsTheSocket() {
+        val adapter = adapter()
+        val connectionId = "legacy-blob-client-message"
+        val channel = adapter.connect(connectionId)
+        adapter.putLegacySocketRow(connectionId, initiator = adapter.stateRow(connectionId)!![initiatorColumn]!!)
+
+        val response = adapter.invoke(clientMessage(connectionId, "Ping!"))
+        adapter.awaitPendingInvocations()
+
+        assertEquals(204, response.statusCode, "A row whose blob no longer decodes is discarded: ${response.body}")
+        assertSocketEnded(adapter, connectionId, channel)
+    }
+
+    @Test
+    fun clientMessageOnRowMissingOnlyTheInitiatorColumnEndsTheSocket() {
+        val adapter = adapter()
+        val connectionId = "no-initiator-client-message"
+        val channel = adapter.connect(connectionId)
+        adapter.stripInitiator(connectionId)
+
+        val response = adapter.invoke(clientMessage(connectionId, "Ping!"))
+        adapter.awaitPendingInvocations()
+
+        assertEquals(
+            204,
+            response.statusCode,
+            "An unattributable socket is discarded, not reported as a server failure: ${response.body}"
+        )
+        assertSocketEnded(adapter, connectionId, channel)
+    }
+
+    @Test
+    fun disconnectOnLegacyRowIsDiscardedNotFailed() {
+        val adapter = adapter()
+        val connectionId = "legacy-row-disconnect"
+        adapter.connect(connectionId)
+        adapter.putLegacySocketRow(connectionId)
+        SampleServer.disconnectHandlerRuns.set(0)
+
+        val response = adapter.invoke(disconnect(connectionId))
+        adapter.awaitPendingInvocations()
+
+        assertEquals(
+            204,
+            response.statusCode,
+            "A disconnect that cannot be attributed is discarded, not reported as a failure: ${response.body}"
+        )
+        assertNull(adapter.stateRow(connectionId), "The row must be cleaned up")
+        assertTrue(
+            connectionId !in adapter.closedConnections,
+            "The socket is already going away, so no close call should be made"
+        )
+        assertEquals(
+            0,
+            SampleServer.disconnectHandlerRuns.get(),
+            "The disconnect phase must not be recorded under a fabricated initiator"
+        )
+    }
+
+    @Test
+    fun disconnectOnRowMissingOnlyTheInitiatorColumnIsDiscarded() {
+        val adapter = adapter()
+        val connectionId = "no-initiator-disconnect"
+        adapter.connect(connectionId)
+        adapter.stripInitiator(connectionId)
+        SampleServer.disconnectHandlerRuns.set(0)
+
+        val response = adapter.invoke(disconnect(connectionId))
+        adapter.awaitPendingInvocations()
+
+        assertEquals(204, response.statusCode, "Expected the disconnect to be discarded: ${response.body}")
+        assertNull(adapter.stateRow(connectionId), "The row must be cleaned up")
+        assertTrue(connectionId !in adapter.closedConnections, "No close call should be made")
+        assertEquals(0, SampleServer.disconnectHandlerRuns.get(), "The disconnect phase must not be recorded")
+    }
+
+    @Test
+    fun subscriptionPushToLegacyRowEndsTheSocket() {
+        val adapter = adapter()
+        val connectionId = "legacy-row-subscription"
+        val channel = adapter.connect(connectionId)
+        adapter.putLegacySocketRow(connectionId)
+
+        adapter.publishToBroadcast()
+
+        assertSocketEnded(adapter, connectionId, channel)
+    }
+
+    @Test
+    fun subscriptionPushToRowMissingOnlyTheInitiatorColumnEndsTheSocket() {
+        val adapter = adapter()
+        val connectionId = "no-initiator-subscription"
+        val channel = adapter.connect(connectionId)
+        adapter.stripInitiator(connectionId)
+
+        adapter.publishToBroadcast()
+
+        assertSocketEnded(adapter, connectionId, channel)
+    }
+
+    /**
+     * `didConnect` is a separate Lambda invocation, so its initiator travels in the payload rather than
+     * the row.  A payload fired by the fork point has no `initiator` at all, and the field was required,
+     * so the whole payload used to fail to decode - silently, since the outer handler writes no response
+     * and Lambda records the async invocation as a success.
+     */
+    @Test
+    fun didConnectWithoutInitiatorEndsTheSocket() {
+        val adapter = adapter()
+        val connectionId = "legacy-did-connect"
+        val channel = adapter.connect(connectionId)
+        adapter.putLegacySocketRow(connectionId)
+
+        val response = decodeResponse(
+            adapter.handleRequest(adapter.legacyDidConnectPayload(connectionId)),
+            "a didConnect payload with no initiator"
+        )
+        adapter.awaitPendingInvocations()
+
+        assertEquals(204, response.statusCode, "The payload must decode and be discarded: ${response.body}")
+        assertSocketEnded(adapter, connectionId, channel)
+    }
+
+    /**
+     * Guards the healthy path against all of the above: a socket with a current row must still receive
+     * client messages, subscription pushes, and a real disconnect.
+     */
+    @Test
+    fun socketWithACurrentRowStillWorksEndToEnd() {
+        val adapter = adapter()
+        val connectionId = "healthy-socket"
+        val channel = adapter.connect(connectionId)
+        SampleServer.disconnectHandlerRuns.set(0)
+
+        assertEquals(200, adapter.invoke(clientMessage(connectionId, "Ping!")).statusCode)
+        adapter.awaitPendingInvocations()
+        assertEquals("echo:Ping!", channel.tryReceive().getOrNull(), "The message should have echoed back")
+
+        adapter.publishToBroadcast()
+        assertEquals("topic:hello", channel.tryReceive().getOrNull(), "The subscription push should have arrived")
+
+        assertEquals(200, adapter.invoke(disconnect(connectionId)).statusCode)
+        adapter.awaitPendingInvocations()
+        assertEquals(1, SampleServer.disconnectHandlerRuns.get(), "The disconnect handler should have run")
+        assertNull(adapter.stateRow(connectionId), "Disconnect cleans up the row")
+        assertTrue(
+            connectionId !in adapter.closedConnections,
+            "A healthy socket is never force-closed by the engine"
+        )
+    }
+}

--- a/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/LegacySocketRowFixture.kt
+++ b/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/LegacySocketRowFixture.kt
@@ -1,0 +1,154 @@
+package com.lightningkite.lightningserver.engine.awsserverless
+
+import com.lightningkite.lightningserver.AnonType
+import com.lightningkite.lightningserver.data.SerializableCache
+import com.lightningkite.lightningserver.http.HttpHeaders
+import com.lightningkite.lightningserver.http.QueryParameters
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.pathing.RawWebSocketPath
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.NothingSerializer
+import kotlinx.serialization.builtins.serializer
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Writes socket rows in the shape a deployment at fork point `4910a921` wrote them.
+ *
+ * This exists because a row produced by today's serializer cannot reproduce the failure a real one
+ * causes.  The stored connect request is a positional `KotlinBytesFormat` blob, and this branch removed
+ * two properties from [com.lightningkite.lightningserver.websockets.WebSocketConnectRequest], so the
+ * only way to test the rolling-deploy path honestly is to encode the old layout.
+ *
+ * [LegacyWebSocketConnectRequest] mirrors that commit's type element for element, **including which
+ * elements carried defaults**: `KotlinBytesFormat` writes an index marker for every optional element, so
+ * the optionality pattern is part of the wire format rather than a detail of the source.  The removed
+ * `requestId` (index 6, no default) and `parentRequestId` (index 7) are what make the blob unreadable
+ * today - the old layout has 11 elements where the current descriptor has 9, and decoding walks off the
+ * end of it.
+ */
+@Serializable
+class LegacyWebSocketConnectRequest<PATH : PathSpec>(
+    val path: RawWebSocketPath<PATH>,
+    val queryParameters: QueryParameters = QueryParameters.EMPTY,
+    val headers: HttpHeaders = HttpHeaders.EMPTY,
+    val domain: String = "",
+    val protocol: String = "",
+    val sourceIp: String = "",
+    /** Removed on this branch.  Non-optional then, so it carries no index marker - keep it that way. */
+    val requestId: String,
+    /** Removed on this branch. */
+    val parentRequestId: String? = null,
+    val upstreamRequestId: String? = null,
+    val cache: SerializableCache = SerializableCache(),
+    val engineSocketId: String? = null,
+)
+
+/**
+ * The legacy shape of [com.lightningkite.lightningserver.websockets.QueryParamWebSocketHandlerData],
+ * which embeds a connect request and is therefore undecodable for the same reason the request is.
+ */
+@Serializable
+class LegacyQueryParamWebSocketHandlerData(
+    val request: LegacyWebSocketConnectRequest<*>,
+    val underlyingData: AnonType,
+)
+
+/**
+ * The legacy shape of [AwsAdapterWs.WebSocketDidConnect]: no `initiator`.
+ *
+ * The payload travels as JSON, not as a positional blob, and the adapter's `Json` sets
+ * `ignoreUnknownKeys`, so the extra `requestId` and `parentRequestId` here are tolerated on arrival.
+ * The missing `initiator` is the whole failure.
+ */
+@Serializable
+class LegacyWebSocketDidConnect(
+    val socketId: String,
+    val connection: LegacyWebSocketConnectRequest<*>,
+    val storage: AnonType,
+)
+
+// Column names, duplicated from AwsWebSocketDynamoDb's private companion: writing the row by hand is
+// the point of this fixture, so the literal names are part of it.
+internal const val socketIdColumn = "wsSocketId"
+internal const val stateColumn = "wsState"
+internal const val requestColumn = "wsRequest"
+internal const val initiatorColumn = "wsInitiator"
+private const val expireColumn = "wsExpire"
+
+internal fun TestAwsAdapter.stateTableName(): String = ws.webSocketDynamo.baseTableName + "-ws-state"
+
+internal fun TestAwsAdapter.legacyConnectRequest(connectionId: String) = LegacyWebSocketConnectRequest<Nothing>(
+    // AWS sockets all arrive at "/" and carry their real path in a query parameter.
+    path = RawWebSocketPath(""),
+    queryParameters = QueryParameters(listOf("path" to "/echo")),
+    requestId = "legacy-request-id",
+    engineSocketId = connectionId,
+)
+
+/**
+ * Replaces [connectionId]'s state row with one written the way the fork point wrote it.
+ *
+ * Overwrites rather than inserts, so a test can connect normally first - keeping the subscription rows
+ * that `didConnect` registered - and then age only the state row.  `wsInitiator` is written only if
+ * [initiator] is given, which models the narrower case of a row whose column set is current but whose
+ * blob is not.
+ */
+internal fun TestAwsAdapter.putLegacySocketRow(connectionId: String, initiator: AttributeValue? = null) {
+    val encoding = internalSerialization.kotlinBytesFormat
+    val request = legacyConnectRequest(connectionId)
+    val storage = LegacyQueryParamWebSocketHandlerData(
+        request = request,
+        underlyingData = AnonType(encoding, Unit, Unit.serializer()),
+    )
+    runBlocking {
+        ws.webSocketDynamo.ensureTables()
+        countingDynamo.putItem {
+            it.tableName(stateTableName())
+            it.item(
+                buildMap {
+                    put(socketIdColumn, AttributeValue.fromS(connectionId))
+                    put(
+                        stateColumn, AttributeValue.fromB(
+                            SdkBytes.fromByteArray(
+                                encoding.encodeToByteArray(
+                                    LegacyQueryParamWebSocketHandlerData.serializer(),
+                                    storage
+                                )
+                            )
+                        )
+                    )
+                    put(
+                        requestColumn, AttributeValue.fromB(
+                            SdkBytes.fromByteArray(
+                                encoding.encodeToByteArray(LegacyWebSocketConnectRequest.serializer(NothingSerializer()), request)
+                            )
+                        )
+                    )
+                    put(
+                        expireColumn,
+                        AttributeValue.fromN(Clock.System.now().plus(8.hours).epochSeconds.toString())
+                    )
+                    initiator?.let { put(initiatorColumn, it) }
+                }
+            )
+        }.await()
+    }
+}
+
+/** The legacy `didConnect` payload the fork point's `${'$'}connect` would have fired for this socket. */
+internal fun TestAwsAdapter.legacyDidConnectPayload(connectionId: String): ByteArray {
+    val encoding = internalSerialization.kotlinBytesFormat
+    return internalSerialization.json.encodeToString(
+        LegacyWebSocketDidConnect.serializer(),
+        LegacyWebSocketDidConnect(
+            socketId = connectionId,
+            connection = legacyConnectRequest(connectionId),
+            storage = AnonType(encoding, Unit, Unit.serializer()),
+        )
+    ).toByteArray()
+}

--- a/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/TestAwsAdapter.kt
+++ b/engine-aws-serverless/src/test/kotlin/com/lightningkite/lightningserver/engine/awsserverless/TestAwsAdapter.kt
@@ -62,8 +62,13 @@ class TestAwsAdapter(server: ServerDefinition) : AwsAdapter(server) {
 
     val webSocketChannels = HashMap<String, Channel<String>>()
     fun webSocketChannel(id: String): Channel<String> = webSocketChannels.getOrPut(id) { Channel() }
+
+    /** Connection ids the engine asked API Gateway to close, so a test can assert a socket was really ended. */
+    val closedConnections: MutableList<String> = Collections.synchronizedList(ArrayList<String>())
+
     override suspend fun apiGatewayWsDeleteConnection(request: DeleteConnectionRequest): DeleteConnectionResponse {
         println("delete ${request.connectionId()}")
+        closedConnections.add(request.connectionId())
         request.connectionId().let { webSocketChannels.remove(it)?.close() }
         return DeleteConnectionResponse.builder().apply {
             sdkHttpResponse(


### PR DESCRIPTION
**Stack: 7 of 16.** Based on `split/e6` — review that one first.
The Initiator PR earlier in this stack changed the shape of things that
outlive a deploy: a new DynamoDB column, removed serialized elements, and a
required field on the lambda payload. During a rolling deploy the new code
reads rows the old code wrote, and none of the four resulting failures
surfaced as anything a reviewer would notice — a 502 with an empty output
stream, a Lambda that records success, and one log line.

`SocketRow` replaces the old state-and-request pair with an explicit
`Absent` / `Legacy(reason)` / `Current(...)` split, decoded for the whole row
at once. The decode catches only `SerializationException` and `IOException`,
which are the two ways a stale row actually surfaces — kotlinx-io reports a
misaligned positional read as EOF, not as a serialization error.

A legacy row is closed rather than guessed at, forcing the client to
reconnect against the new code. Guessing would mean inventing an initiator,
which is exactly the fabricated-provenance problem the audit log exists to
avoid.

`LegacySocketRowFixture` builds rows in the *old* wire format from the actual
pre-change serializers, so the test would notice if the compatibility story
were merely asserted rather than true.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd