### PR TITLE
Sessions: keep the history an auth log needs, and raise auth events

### DIFF
--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/ServerDefinition.kt
@@ -4,6 +4,7 @@ import com.lightningkite.lightningserver.InternalLightningServerApi
 import com.lightningkite.lightningserver.definition.builder.*
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.AuthEventReporter
 import com.lightningkite.lightningserver.runtime.ExecutionInterceptor
 import com.lightningkite.lightningserver.runtime.compileAndInstrument
 import com.lightningkite.lightningserver.serialization.*
@@ -40,6 +41,7 @@ public data class ServerDefinition(
 
         public val endpoints: PathSpecMap<ServerPathEndpoints>,
         public val executionInterceptors: List<ExecutionInterceptor>,
+        public val authEventReporters: List<AuthEventReporter>,
         public val httpConnectionInterceptors: List<HttpConnectionInterceptor>,
         public val httpLogicalInterceptors: List<HttpLogicalInterceptor>,
         public val webSocketConnectionInterceptors: List<WebSocketConnectionInterceptor>,
@@ -73,6 +75,9 @@ public data class ServerDefinition(
 
     /** Interceptors wrapping every execution the server runs, of every kind. See [ExecutionInterceptor]. */
     public val executionInterceptors: List<ExecutionInterceptor> get() = flattened.executionInterceptors
+
+    /** Everything that wants to hear about authentication events. Empty unless a module installs one. */
+    public val authEventReporters: List<AuthEventReporter> get() = flattened.authEventReporters
     public val compiledExecutionInterceptors: ExecutionInterceptor by lazy { executionInterceptors.compileAndInstrument() }
 
     /** Interceptors wrapping the whole physical request. See [HttpConnectionInterceptor]. */
@@ -135,6 +140,7 @@ public data class ServerDefinition(
         externalSerializersModule = Runtime.Cached(externalSerializersModule),
         annotationValidators = Runtime.Cached(annotationValidators),
         executionInterceptors = executionInterceptors.toSealedList(),
+        authEventReporters = authEventReporters.toSealedList(),
         httpConnectionInterceptors = httpConnectionInterceptors.toSealedList(),
         httpLogicalInterceptors = httpLogicalInterceptors.toSealedList(),
         webSocketConnectionInterceptors = webSocketConnectionInterceptors.toSealedList(),
@@ -200,6 +206,7 @@ public data class ServerDefinition(
             externalSerializersModule = { flattenedModuleItems.fold(thisLayer.externalSerializersModule()) { acc, module -> acc + module.externalSerializersModule() } },
             annotationValidators = { flattenedModuleItems.fold(thisLayer.annotationValidators()) { acc, module -> acc + module.annotationValidators() } },
             executionInterceptors = flattenList { it.executionInterceptors },
+            authEventReporters = flattenList { it.authEventReporters },
             httpConnectionInterceptors = flattenList { it.httpConnectionInterceptors },
             httpLogicalInterceptors = flattenList { it.httpLogicalInterceptors },
             webSocketConnectionInterceptors = flattenList { it.webSocketConnectionInterceptors },

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/definition/builder/ServerBuilder.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/definition/builder/ServerBuilder.kt
@@ -4,6 +4,7 @@ import com.lightningkite.lightningserver.*
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.AuthEventReporter
 import com.lightningkite.lightningserver.runtime.ExecutionInterceptor
 import com.lightningkite.lightningserver.serialization.*
 import com.lightningkite.lightningserver.typedoutput.TypedOutputInterceptor
@@ -99,6 +100,8 @@ public abstract class ServerBuilder : Extendable {
 
     private val typedOutputInterceptors: ListRegistry<TypedOutputInterceptor> = ListRegistry()
 
+    private val authEventReporters: ListRegistry<AuthEventReporter> = ListRegistry()
+
     private var exceptionHandler: ExceptionHttpHandler = DefaultExceptionHttpHandler
 
     private val preDeployTasks: MapRegistry<PathSpec0, PreDeployTask> = MapRegistry()
@@ -117,6 +120,10 @@ public abstract class ServerBuilder : Extendable {
     @JvmName("installExecutionInterceptor")
     public fun <T : ExecutionInterceptor> install(interceptor: T): T =
         interceptor.also { executionInterceptors.register(it) }
+
+    @JvmName("installAuthEventReporter")
+    public fun <T : AuthEventReporter> install(reporter: T): T =
+        reporter.also { authEventReporters.register(it) }
 
     @JvmName("installHttpConnectionInterceptor")
     public fun <T : HttpConnectionInterceptor> install(interceptor: T): T =
@@ -341,6 +348,7 @@ public abstract class ServerBuilder : Extendable {
             externalSerializersModule = externalSerialization,
             annotationValidators = annotationValidators,
             executionInterceptors = executionInterceptors.toSealedList(),
+            authEventReporters = authEventReporters.toSealedList(),
             httpConnectionInterceptors = httpConnectionInterceptors.toSealedList(),
             httpLogicalInterceptors = httpLogicalInterceptors.toSealedList(),
             webSocketConnectionInterceptors = webSocketConnectionInterceptors.toSealedList(),

--- a/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/AuthEventReporter.kt
+++ b/core/src/main/kotlin/com/lightningkite/lightningserver/runtime/AuthEventReporter.kt
@@ -1,0 +1,63 @@
+package com.lightningkite.lightningserver.runtime
+
+/**
+ * Receives authentication events so that something can record them.
+ *
+ * The seam lives here, in `core`, rather than in the module that raises the events or the one that
+ * records them, because those two do not depend on each other and should not have to. `sessions`
+ * raises; an audit module installs a reporter that writes. A deployment that installs none pays a
+ * null check.
+ *
+ * ## Why authentication needs its own seam at all
+ * The other audit layers attach to something the framework already routes through — a typed output,
+ * a table, an execution. An authentication *failure* touches none of those: the login endpoints are
+ * `noAuth` and throw before any authentication resolves, so the access log structurally cannot see
+ * them, and nothing is written to a table. Without a seam the event has nowhere to be observed.
+ * See `plans/audit-logging.md` 7.2.
+ *
+ * ## Contract
+ * Implementations must not throw. Unlike the disclosure log, an auth event is reported from paths
+ * that are already failing — rejecting a login, ending a session — and turning a recording failure
+ * into a second, different failure there would obscure the original. A reporter that cannot write
+ * should say so through its own logging and return. This is a deliberate departure from the
+ * fail-closed rule the disclosure and data access logs follow, and the reason is that those two
+ * gate *disclosure*, which must not happen unrecorded, while this one observes events that have
+ * already happened and cannot be un-happened by throwing.
+ */
+public interface AuthEventReporter {
+    /** Identifies this reporter for instrumentation. */
+    public val name: String get() = this::class.simpleName ?: "anonymous"
+
+    /**
+     * Records one authentication event.
+     *
+     * @param type A value from the recorder's own vocabulary, passed as a string so that `core` does
+     *   not have to own the taxonomy. The audit module maps these onto its record type.
+     * @param principal The subject the event is about, or null when the attempt failed before one
+     *   was resolved.
+     * @param actor The principal that caused the event when it differs from [principal].
+     * @param sessionId The session the event concerns, where there is one.
+     * @param sourceIp Where the attempt came from, when it was actually observed. Pass null rather
+     *   than a placeholder: a fabricated origin reads as a real one to whoever queries the log.
+     * @param userAgent As [sourceIp].
+     * @param detail Free text for the reason, where there is one.
+     * @param method How the attempt was made, where the event came from a particular mechanism — a
+     *   proof method's `via`, for instance. A string for the same reason [type] is: the taxonomy
+     *   belongs to whoever raises the event, not here. Null on paths that have no such distinction,
+     *   such as a refresh token exchange.
+     * @param methodProperty The property [method] was applied to, where it has one — the `email` in
+     *   an emailed PIN. Null for methods that identify the subject directly.
+     */
+    context(runtime: ServerRuntime)
+    public suspend fun report(
+        type: String,
+        principal: String? = null,
+        actor: String? = null,
+        sessionId: String? = null,
+        sourceIp: String? = null,
+        userAgent: String? = null,
+        detail: String? = null,
+        method: String? = null,
+        methodProperty: String? = null,
+    )
+}

--- a/sessions-oauth/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/OauthProofEndpoints.kt
+++ b/sessions-oauth/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/OauthProofEndpoints.kt
@@ -102,12 +102,25 @@ public class OauthProofEndpoints(
         cache = cache,
     ) { response: OauthResponse, _: Uuid ->
         val profile = provider.getProfile(response, credentials())
-        val email = profile.email ?: throw BadRequestException("No email was found for this profile.")
+        if (profile.email == null) {
+            // The provider authenticated someone, and returned nothing this server can identify them
+            // by. Not a subject that failed to resolve — there was never anything to resolve.
+            reportProofRejected(info, ProofFailureReason.MalformedRequest)
+            throw BadRequestException("No email was found for this profile.")
+        }
+        val proof = makeProof(profile)
+        // The proof's own value rather than the profile's email: `makeProof` is overridable, and what
+        // was accepted is whatever it put its signature on.
+        //
+        // No request is passed, and so no origin is recorded: `OauthCallbackEndpoint.onAccess` does
+        // not carry one, and widening that seam would change a public signature every caller
+        // implements. The origin is still reachable by joining the event's `requestId`.
+        reportProofAccepted(info, principal = proof.value)
         // Open-redirect note: the final destination is produced entirely by the app-supplied
         // `continueUiAuthUrl` from a server-generated, signed Proof. No user- or attacker-controllable
         // value (query param or `state`) feeds into it, so the redirect target is app-controlled and
         // does not require redirect-URI whitelisting here.
-        HttpResponse.redirectToGet(continueUiAuthUrl(makeProof(profile)))
+        HttpResponse.redirectToGet(continueUiAuthUrl(proof))
     }
 
     public val openEndpoint: HttpHandler<*> = path.path("open").get bind HttpHandler {

--- a/sessions-oauth/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/OauthProofAuthEventWiringTest.kt
+++ b/sessions-oauth/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/OauthProofAuthEventWiringTest.kt
@@ -1,0 +1,141 @@
+package com.lightningkite.lightningserver.sessions.proofs
+
+import com.lightningkite.lightningserver.BadRequestException
+import com.lightningkite.lightningserver.definition.Runtime
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.AuthEventReporter
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.sessions.proofs.oauth.*
+import com.lightningkite.services.cache.Cache
+import com.sun.net.httpserver.HttpServer
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.uuid.Uuid
+
+/**
+ * The OAuth callback's auth-event wiring, driven through a completed login flow.
+ *
+ * OAuth is an *acceptance*: a trusted third party checked a credential and the callback mints a proof
+ * on the strength of it. That makes it the same kind of event as a password being accepted, and it
+ * was recorded nowhere — the callback is a redirect target, not an authenticated endpoint, so no
+ * other audit layer sees it either.
+ *
+ * A capturing reporter rather than the real audit log, because the point being proved here is that a
+ * real endpoint reaches the seam; `AuthEventLogTest` covers what the writer then does with it, and
+ * pulling `audit` into this module's test classpath to re-prove that would buy nothing.
+ */
+class OauthProofAuthEventWiringTest {
+
+    private class CapturingReporter : AuthEventReporter {
+        data class Event(val type: String, val principal: String?, val method: String?, val detail: String?)
+
+        val events: MutableList<Event> = mutableListOf()
+
+        context(runtime: ServerRuntime)
+        override suspend fun report(
+            type: String,
+            principal: String?,
+            actor: String?,
+            sessionId: String?,
+            sourceIp: String?,
+            userAgent: String?,
+            detail: String?,
+            method: String?,
+            methodProperty: String?,
+        ) {
+            events += Event(type, principal, method, detail)
+        }
+    }
+
+    /** Minimal loopback HTTP server standing in for the provider's token endpoint. */
+    private class FakeTokenEndpoint : AutoCloseable {
+        private val server: HttpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+            createContext("/") { exchange ->
+                val bytes = """{"access_token":"at-123","token_type":"Bearer","scope":"email"}"""
+                    .toByteArray(StandardCharsets.UTF_8)
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, bytes.size.toLong())
+                exchange.responseBody.use { it.write(bytes) }
+            }
+            start()
+        }
+
+        val tokenUrl: String get() = "http://127.0.0.1:${server.address.port}/token"
+
+        override fun close() {
+            server.stop(0)
+        }
+    }
+
+    private fun testServer(tokenUrl: String, profileEmail: String?) = object : ServerBuilder() {
+        val cache = setting("cache", Cache.Settings("ram"))
+        val reporter = install(CapturingReporter())
+
+        val provider = OauthProviderInfo(
+            niceName = "TestProvider",
+            loginUrl = "https://provider.example/authorize",
+            tokenUrl = tokenUrl,
+            scopeForProfile = "email",
+            mode = OauthResponseMode.query,
+            getProfile = { _, _ -> ExternalProfile(email = profileEmail) },
+        )
+
+        val oauth = path.path("oauth") include OauthProofEndpoints(
+            provider = provider,
+            cache = cache,
+            credentials = Runtime.Constant(OauthProviderCredentials("client-id", "client-secret")),
+            continueUiAuthUrl = { "https://app.example/continue" },
+        )
+    }
+
+    /** Registers a real state + PKCE pair the way a login start does, and returns the callback nonce. */
+    context(server: ServerRuntime)
+    private suspend fun nonceFor(callback: OauthCallbackEndpoint<Uuid>): String =
+        Url(callback.loginUrl(Uuid.random())).parameters["state"]!!
+
+    @Test
+    fun `a completed oauth login is recorded as an accepted proof naming the identity`() = runBlocking {
+        FakeTokenEndpoint().use { fake ->
+            val server = testServer(fake.tokenUrl, profileEmail = "user@example.com")
+            server.test({}) {
+                server.oauth.callback.handle(OauthCode(code = "auth-code-xyz", state = nonceFor(server.oauth.callback)))
+
+                val event = server.reporter.events.single()
+                assertEquals("ProofAccepted", event.type)
+                assertEquals("user@example.com", event.principal)
+                assertEquals("testprovider", event.method)
+            }
+        }
+    }
+
+    /**
+     * The provider authenticated somebody and returned nothing this server can identify them by. Not
+     * a subject that failed to resolve — there was never anything to resolve — so the row says the
+     * attempt could not be read as identifying anyone, and names no principal.
+     */
+    @Test
+    fun `an oauth profile with no identifying property is recorded as a rejection`() = runBlocking {
+        FakeTokenEndpoint().use { fake ->
+            val server = testServer(fake.tokenUrl, profileEmail = null)
+            server.test({}) {
+                assertFailsWith<BadRequestException> {
+                    server.oauth.callback.handle(
+                        OauthCode(code = "auth-code-xyz", state = nonceFor(server.oauth.callback))
+                    )
+                }
+
+                val event = server.reporter.events.single()
+                assertEquals("ProofRejected", event.type)
+                assertEquals("MalformedRequest", event.detail)
+                assertEquals("testprovider", event.method)
+                assertEquals(null, event.principal)
+            }
+        }
+    }
+}

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/AuthFailureReason.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/AuthFailureReason.kt
@@ -1,0 +1,79 @@
+package com.lightningkite.lightningserver.sessions
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Why an authentication attempt did not succeed.
+ *
+ * These are the reasons the session path already distinguished as debug strings; naming them makes
+ * the distinction survive past a developer's console. The auth event log
+ * (`plans/audit-logging.md` section 7) needs "a failed attempt, and why" as data — "wrong secret"
+ * and "session was terminated" are different security events, and a free-text string cannot be
+ * counted, filtered, or alerted on.
+ *
+ * Deliberately coarse: each value is a distinction an auditor would act on differently. Anything
+ * finer belongs in the accompanying detail, not in a new constant.
+ *
+ * @property reachableWithoutCredentials Whether an attacker holding no valid credentials can cause
+ *   this reason at will. See the property's own documentation — it decides whether the reason is
+ *   safe to record, and every value has to answer it.
+ */
+@Serializable
+public enum class AuthFailureReason(
+    /**
+     * Whether an attacker with no credentials at all can trigger this reason on demand.
+     *
+     * A refresh token is not signed: [RefreshToken.valid] is a prefix check, and the type and
+     * session id are read straight back out of the attacker's own string. So every rejection that
+     * happens *before* the session secret is verified against its hash can be produced at will by
+     * anyone who can reach the server, as many times as they like.
+     *
+     * Recording those is an amplification vector rather than an audit trail. One forged token per
+     * request means one audit row per request, written by an unauthenticated caller, into the same
+     * database as the fail-closed disclosure and data access logs — so filling it takes the server
+     * down with it. They are also worthless as evidence: the session id in the record is a number
+     * the attacker picked, so the row attests to nothing that happened.
+     *
+     * The two rejections that *follow* the hash check, and the two that require naming a real
+     * session, are not reachable this way: a session id is a 122-bit random UUID, so an attacker
+     * cannot produce one, and the hash check cannot be passed without the secret. Those are real
+     * events about a real account and are recorded.
+     *
+     * There is deliberately no default. A new reason has to state which side of the credential
+     * check it falls on, because getting it wrong silently reopens the hole — which is exactly what
+     * happened when this was a two-value check inside `authFailed` and [NoSuchSession] was added
+     * without anyone noticing it belonged in the list.
+     */
+    public val reachableWithoutCredentials: Boolean,
+) {
+    /** The token did not parse, or carried no usable session reference. */
+    TokenMalformed(reachableWithoutCredentials = true),
+
+    /** The token's declared type does not match the principal handler it was presented to. */
+    TokenTypeMismatch(reachableWithoutCredentials = true),
+
+    /**
+     * The token was well-formed but names a session that does not exist.
+     *
+     * Forgeable: the session id comes out of the token string, so any well-formed token naming any
+     * random UUID lands here. A genuine occurrence — a client retrying against a restored database
+     * — is indistinguishable from a forged one, so there is nothing here worth recording. That the
+     * request happened at all is already in the request log.
+     */
+    NoSuchSession(reachableWithoutCredentials = true),
+
+    /** The subject exists but is not currently permitted to authenticate — deactivated, suspended. */
+    AuthenticationNotPermitted(reachableWithoutCredentials = false),
+
+    /** The presented secret did not match the session's stored hash. */
+    SecretMismatch(reachableWithoutCredentials = false),
+
+    /** Past the session's hard expiry. */
+    SessionExpired(reachableWithoutCredentials = false),
+
+    /** Past the session's sliding staleness window. */
+    SessionStale(reachableWithoutCredentials = false),
+
+    /** The session was explicitly terminated. */
+    SessionTerminated(reachableWithoutCredentials = false),
+}

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/SessionManager.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/SessionManager.kt
@@ -92,6 +92,19 @@ public abstract class SessionManager<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
     public val principal: PrincipalType<SUBJECT, ID>,
     database: Runtime<Database>,
     public val tokenFormat: Runtime<TokenFormat> = Runtime { PrivateTinyTokenFormat() },
+    /**
+     * Decorates the session table, so a deployment can observe session creation, update and
+     * termination without reaching into this class.
+     *
+     * The write paths here are deliberately sealed — `newSession` is not open,
+     * `terminateSessionById` is private — so before this existed there was no seam at all for the
+     * auth event log (`plans/audit-logging.md` 7.2) to attach to. Applied ahead of permissions, so a
+     * decorator sees privileged and unprivileged access alike.
+     *
+     * For write-only observation, `sessionInfo.registerChangeListener` is already sufficient and
+     * needs nothing from here; this is the wider seam, which also sees reads.
+     */
+    private val sessionSignals: context(ServerRuntime) (Table<Session<SUBJECT, ID>>) -> Table<Session<SUBJECT, ID>> = { it },
 ) : ServerBuilder(), Authentication.Reader<SUBJECT> {
     public object Scopes {
         public val self: RequiredScope = RequiredScope("auth:self")
@@ -168,6 +181,7 @@ public abstract class SessionManager<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
             serializer = Session.serializer(principal.subjectSerializer, principal.idSerializer),
             idSerializer = Uuid.serializer(),
             tableName = principal.name + "Session",
+            signals = { sessionSignals(it) },
             permissions = {
                 val auth = this.authOrNull
                 val canUse: Condition<Session<SUBJECT, ID>> = when {
@@ -186,7 +200,13 @@ public abstract class SessionManager<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
                         )
                     ),
                     update = isRoot,
-                    delete = isRoot,
+                    // Sessions are terminated, never erased. The row is the only record that a
+                    // session ever existed, and two comments in this file already promise it is
+                    // "kept for audit trail" — but delete was exposed over REST, so a super-user
+                    // could erase the evidence and nothing recorded that they had. Termination
+                    // (Session.terminated) remains available and is what callers want; it goes
+                    // through table(), which does not consult these permissions.
+                    delete = Condition.Never,
                 )
             }
         )
@@ -351,41 +371,111 @@ public abstract class SessionManager<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
      * @return The validated Session, or null if token is malformed
      * @throws UnauthorizedException if token is well-formed but invalid (wrong secret, expired, etc.)
      */
+    /**
+     * The single point every authentication rejection passes through.
+     *
+     * Exists so the reason is a value rather than a sentence: the auth event log
+     * (`plans/audit-logging.md` section 7) has to record *why* an attempt failed, and a debug string
+     * printed to stdout is not something that can be counted or alerted on. Reporting stays gated on
+     * the debug setting exactly as before; the enum is what makes this seam worth hooking later.
+     */
     context(server: ServerRuntime)
-    private suspend fun RefreshToken.session(request: Request<*>?): Session<SUBJECT, ID>? {
+    private suspend fun authFailed(
+        reason: AuthFailureReason,
+        principal: String? = null,
+        sessionId: String? = null,
+        request: Request<*>? = null,
+    ) {
+        if (generalSettings().debug) println("Auth failed: $reason" + (sessionId?.let { " ($it)" } ?: ""))
+        // A rejection an attacker can produce on demand is an amplification vector, not an audit
+        // trail: one forged token per request writes one audit row per request, unauthenticated,
+        // into the same database as the fail-closed disclosure and data access logs. Each reason
+        // declares which side of the credential check it falls on, rather than this being a list
+        // here that the next reason gets left out of. See AuthFailureReason.reachableWithoutCredentials.
+        if (reason.reachableWithoutCredentials) return
+        // Reporters must not throw (see AuthEventReporter): this path is already rejecting a login,
+        // and a second failure here would obscure the first.
+        server.server.authEventReporters.forEach {
+            it.report(
+                type = "AuthenticationFailed",
+                // Indexed on the record precisely so "when did this account start failing logins"
+                // is answerable. Null only where the attempt failed before any subject resolved.
+                principal = principal,
+                sessionId = sessionId,
+                // Only what was actually observed; a placeholder would read as a real origin.
+                sourceIp = request?.sourceIp,
+                userAgent = request?.headers?.get(HttpHeader.UserAgent)?.root,
+                detail = reason.name,
+            )
+        }
+    }
+
+    context(server: ServerRuntime)
+    /**
+     * [request] is non-null because both call sites are request handlers; the type says so rather
+     * than leaving a branch that cannot be reached. It was nullable, which made the placeholder
+     * fallback below unreachable *and* untestable — a mutation reintroducing a literal `"test"` ip
+     * could not be killed by any test, because no caller can supply the null that would select it.
+     */
+    private suspend fun RefreshToken.session(request: Request<*>): Session<SUBJECT, ID>? {
         if (!valid) {
-            if (generalSettings().debug) println("Auth failed because !valid")
+            authFailed(AuthFailureReason.TokenMalformed, request = request)
             return null
         }
         if (type != principal.name) {
-            if (generalSettings().debug) println("Auth failed because type != handler.name")
+            authFailed(AuthFailureReason.TokenTypeMismatch, request = request)
             return null
         }
 
         val session = sessionInfo.table().get(_id) ?: run {
-            if (generalSettings().debug) println("No such session")
+            authFailed(AuthFailureReason.NoSuchSession, sessionId = _id.toString(), request = request)
             throw UnauthorizedException("No such session")
         }
         val subject = principal.fetch(session.subjectId)
         if(!permitAuthentication(subject)){
-            if (generalSettings().debug) println("Permit Authentication failed")
+            authFailed(
+                AuthFailureReason.AuthenticationNotPermitted,
+                principal = session.subjectId.toString(),
+                sessionId = session._id.toString(),
+                request = request,
+            )
             throw ForbiddenException()
         }
         // SECURITY: Constant-time hash comparison to prevent timing attacks
         if (!plainTextSecret.checkAgainstHash(session.secretHash)) {
-            if (generalSettings().debug) println("Auth failed because hash verification failed for session ${session._id}")
+            authFailed(
+                AuthFailureReason.SecretMismatch,
+                principal = session.subjectId.toString(),
+                sessionId = session._id.toString(),
+                request = request,
+            )
             throw UnauthorizedException("Incorrect hash for session")
         }
         if ((session.expires ?: Instant.DISTANT_FUTURE) < now()) {
-            if (generalSettings().debug) println("Auth failed because (session.expires ?: Instant.DISTANT_FUTURE) < now()")
+            authFailed(
+                AuthFailureReason.SessionExpired,
+                principal = session.subjectId.toString(),
+                sessionId = session._id.toString(),
+                request = request,
+            )
             throw UnauthorizedException("Session has expired (hard).")
         }
         if ((session.stale ?: Instant.DISTANT_FUTURE) < now()) {
-            if (generalSettings().debug) println("Auth failed because (session.stale ?: Instant.FUTURE) < now()")
+            authFailed(
+                AuthFailureReason.SessionStale,
+                principal = session.subjectId.toString(),
+                sessionId = session._id.toString(),
+                request = request,
+            )
             throw UnauthorizedException("Session has expired (stale).")
         }
         if (session.terminated != null) {
-            if (generalSettings().debug) println("Auth failed because session.terminated != null")
+            authFailed(
+                AuthFailureReason.SessionTerminated,
+                principal = session.subjectId.toString(),
+                sessionId = session._id.toString(),
+                request = request,
+            )
             throw UnauthorizedException("Session has been terminated.")
         }
 
@@ -395,8 +485,12 @@ public abstract class SessionManager<SUBJECT : HasId<ID>, ID : Comparable<ID>>(
         // Update session metadata on each use for audit trail and sliding expiration
         sessionInfo.table().updateOneById(_id, modification(spath) {
             it.lastUsed assign now()
-            it.userAgents addAll setOf(request?.headers?.get(HttpHeader.UserAgent)?.root ?: "")
-            it.ips addAll setOf(request?.sourceIp ?: "test")
+            // Record only what was actually observed. These sets are the closest thing the system
+            // has to an authentication audit trail, and a placeholder in them is indistinguishable
+            // from a real observation: a literal "test" ip read as a genuine origin, and an empty
+            // user agent as a genuine one. Absent is absent.
+            it.userAgents addAll setOfNotNull(request.headers[HttpHeader.UserAgent]?.root)
+            it.ips addAll setOf(request.sourceIp)
 
             // Reset staleness window on each use (sliding expiration)
             sessionStaleAfter(subject)?.let { length ->

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpoints.kt
@@ -10,7 +10,7 @@ import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.serverRuntime
-import com.lightningkite.lightningserver.sessions.proofs.extensions.constrainAttemptRate
+import com.lightningkite.lightningserver.runtime.now
 import com.lightningkite.lightningserver.sessions.proofs.extensions.makeProof
 import com.lightningkite.lightningserver.typed.*
 import com.lightningkite.lightningserver.typed.sdk.*
@@ -27,6 +27,7 @@ import kotlinx.serialization.builtins.serializer
 import java.security.SecureRandom
 import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Instant
 import kotlin.time.Duration.Companion.hours
 import kotlin.uuid.Uuid
 
@@ -38,6 +39,16 @@ public data class BackupCodeSecret(
     val code: String,
     val subjectId: String,
     val subjectType: String,
+    val createdAt: Instant,
+    /**
+     * When this code was redeemed, or null while it is still usable.
+     *
+     * Redeeming a code used to delete its row, which left no trace that the code had ever existed,
+     * let alone been used — the one event on this table an auditor is certain to ask about. The row
+     * is now retained and marked instead, and it is this field, not the row's absence, that makes a
+     * code single-use.
+     */
+    val usedAt: Instant? = null,
 ) : HasId<Uuid>
 
 @OptIn(InternalSerializationApi::class)
@@ -82,8 +93,13 @@ public class BackupCodeEndpoints(
             errorCases = listOf(),
             examples = listOf(),
             implementation = { _: Unit ->
+                // Revokes the codes that are still live. Redeemed rows stay: they are a record of an
+                // authentication that happened, not a secret that needs withdrawing.
                 modelInfo.table().deleteManyIgnoringOld(
-                    condition { it.subjectId.eq(auth.rawId) and it.subjectType.eq(auth.principalName) }
+                    condition {
+                        it.subjectId.eq(auth.rawId) and it.subjectType.eq(auth.principalName) and
+                                it.usedAt.eq(null)
+                    }
                 )
 
                 val r = SecureRandom()
@@ -102,6 +118,7 @@ public class BackupCodeEndpoints(
                         code = it.lowercase(),
                         subjectId = auth.rawId,
                         subjectType = auth.principalName,
+                        createdAt = now(),
                     )
                 })
 
@@ -120,8 +137,12 @@ public class BackupCodeEndpoints(
             examples = listOf(),
             implementation = { _: Unit ->
 
+                // As above: clearing withdraws live codes, it does not erase redemption history.
                 modelInfo.table().deleteManyIgnoringOld(
-                    condition { it.subjectId.eq(auth.rawId) and it.subjectType.eq(auth.principalName) }
+                    condition {
+                        it.subjectId.eq(auth.rawId) and it.subjectType.eq(auth.principalName) and
+                                it.usedAt.eq(null)
+                    }
                 )
 
                 Unit
@@ -139,7 +160,10 @@ public class BackupCodeEndpoints(
             examples = listOf(),
             implementation = { _: Unit ->
                 modelInfo.table().findOne(
-                    condition { it.subjectId.eq(auth.rawId) and it.subjectType.eq(auth.principalName) }
+                    condition {
+                        it.subjectId.eq(auth.rawId) and it.subjectType.eq(auth.principalName) and
+                                it.usedAt.eq(null)
+                    }
                 ) != null
             }
         )
@@ -174,31 +198,66 @@ public class BackupCodeEndpoints(
                 val subject = input.type
 
                 val handler = serverRuntime.server.principalTypes.values.find { it.name == subject }
-                    ?: throw IllegalArgumentException("No subject $subject recognized")
+                    ?: run {
+                        reportProofRejected(info, ProofFailureReason.MalformedRequest, request = request)
+                        throw IllegalArgumentException("No subject $subject recognized")
+                    }
 
                 // Normalize BEFORE building the rate-limit key: the key must be derived from the canonical
                 // identifier so that case/whitespace variants of the same account share one bucket. Keying on
                 // the raw value would let an attacker dodge the limiter (and its exponential backoff) simply
                 // by varying case or whitespace.
                 val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
-                cache().constrainAttemptRate(
-                    cacheKey = "backup-code-count-${input.property}-${normalizedValue}"
+                cache().constrainProofAttemptRate(
+                    cacheKey = "backup-code-count-${input.property}-${normalizedValue}",
+                    method = info,
+                    request = request,
                 ) {
                     val subjectId = handler.fetchUserIdString(input.property, input.value)
-                        ?: throw BadRequestException("Invalid Backup Code")
+                        ?: run {
+                            // No account resolved, so no principal to name. Recorded anyway: a run of these
+                            // against different values is what enumeration looks like.
+                            reportProofRejected(info, ProofFailureReason.NoSuchSubject, request = request)
+                            throw BadRequestException("Invalid Backup Code")
+                        }
 
                     val secrets = modelInfo.table().find(condition {
                         it.subjectId.eq(subjectId) and
-                                it.subjectType.eq(subject)
+                                it.subjectType.eq(subject) and
+                                it.usedAt.eq(null)
                     })
                         .toList()
 
                     val normalizedCode = input.password.filter { it.isLetter() }.lowercase()
                     val match = secrets.find { normalizedCode == it.code }
-                        ?: throw BadRequestException("Invalid Backup Code")
+                        ?: run {
+                            reportProofRejected(
+                                info,
+                                ProofFailureReason.SecretMismatch,
+                                principal = subjectId,
+                                request = request,
+                            )
+                            throw BadRequestException("Invalid Backup Code")
+                        }
 
-                    modelInfo.table().deleteOneById(match._id)
+                    // Claim the code by marking it, conditional on it still being unused, so that two
+                    // concurrent redemptions of the same code cannot both succeed. Losing this race is
+                    // indistinguishable from presenting an already-spent code, and answers the same.
+                    val claimed = modelInfo.table().updateOne(
+                        condition { it._id.eq(match._id) and it.usedAt.eq(null) },
+                        modification { it.usedAt assign now() },
+                    )
+                    if (claimed.old == null) {
+                        reportProofRejected(
+                            info,
+                            ProofFailureReason.SecretAlreadyUsed,
+                            principal = subjectId,
+                            request = request,
+                        )
+                        throw BadRequestException("Invalid Backup Code")
+                    }
 
+                    reportProofAccepted(info, principal = subjectId, request = request)
                     proofSigner.await().makeProof(
                         info = info.copy(strength = 10),
                         property = input.property,
@@ -216,7 +275,8 @@ public class BackupCodeEndpoints(
         modelInfo.table().findOne(
             condition {
                 it.subjectId.eq(principal.idString(subject._id)) and
-                        it.subjectType.eq(principal.name)
+                        it.subjectType.eq(principal.name) and
+                        it.usedAt.eq(null)
             }
         ) != null
 }

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/KnownDeviceProofEndpoints.kt
@@ -10,7 +10,6 @@ import com.lightningkite.lightningserver.pathing.PathSpec0
 import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.now
 import com.lightningkite.lightningserver.sessions.*
-import com.lightningkite.lightningserver.sessions.proofs.extensions.constrainAttemptRate
 import com.lightningkite.lightningserver.sessions.proofs.extensions.makeProof
 import com.lightningkite.lightningserver.typed.*
 import com.lightningkite.lightningserver.typed.sdk.*
@@ -168,6 +167,7 @@ public class KnownDeviceProofEndpoints(
                 val id = input.substringBefore('/').let {
                     try { Uuid.parse(it) }
                     catch (e: IllegalArgumentException) {
+                        reportProofRejected(info, ProofFailureReason.MalformedRequest, request = request)
                         throw BadRequestException(
                             message = "Invalid known device identifier. ${e.message}",
                             data = it,
@@ -176,15 +176,28 @@ public class KnownDeviceProofEndpoints(
                     }
                 }
                 val secret = input.substringAfter('/')
-                cache().constrainAttemptRate(
-                    cacheKey = "known-devices-count-${id}"
+                cache().constrainProofAttemptRate(
+                    cacheKey = "known-devices-count-${id}",
+                    method = info,
+                    request = request,
                 ) {
                     val active = modelInfo.table().get(id)
-                        ?: throw BadRequestException("No such known device")
+                        ?: run {
+                            // The device id names no record, so there is no account behind it to name.
+                            reportProofRejected(info, ProofFailureReason.NoSuchSubject, request = request)
+                            throw BadRequestException("No such known device")
+                        }
 
                     // Good: Uses constant-time checkAgainstHash to prevent timing attacks
-                    if (!secret.checkAgainstHash(active.hash))
+                    if (!secret.checkAgainstHash(active.hash)) {
+                        reportProofRejected(
+                            info,
+                            ProofFailureReason.SecretMismatch,
+                            principal = active.subjectId,
+                            request = request,
+                        )
                         throw BadRequestException("User ID and code do not match")
+                    }
 
                     // Lazy migration: if using old slow PBKDF2 hash, upgrade to fast SHA-256 hash
                     val shouldMigrate = active.hash.isSlowHash()
@@ -196,6 +209,7 @@ public class KnownDeviceProofEndpoints(
                         }
                     })
 
+                    reportProofAccepted(info, principal = active.subjectId, request = request)
                     proofSigner.await().makeProof(
                         property = "${active.subjectType}/_id",
                         value = active.subjectId,

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PasswordProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PasswordProofEndpoints.kt
@@ -168,27 +168,48 @@ public class PasswordProofEndpoints(
                 val now = now()
                 val subject = input.type
                 val handler = serverRuntime.server.principalTypes.values.find { it.name == subject }
-                    ?: throw IllegalArgumentException("No subject $subject recognized")
+                    ?: run {
+                        reportProofRejected(info, ProofFailureReason.MalformedRequest, request = request)
+                        throw IllegalArgumentException("No subject $subject recognized")
+                    }
                 // Normalize BEFORE building the rate-limit key: the key must be derived from the canonical
                 // identifier so that case/whitespace variants (e.g. "Bob@x.com" vs "bob@x.com ") of the same
                 // account share one bucket. Keying on the raw value would let an attacker dodge the limiter
                 // (and its exponential backoff) simply by varying case or whitespace.
                 val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
-                cache().constrainAttemptRate("password-${input.property}-${normalizedValue}") {
+                cache().constrainProofAttemptRate(
+                    cacheKey = "password-${input.property}-${normalizedValue}",
+                    method = info,
+                    request = request,
+                ) {
                     val subjectId = handler.fetchUserIdString(input.property, normalizedValue)
-                        ?: throw BadRequestException("User ID and code do not match")
+                        ?: run {
+                            // No account resolved, so no principal to name. Recorded anyway: a run of
+                            // these against different values is what enumeration looks like.
+                            reportProofRejected(info, ProofFailureReason.NoSuchSubject, request = request)
+                            throw BadRequestException("User ID and code do not match")
+                        }
 
                     val active = modelInfo.table().find(condition {
                         it.subjectId.eq(subjectId) and it.subjectType.eq(subject) and active
                     }).toList()
 
                     val matching = active.find { input.password.checkAgainstHash(it.hash) }
-                        ?: throw BadRequestException("User ID and code do not match")
+                        ?: run {
+                            reportProofRejected(
+                                info,
+                                ProofFailureReason.SecretMismatch,
+                                principal = subjectId,
+                                request = request,
+                            )
+                            throw BadRequestException("User ID and code do not match")
+                        }
 
                     modelInfo.table().updateOneById(matching._id, modification {
                         it.lastUsedAt assign now
                     })
 
+                    reportProofAccepted(info, principal = subjectId, request = request)
                     proofSigner.await().makeProof(
                         property = input.property,
                         value = normalizedValue,

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PinBasedProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PinBasedProofEndpoints.kt
@@ -1,5 +1,7 @@
 package com.lightningkite.lightningserver.sessions.proofs
 
+import com.lightningkite.lightningserver.BadRequestException
+import com.lightningkite.lightningserver.NotFoundException
 import com.lightningkite.lightningserver.auth.PrincipalType
 import com.lightningkite.lightningserver.auth.noAuth
 import com.lightningkite.lightningserver.definition.RuntimeDeferred
@@ -78,9 +80,33 @@ public abstract class PinBasedProofEndpoints(
             errorCases = emptyList(),
             successCode = HttpStatus.OK,
             implementation = { input: FinishProof ->
+                // What the attempt is against. A PIN proves ownership of an address, not of an account —
+                // these endpoints never resolve a subject, that happens later at login — so the address is
+                // the truthful answer to "who was this about", and it is the only one a failure has.
+                val target = pin.pendingTarget(input.key)
+                val value = try {
+                    pin.assert(input.key, input.password)
+                } catch (e: NotFoundException) {
+                    reportProofRejected(
+                        info,
+                        ProofFailureReason.SecretExpired,
+                        principal = target,
+                        request = request,
+                    )
+                    throw e
+                } catch (e: BadRequestException) {
+                    reportProofRejected(
+                        info,
+                        ProofFailureReason.SecretMismatch,
+                        principal = target,
+                        request = request,
+                    )
+                    throw e
+                }
+                reportProofAccepted(info, principal = value, request = request)
                 proofSigner.await().makeProof(
                     property = property,
-                    value = pin.assert(input.key, input.password),
+                    value = value,
                 )
             }
         )

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PinHandler.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PinHandler.kt
@@ -50,6 +50,16 @@ public open class PinHandler(
         return pin
     }
 
+    /**
+     * The identifier a pending PIN was established for, or null when [key] is unknown or expired.
+     *
+     * Exists so that a failed [assert] can say *what* the attempt was against: the key on its own is a
+     * random UUID, which cannot be counted or alerted on. Reads the same entry [assert] consumes on
+     * success, without disturbing it.
+     */
+    context(server: ServerRuntime)
+    public suspend fun pendingTarget(key: String): String? = cache().get<String>(valueCacheKey(key))
+
     context(server: ServerRuntime)
     public suspend fun assert(key: String, pin: String): String {
         val hashedPin = cache().get<String>(cacheKey(key))

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/TimeBasedOTPProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/TimeBasedOTPProofEndpoints.kt
@@ -156,17 +156,27 @@ public class TimeBasedOTPProofEndpoints(
                 val gracePeriod = now().minus(5.seconds)
                 val subject = input.type
                 val handler = serverRuntime.server.principalTypes[subject]
-                    ?: throw IllegalArgumentException("No subject $subject recognized")
+                    ?: run {
+                        reportProofRejected(info, ProofFailureReason.MalformedRequest, request = request)
+                        throw IllegalArgumentException("No subject $subject recognized")
+                    }
                 // Normalize BEFORE building the rate-limit key: the key must be derived from the canonical
                 // identifier so that case/whitespace variants of the same account share one bucket. Keying on
                 // the raw value would let an attacker dodge the limiter (and its exponential backoff) simply
                 // by varying case or whitespace.
                 val normalizedValue = handler.normalizePropertyValue(input.property, input.value)
-                cache().constrainAttemptRate(
-                    cacheKey = "totp-count-${input.property}-${normalizedValue}"
+                cache().constrainProofAttemptRate(
+                    cacheKey = "totp-count-${input.property}-${normalizedValue}",
+                    method = info,
+                    request = request,
                 ) {
                     val subjectId = handler.fetchUserIdString(input.property, normalizedValue)
-                        ?: throw BadRequestException("User ID and code do not match")
+                        ?: run {
+                            // No account resolved, so no principal to name. Recorded anyway: a run of these
+                            // against different values is what enumeration looks like.
+                            reportProofRejected(info, ProofFailureReason.NoSuchSubject, request = request)
+                            throw BadRequestException("User ID and code do not match")
+                        }
 
                     val active = modelInfo.table().find(condition {
                         it.subjectId.eq(subjectId) and it.subjectType.eq(subject) and active
@@ -185,7 +195,15 @@ public class TimeBasedOTPProofEndpoints(
                         matching = secret
                         break
                     }
-                    val matched = matching ?: throw BadRequestException("User ID and code do not match")
+                    val matched = matching ?: run {
+                        reportProofRejected(
+                            info,
+                            ProofFailureReason.SecretMismatch,
+                            principal = subjectId,
+                            request = request,
+                        )
+                        throw BadRequestException("User ID and code do not match")
+                    }
 
                     // Enforce single-use (RFC 6238 §5.2): a code is valid for exactly one time-step, so the same
                     // code must not mint two proofs. Key on the secret + the time-step that validated; reuse the
@@ -199,14 +217,23 @@ public class TimeBasedOTPProofEndpoints(
                     // A reused code is reported plainly (unlike a wrong code, which stays opaque): revealing reuse
                     // is harmless here — it only confirms a code the caller already supplied was once valid — and
                     // a clear "wait for the next code" is far better UX than a misleading "does not match".
-                    if (!claimed) throw BadRequestException(
-                        "That code was already used. Please wait for your authenticator to show a new code."
-                    )
+                    if (!claimed) {
+                        reportProofRejected(
+                            info,
+                            ProofFailureReason.SecretAlreadyUsed,
+                            principal = subjectId,
+                            request = request,
+                        )
+                        throw BadRequestException(
+                            "That code was already used. Please wait for your authenticator to show a new code."
+                        )
+                    }
 
                     modelInfo.table().updateOneById(matched._id, modification {
                         it.lastUsedAt assign now
                     })
 
+                    reportProofAccepted(info, principal = subjectId, request = request)
                     proofSigner.await().makeProof(
                         property = input.property,
                         value = normalizedValue,

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/WebAuthNProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/WebAuthNProofEndpoints.kt
@@ -390,16 +390,28 @@ public class WebAuthNProofEndpoints(
 
                 val cacheKey = challengeCacheKey(challengeId)
                 val fromCache = cache().getAndRemove<AuthenticationCache>(cacheKey)
-                    ?: throw BadRequestException("No Challenge available")
+                    ?: run {
+                        // The challenge is single-use and time-limited, so an unknown id is one that
+                        // expired, was already spent, or was never issued. No subject is known yet.
+                        reportProofRejected(info, ProofFailureReason.SecretExpired, request = request)
+                        throw BadRequestException("No Challenge available")
+                    }
                 cache().remove(cacheKey)
 
-                if (fromCache.challenge != WebAuthN.base64Decoder.decode(clientData.challenge).decodeToString())
+                if (fromCache.challenge != WebAuthN.base64Decoder.decode(clientData.challenge).decodeToString()) {
+                    reportProofRejected(info, ProofFailureReason.SecretMismatch, request = request)
                     throw BadRequestException("No Challenge available")
+                }
 
                 val publicKeyCredential: WebAuthNCredential = modelInfo.table()
                     .find(condition { it._id.eq(credentials.id) and active })
                     .firstOrNull()
-                    ?: throw ForbiddenException("Invalid Credential ID")
+                    ?: run {
+                        // The credential id is what identifies the account here, so an unknown one
+                        // resolves no subject.
+                        reportProofRejected(info, ProofFailureReason.NoSuchSubject, request = request)
+                        throw ForbiddenException("Invalid Credential ID")
+                    }
 
                 val authRequest = AuthenticationRequest(
                     WebAuthN.base64Decoder.decode(credentials.id),
@@ -442,6 +454,12 @@ public class WebAuthNProofEndpoints(
                     )
                 } catch (e: VerificationException) {
                     e.printStackTrace()
+                    reportProofRejected(
+                        info,
+                        ProofFailureReason.SecretMismatch,
+                        principal = publicKeyCredential.subjectId,
+                        request = request,
+                    )
                     throw BadRequestException("Failed to verify Authenticator")
                 }
 
@@ -458,6 +476,7 @@ public class WebAuthNProofEndpoints(
                     }
                 )
 
+                reportProofAccepted(info, principal = publicKeyCredential.subjectId, request = request)
                 proofSigner.await().makeProof(
                     info = if (authData.authenticatorData?.isFlagUV == true) info.copy(strength = 20) else info,
                     property = "${fromCache.subjectType}/_id",

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/extensions/Cache.ext.kt
@@ -32,6 +32,16 @@ public suspend fun Cache.claimOnce(cacheKey: String, ttl: Duration): Boolean =
     setIfNotExists(cacheKey, now(), ttl)
 
 /**
+ * The rejection [constrainAttemptRate] raises when a key has run out of attempts.
+ *
+ * A subclass rather than a plain [BadRequestException] so that a caller can tell "the limiter turned
+ * this away" apart from "the credential was wrong", which look identical to the client on purpose but
+ * are different security events. The status, detail and message are unchanged, so what the caller
+ * receives is exactly what it was.
+ */
+public class TooManyAttemptsException(message: String) : BadRequestException(message = message)
+
+/**
  *  Tracks the number of action attempts against a given [cacheKey] and applies rate limiting with
  *  **exponential backoff** so that repeated abuse of the same key is punished progressively harder.
  *
@@ -91,7 +101,7 @@ public suspend inline fun <R> Cache.constrainAttemptRate(
         // still treated as a repeat offender (defeats slow "popcorn" brute forcing).
         this.add(levelKey, 1, maxBlocked * 4)
         this.add(cacheKey, 1, blockDuration)
-        throw BadRequestException("Too many attempts; please wait ${blockDuration.inWholeMinutes} minutes.")
+        throw TooManyAttemptsException("Too many attempts; please wait ${blockDuration.inWholeMinutes} minutes.")
     }
 
     return try {

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/proofAuthEvents.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/proofAuthEvents.kt
@@ -1,0 +1,164 @@
+package com.lightningkite.lightningserver.sessions.proofs
+
+import com.lightningkite.lightningserver.data.Request
+import com.lightningkite.lightningserver.http.HttpHeader
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.sessions.proofs.extensions.TooManyAttemptsException
+import com.lightningkite.lightningserver.sessions.proofs.extensions.constrainAttemptRate
+import com.lightningkite.services.cache.Cache
+import kotlinx.serialization.Serializable
+
+/**
+ * Why a credential presented to a proof endpoint was rejected.
+ *
+ * Separate from `AuthFailureReason` rather than an extension of it, for two reasons. The reasons
+ * there describe a *refresh token* being exchanged, which is a different act from presenting a
+ * credential — a token attests to an authentication that already happened, a proof is the
+ * authentication. And every value there must answer `reachableWithoutCredentials`, which decides
+ * whether the reason is suppressed; that question is meaningless here, because proof failures are
+ * all recorded (see [reportProofRejected]). Folding these in would drag that suppression along.
+ *
+ * Deliberately coarse, like its neighbour: each value is a distinction an auditor would act on
+ * differently. "Which of this account's three passwords didn't match" is detail, not a new constant.
+ */
+@Serializable
+public enum class ProofFailureReason {
+    /**
+     * The attempt could not be read as identifying anyone: an unrecognised principal type, an
+     * unparseable identifier, or an external profile carrying no identifying property.
+     */
+    MalformedRequest,
+
+    /**
+     * Rejected by the attempt limiter before the credential was looked at.
+     *
+     * Distinct from the failures that fed the limiter, which were each recorded on their own: this
+     * one says the attempts *continued* past the point where the server stopped answering them,
+     * which is the difference between a user who forgot a password and a script that did not stop.
+     */
+    RateLimited,
+
+    /**
+     * The identifying property and value matched no account.
+     *
+     * Enumeration-adjacent by nature, and deliberately indistinguishable from [SecretMismatch] in
+     * what the endpoint answers the caller — the difference lives only here. the audit record's
+     * `principal` stays null for these: there is no account to name, and inventing one would make
+     * the log assert something that did not happen.
+     */
+    NoSuchSubject,
+
+    /** An account or credential record resolved, and the presented secret did not match it. */
+    SecretMismatch,
+
+    /** The PIN, challenge, or code existed but is past its window or out of attempts. */
+    SecretExpired,
+
+    /** A single-use credential was presented a second time. */
+    SecretAlreadyUsed,
+}
+
+/**
+ * Records that a credential presented to a proof endpoint was rejected.
+ *
+ * ## Why proof endpoints, specifically
+ * `SessionManager.authFailed` covers refresh-token rejections, which are mostly expired sessions.
+ * Credential *guessing* happens here: passwords, PINs, TOTP, backup codes, WebAuthN. Without this,
+ * "how many failures has this account had in the last ten minutes" is unanswerable for every
+ * interesting kind of failure.
+ *
+ * ## Every failure is recorded, including ones that resolved no account
+ * There is deliberately no `reachableWithoutCredentials`-style suppression here, and the token path's
+ * guard must not be copied over. That guard exists because a refresh token is unsigned, so an
+ * attacker can mint rejections at will and turn the audit table into an amplification target. Proof
+ * endpoints are different: each one is behind `constrainAttemptRate`, which caps how fast a given
+ * key can produce failures at all. A failure against an account that does not exist is exactly the
+ * evidence of enumeration an auditor wants, so dropping it would remove the record of the attack
+ * this layer is for.
+ *
+ * @param method Which proof method rejected the attempt; its `via` and `property` land on the record.
+ * @param reason Countable, so it can be alerted on. Never a sentence.
+ * @param principal The account the attempt was against, where one resolved. Null otherwise — see
+ *   [ProofFailureReason.NoSuchSubject]; a proof endpoint that resolved nothing has no subject to
+ *   name, and naming one anyway would be a fabrication.
+ * @param request The request the attempt arrived on, for its origin. Only what was actually
+ *   observed is recorded; a missing user agent stays null rather than becoming a blank string.
+ */
+context(server: ServerRuntime)
+public suspend fun reportProofRejected(
+    method: ProofMethodInfo,
+    reason: ProofFailureReason,
+    principal: String? = null,
+    request: Request<*>? = null,
+): Unit = reportProofEvent("ProofRejected", method, principal, request, reason.name)
+
+/**
+ * Records that a credential presented to a proof endpoint was accepted.
+ *
+ * Raised where the acceptance happens — at the end of a `prove` handler, after the secret has been
+ * checked — and deliberately not where proofs are *minted*. `Signer.makeProof` also mints a proof to
+ * be mailed to someone (a magic link), which is not a credential having been presented and must not
+ * be recorded as one. See the module notes on that split.
+ *
+ * @param principal The account that authenticated. For a method that proves ownership of an address
+ *   rather than of an account (an emailed or texted PIN), this is that address: those endpoints
+ *   never resolve a subject at all — resolution happens later, at login — so the address is the
+ *   truthful answer to "who was this about".
+ */
+context(server: ServerRuntime)
+public suspend fun reportProofAccepted(
+    method: ProofMethodInfo,
+    principal: String? = null,
+    request: Request<*>? = null,
+): Unit = reportProofEvent("ProofAccepted", method, principal, request, null)
+
+context(server: ServerRuntime)
+private suspend fun reportProofEvent(
+    type: String,
+    method: ProofMethodInfo,
+    principal: String?,
+    request: Request<*>?,
+    detail: String?,
+) {
+    // Reporters must not throw (see AuthEventReporter): a rejection path is already failing, and a
+    // second failure raised here would obscure the first.
+    server.server.authEventReporters.forEach {
+        it.report(
+            type = type,
+            principal = principal,
+            sourceIp = request?.sourceIp,
+            userAgent = request?.headers?.get(HttpHeader.UserAgent)?.root,
+            detail = detail,
+            method = method.via,
+            methodProperty = method.property,
+        )
+    }
+}
+
+/**
+ * [constrainAttemptRate] for a proof endpoint: the same limiter, with the rejection it raises
+ * recorded as a proof failure.
+ *
+ * Wrapped here rather than caught at each `prove` handler because the limiter answers *before* the
+ * handler body runs, so the only place to see it is around the call — and writing that out at every
+ * limited `prove` would bury each handler's actual logic in a try/catch.
+ *
+ * @param method The proof method whose attempt was limited.
+ * @param request The request the attempt arrived on, for its origin.
+ */
+context(server: ServerRuntime)
+public suspend inline fun <R> Cache.constrainProofAttemptRate(
+    cacheKey: String,
+    method: ProofMethodInfo,
+    request: Request<*>?,
+    action: () -> R,
+): R = try {
+    constrainAttemptRate(cacheKey, action = action)
+} catch (e: TooManyAttemptsException) {
+    // The attempts that filled the bucket were each recorded on their own; this one says they did not
+    // stop, which is the difference between a forgotten password and a script. No principal: the
+    // limiter turns the request away before any account is looked up, and looking one up here would
+    // hand an attacker a database query per blocked request.
+    reportProofRejected(method, ProofFailureReason.RateLimited, request = request)
+    throw e
+}

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
@@ -6,6 +6,7 @@ import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.auth.*
 import com.lightningkite.lightningserver.definition.Runtime
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.data.get
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.*
 import com.lightningkite.lightningserver.plainText
@@ -22,6 +23,11 @@ import com.lightningkite.lightningserver.sessions.token.PrivateTinyTokenFormat
 import com.lightningkite.lightningserver.typed.test
 import com.lightningkite.services.database.Database
 import com.lightningkite.services.database.HasId
+import com.lightningkite.services.database.get
+import com.lightningkite.services.database.Table
+import com.lightningkite.services.database.Condition
+import com.lightningkite.lightningserver.typed.AuthAccess
+import com.lightningkite.services.database.postCreate
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -59,10 +65,12 @@ class SessionManagerTest {
         database: Runtime<Database>,
         private val expirationDuration: Duration? = 30.days,
         private val staleDuration: Duration? = 7.days,
+        sessionSignals: context(ServerRuntime) (Table<Session<SessionTestUser, Uuid>>) -> Table<Session<SessionTestUser, Uuid>> = { it },
     ) : SessionManager<SessionTestUser, Uuid>(
         principal = SessionTestUser,
         database = database,
-        tokenFormat = Runtime { PrivateTinyTokenFormat() }
+        tokenFormat = Runtime { PrivateTinyTokenFormat() },
+        sessionSignals = sessionSignals,
     ) {
         context(server: ServerRuntime)
         override suspend fun sessionExpiration(subject: SessionTestUser): Instant? =
@@ -183,6 +191,159 @@ class SessionManagerTest {
 
                 assertNotNull(accessToken)
                 assertTrue(accessToken.isNotEmpty())
+            }
+        }
+    }
+
+    /**
+     * The session's `ips` and `userAgents` sets are the closest thing this system has to an
+     * authentication audit trail, so an unobserved value must be absent from them rather than
+     * present as a placeholder — an empty-string user agent reads as a real observation to anyone
+     * querying it, exactly as the literal "test" ip did on the request-less path.
+     */
+    @Test
+    fun `an unobserved user agent is not recorded as a placeholder`() = runBlocking {
+        SessionTestUser.users.clear()
+        val userId = Uuid.random()
+        SessionTestUser.users[userId] = SessionTestUser(userId, "test@example.com")
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+
+            val sessions = path.path("auth") include TestSessionManager(database = database)
+        }.let { server ->
+            server.test({}) {
+                val (session, refreshToken) = server.sessions.newSession(userId)
+                // The harness supplies a source ip but no User-Agent header.
+                server.sessions.tokenSimple.test(null, refreshToken.string)
+
+                val stored = with(serverRuntime) { server.sessions.sessionInfo.table().get(session._id) }
+                assertNotNull(stored)
+                assertEquals(
+                    emptySet(),
+                    stored.userAgents,
+                    "an absent user agent was recorded as a value",
+                )
+                // The ip was genuinely observed, so it is genuinely recorded.
+                assertEquals(setOf("localhost"), stored.ips)
+            }
+        }
+    }
+
+    /**
+     * The other half of the same audit-trail promise: what *is* observed must be the request's own
+     * value, not something the code supplies. The test above drives the session through the typed
+     * harness, which fixes the ip and sends no User-Agent, so it can only show that an absent value
+     * stays absent. Here a real request presents its refresh token as a bearer credential — the path
+     * a client that has not yet exchanged for an access token actually takes — carrying an ip and a
+     * user agent that appear nowhere else, so a recorded constant could not pass for either.
+     */
+    @Test
+    fun `a session use records the ip and user agent the request carried`() = runBlocking {
+        SessionTestUser.users.clear()
+        val userId = Uuid.random()
+        SessionTestUser.users[userId] = SessionTestUser(userId, "test@example.com")
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+
+            val sessions = path.path("auth") include TestSessionManager(database = database)
+        }.let { server ->
+            server.test({}) {
+                val (session, refreshToken) = server.sessions.newSession(userId)
+
+                val request = HttpRequest<PathSpec>(
+                    path = RawHttpEndpoint(asString = "/ping", method = HttpMethod.GET),
+                    queryParameters = QueryParameters.EMPTY,
+                    headers = HttpHeaders {
+                        add(HttpHeader.Authorization, "Bearer ${refreshToken.string}")
+                        add(HttpHeader.UserAgent, "ExampleClient/9.9 (audit-trail probe)")
+                    },
+                    domain = "example.com",
+                    protocol = "https",
+                    sourceIp = "203.0.113.7",
+                )
+                // Resolving the request's authentication is what drives the session-use update. If the
+                // token were not accepted no update would happen at all, and the assertions below would
+                // be reading an untouched session rather than a recorded one.
+                val resolved = with(serverRuntime) { request[Authentication.CacheKey] }
+                assertNotNull(resolved, "the refresh token was not accepted, so no session use was recorded")
+
+                val stored = with(serverRuntime) { server.sessions.sessionInfo.table().get(session._id) }
+                assertNotNull(stored)
+                assertEquals(setOf("203.0.113.7"), stored.ips, "the recorded ip is not the one the request came from")
+                assertEquals(
+                    setOf("ExampleClient/9.9 (audit-trail probe)"),
+                    stored.userAgents,
+                    "the recorded user agent is not the one the request sent",
+                )
+            }
+        }
+    }
+
+    /**
+     * The auth event log needs to observe session creation and termination, and the write paths that
+     * do both are sealed — `newSession` is not open, `terminateSessionById` is private. The signals
+     * seam is what makes them observable from outside without unsealing anything.
+     */
+    @Test
+    fun `the signals seam sees session writes`() = runBlocking {
+        SessionTestUser.users.clear()
+        val userId = Uuid.random()
+        SessionTestUser.users[userId] = SessionTestUser(userId, "test@example.com")
+
+        val created = mutableListOf<Uuid>()
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+
+            val sessions = path.path("auth") include TestSessionManager(
+                database = database,
+                sessionSignals = { table -> table.postCreate { created += it._id } },
+            )
+        }.let { server ->
+            server.test({}) {
+                val (session, _) = server.sessions.newSession(userId)
+                assertEquals(listOf(session._id), created, "the seam did not observe session creation")
+            }
+        }
+    }
+
+    /**
+     * A session row is the only record that a session ever existed, and this file twice promises it
+     * is "kept for audit trail" — but delete was granted to super-users and exposed over REST, so
+     * the evidence could be erased with nothing recording that it had been. Termination is the
+     * supported operation and is unaffected: it goes through table(), which does not consult these
+     * permissions.
+     */
+    @Test
+    fun `session rows cannot be deleted, even by a super user`() = runBlocking {
+        SessionTestUser.users.clear()
+        val userId = Uuid.random()
+        SessionTestUser.users[userId] = SessionTestUser(userId, "test@example.com")
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+
+            val sessions = path.path("auth") include TestSessionManager(database = database)
+
+            init {
+                // Make the test subject a super user, so `isRoot` resolves to Always. Without this
+                // every branch collapses to Never for an unprivileged caller and the assertion below
+                // would hold no matter what delete was granted.
+                AuthRequirement.isSuperUser = SessionTestUser.require()
+            }
+        }.let { server ->
+            server.test({}) {
+                val (session, _) = server.sessions.newSession(userId)
+                val auth = with(server.sessions) { session.toAuth() }
+                val permissions = with(serverRuntime) {
+                    server.sessions.sessionInfo.permissions(AuthAccess(auth))
+                }
+                assertTrue(
+                    permissions.delete == Condition.Never,
+                    "a super user can delete session rows, erasing the only record the session existed",
+                )
             }
         }
     }

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpointsTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/proofs/BackupCodeEndpointsTest.kt
@@ -2,16 +2,33 @@
 package com.lightningkite.lightningserver.sessions.proofs
 
 import com.lightningkite.lightningserver.BadRequestException
+import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.auth.*
+import com.lightningkite.lightningserver.definition.Runtime
 import com.lightningkite.lightningserver.definition.RuntimeDeferred
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.encryption.SecretBasis
 import com.lightningkite.lightningserver.encryption.signer
+import com.lightningkite.lightningserver.http.HttpHeaders
+import com.lightningkite.lightningserver.http.HttpRequest
+import com.lightningkite.lightningserver.http.HttpStatus
+import com.lightningkite.lightningserver.http.QueryParameters
+import com.lightningkite.lightningserver.http.generateRequestId
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
+import com.lightningkite.lightningserver.runtime.Engine
 import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.handle
+import com.lightningkite.lightningserver.runtime.now
+import com.lightningkite.lightningserver.runtime.serverRuntime
 import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.sessions.proofs.extensions.TooManyAttemptsException
 import com.lightningkite.lightningserver.typed.test
 import com.lightningkite.services.cache.Cache
 import com.lightningkite.services.database.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -22,6 +39,48 @@ import org.junit.Test
 import kotlin.test.*
 import kotlin.time.Duration.Companion.hours
 import kotlin.uuid.Uuid
+
+/**
+ * A [Database] that lets a test run something in the middle of a read of one table.
+ *
+ * Concurrency cannot be pinned down by launching two coroutines and hoping they interleave; the
+ * outcome would depend on the scheduler and the test would discriminate nothing reliably. So the
+ * interleaving is staged instead: [nextInterleave] is consulted on each read of [tableName] and, if
+ * it yields an action, that action runs to completion *after* the rows have been fetched but
+ * *before* the caller receives them. The caller therefore proceeds on a view of the table that is
+ * already out of date — precisely the window an atomic conditional write has to close.
+ *
+ * The rows are materialized before the action runs so that the caller sees the pre-action state even
+ * on a backend whose result flow is lazy over live storage.
+ */
+private class InterleavingDatabase(
+    private val wraps: Database,
+    private val tableName: String,
+    private val nextInterleave: () -> (suspend () -> Unit)?,
+) : Database by wraps {
+
+    override fun <T : Any> table(tableDef: DatabaseTableDefinition<T>): Table<T> =
+        decorate(tableDef, wraps.table(tableDef))
+
+    override suspend fun <T : Any> prepare(tableDef: DatabaseTableDefinition<T>): Table<T> =
+        decorate(tableDef, wraps.prepare(tableDef))
+
+    private fun <T : Any> decorate(tableDef: DatabaseTableDefinition<T>, table: Table<T>): Table<T> =
+        if (tableDef.name != tableName) table
+        else object : Table<T> by table {
+            override suspend fun find(
+                condition: Condition<T>,
+                orderBy: List<SortPart<T>>,
+                skip: Int,
+                limit: Int,
+                maxQueryMs: Long,
+            ): Flow<T> {
+                val rows = table.find(condition, orderBy, skip, limit, maxQueryMs).toList()
+                nextInterleave()?.invoke()
+                return rows.asFlow()
+            }
+        }
+}
 
 /**
  * Tests for BackupCodeEndpoints - backup code authentication.
@@ -90,7 +149,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "abcdefghij",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -136,7 +196,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "testbackupcode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -160,7 +221,7 @@ class BackupCodeEndpointsTest {
     }
 
     @Test
-    fun `backup code is deleted after use`() = runBlocking {
+    fun `a used backup code is retained and marked, not deleted`() = runBlocking {
         TestUser.users.clear()
         val userId = Uuid.random()
         val user = TestUser(userId, "test@example.com")
@@ -190,7 +251,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "onetimecode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -211,11 +273,21 @@ class BackupCodeEndpointsTest {
                     )
                 )
 
-                // Verify code was deleted
-                codeCount = table.find(condition<BackupCodeSecret> {
+                // The row survives — it is the only evidence the code was ever used — but is spent.
+                val after = table.find(condition<BackupCodeSecret> {
                     it.subjectId.eq(TestUser.idString(userId))
-                }).count()
-                assertEquals(0, codeCount)
+                }).toList()
+                assertEquals(1, after.size, "using a backup code destroyed the record that it existed")
+                assertNotNull(after.single().usedAt, "a used backup code was not marked as used")
+
+                // And it no longer counts as an established method.
+                assertEquals(
+                    0,
+                    table.find(condition<BackupCodeSecret> {
+                        it.subjectId.eq(TestUser.idString(userId)) and it.usedAt.eq(null)
+                    }).count(),
+                    "a spent backup code still reads as usable",
+                )
             }
         }
     }
@@ -251,7 +323,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "singlusecode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -312,7 +385,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "validcode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -363,7 +437,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "abcdefghij",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -417,7 +492,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "backupcode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -463,7 +539,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "useronecode",
                             subjectId = TestUser.idString(userId1),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -485,7 +562,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "usertwocode",
                             subjectId = TestUser.idString(userId2),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -547,7 +625,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "firstcode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -556,7 +635,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "secondcode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
@@ -565,12 +645,13 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "thirdcode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )
 
-                // All codes should work (and be deleted after use)
+                // All codes should work (and be marked spent after use)
                 server.backupCodes.prove.test(
                     null, IdentificationAndPassword(
                         type = "TestUser",
@@ -580,13 +661,433 @@ class BackupCodeEndpointsTest {
                     )
                 )
 
-                // Verify second code was deleted but others remain
-                val remainingCodes = table.find(condition<BackupCodeSecret> {
+                // Every row survives; only the redeemed one is spent, and the others stay usable.
+                val allCodes = table.find(condition<BackupCodeSecret> {
+                    it.subjectId.eq(TestUser.idString(userId))
+                }).toList()
+                assertEquals(3, allCodes.size, "using one code removed rows")
+                assertEquals(listOf("secondcode"), allCodes.filter { it.usedAt != null }.map { it.code })
+
+                val stillUsable = table.find(condition<BackupCodeSecret> {
+                    it.subjectId.eq(TestUser.idString(userId)) and it.usedAt.eq(null)
+                }).toList()
+                assertEquals(2, stillUsable.size)
+                assertTrue(stillUsable.none { it.code == "secondcode" })
+            }
+        }
+    }
+
+    /**
+     * Redeeming a backup code claims it with a conditional update whose condition includes that the
+     * code is still unspent. That condition is the whole of the protection against two redemptions of
+     * the same code both succeeding; a plain read-then-write would satisfy every other test in this
+     * file, because they are all sequential, and the flaw only appears when one redemption reads the
+     * code before another has finished spending it.
+     *
+     * So the interleaving is staged rather than raced for: a second, complete redemption runs inside
+     * the window between the first one's read and its write. Against the conditional update the first
+     * redemption then loses on the condition and is rejected exactly as a replay would be; against a
+     * read-then-write it would overwrite the second one's mark and both would be handed a proof.
+     */
+    @Test
+    fun `two interleaved redemptions of one backup code cannot both succeed`() = runBlocking {
+        TestUser.users.clear()
+        val userId = Uuid.random()
+        TestUser.users[userId] = TestUser(userId, "test@example.com")
+
+        // Armed just before the contested redemption and consumed by the first read, so the setup and
+        // verification queries below are unaffected.
+        var interleave: (suspend () -> Unit)? = null
+
+        object : ServerBuilder() {
+            val rawDatabase = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val database: Runtime<Database> = object : Runtime<Database> {
+                context(server: Engine)
+                override fun invoke(): Database =
+                    InterleavingDatabase(rawDatabase(), "BackupCodeSecret") {
+                        val next = interleave
+                        interleave = null
+                        next
+                    }
+            }
+
+            val backupCodes = path.path("auth").path("backup") include BackupCodeEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours,
+            )
+        }.let { server ->
+            server.test({}) {
+                val table = server.backupCodes.modelInfo.table()
+                table.insert(
+                    listOf(
+                        BackupCodeSecret(
+                            code = "contestedcode",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                        )
+                    )
+                )
+                assertEquals(
+                    1,
+                    table.find(condition<BackupCodeSecret> { it.usedAt.eq(null) }).count(),
+                    "there is no live code to contest",
+                )
+
+                val request = IdentificationAndPassword(
+                    type = "TestUser",
+                    property = "email",
+                    value = "test@example.com",
+                    password = "contestedcode",
+                )
+
+                var interleavedProof: Proof? = null
+                interleave = { interleavedProof = server.backupCodes.prove.test(null, request) }
+
+                val rejected = assertFailsWith<BadRequestException>(
+                    "one backup code was redeemed twice"
+                ) { server.backupCodes.prove.test(null, request) }
+
+                // The interleaved redemption is the whole fixture. If it never ran, nothing was
+                // contested and the rejection above would prove nothing.
+                assertNotNull(interleavedProof, "the interleaved redemption never ran")
+                assertNull(interleave, "the interleave was never consumed")
+                assertFalse(
+                    rejected is TooManyAttemptsException,
+                    "the rejection came from the rate limiter, not from losing the claim",
+                )
+
+                val after = table.find(Condition.Always).toList()
+                assertEquals(1, after.size, "the contested code's row did not survive")
+                assertNotNull(after.single().usedAt, "the code that produced a proof was not marked spent")
+            }
+        }
+    }
+
+    // ========== Revocation: resetCodes and clearCodes ==========
+
+    /**
+     * The proof endpoints are declared against `HasId<*>` rather than a concrete principal, so a
+     * [TestUser] authentication has to be widened to be handed to one. Nothing about the
+     * authentication changes; only its static type.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun Authentication<TestUser>.forEndpoint(): Authentication<HasId<*>> =
+        this as Authentication<HasId<*>>
+
+    /**
+     * Revocation withdraws secrets; it is not a way to erase history. A spent row is the record of an
+     * authentication that happened, and the `usedAt == null` guard on the delete is the only thing
+     * keeping that record out of the blast radius — without it, resetting your codes quietly destroys
+     * the evidence of every code you ever redeemed.
+     */
+    @Test
+    fun `resetCodes withdraws live codes and keeps the record of spent ones`() = runBlocking {
+        TestUser.users.clear()
+        val userId = Uuid.random()
+        val user = TestUser(userId, "test@example.com")
+        TestUser.users[userId] = user
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val backupCodes = path.path("auth").path("backup") include BackupCodeEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours,
+                codeLength = 10,
+                generateCount = 5,
+            )
+        }.let { server ->
+            server.test({}) {
+                val table = server.backupCodes.modelInfo.table()
+                val spentAt = now()
+
+                table.insert(
+                    listOf(
+                        BackupCodeSecret(
+                            code = "liveonecode",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                        ),
+                        BackupCodeSecret(
+                            code = "livetwocode",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                        ),
+                        BackupCodeSecret(
+                            code = "alreadyspent",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                            usedAt = spentAt,
+                        ),
+                    )
+                )
+
+                // The fixture has to actually be in the state the test claims, or every assertion
+                // below would hold just as well against an empty table.
+                val before = table.find(condition<BackupCodeSecret> {
+                    it.subjectId.eq(TestUser.idString(userId))
+                }).toList()
+                assertEquals(3, before.size)
+                assertEquals(2, before.count { it.usedAt == null })
+
+                val auth = Authentication(TestUser, userId, sessionId = null).forEndpoint()
+                val issued = server.backupCodes.resetCodes.test(auth, Unit)
+                assertEquals(5, issued.size, "reset did not issue a fresh set of codes")
+
+                val after = table.find(condition<BackupCodeSecret> {
                     it.subjectId.eq(TestUser.idString(userId))
                 }).toList()
 
-                assertEquals(2, remainingCodes.size)
-                assertTrue(remainingCodes.none { it.code == "secondcode" })
+                val spent = after.filter { it.usedAt != null }
+                assertEquals(listOf("alreadyspent"), spent.map { it.code }, "revocation erased a redemption record")
+                assertEquals(spentAt, spent.single().usedAt, "the redemption's timestamp did not survive revocation")
+
+                val live = after.filter { it.usedAt == null }
+                assertEquals(5, live.size, "the old live codes were not replaced by exactly the new ones")
+                assertTrue(
+                    live.none { it.code == "liveonecode" || it.code == "livetwocode" },
+                    "a revoked code is still usable",
+                )
+            }
+        }
+    }
+
+    /** As [resetCodes withdraws live codes and keeps the record of spent ones], for the endpoint that withdraws without reissuing. */
+    @Test
+    fun `clearCodes withdraws live codes and keeps the record of spent ones`() = runBlocking {
+        TestUser.users.clear()
+        val userId = Uuid.random()
+        val user = TestUser(userId, "test@example.com")
+        TestUser.users[userId] = user
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val backupCodes = path.path("auth").path("backup") include BackupCodeEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours,
+            )
+        }.let { server ->
+            server.test({}) {
+                val table = server.backupCodes.modelInfo.table()
+                val spentAt = now()
+
+                table.insert(
+                    listOf(
+                        BackupCodeSecret(
+                            code = "stillusable",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                        ),
+                        BackupCodeSecret(
+                            code = "alreadyspent",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                            usedAt = spentAt,
+                        ),
+                    )
+                )
+                val before = table.find(condition<BackupCodeSecret> {
+                    it.subjectId.eq(TestUser.idString(userId))
+                }).toList()
+                assertEquals(2, before.size)
+                assertEquals(1, before.count { it.usedAt == null })
+
+                val auth = Authentication(TestUser, userId, sessionId = null).forEndpoint()
+                server.backupCodes.clearCodes.test(auth, Unit)
+
+                val after = table.find(condition<BackupCodeSecret> {
+                    it.subjectId.eq(TestUser.idString(userId))
+                }).toList()
+                assertEquals(
+                    listOf("alreadyspent"),
+                    after.map { it.code },
+                    "clearing should leave exactly the spent rows behind",
+                )
+                assertEquals(spentAt, after.single().usedAt, "the redemption's timestamp did not survive clearing")
+                assertFalse(
+                    server.backupCodes.established(TestUser, user),
+                    "a cleared user still reads as having backup codes established",
+                )
+            }
+        }
+    }
+
+    /**
+     * These endpoints delete credentials, and the condition they delete by is the whole of the
+     * authorization: drop the subject from it and any authenticated caller wipes everyone's codes.
+     */
+    @Test
+    fun `revocation does not reach another subject's codes`() = runBlocking {
+        TestUser.users.clear()
+        val ownerId = Uuid.random()
+        TestUser.users[ownerId] = TestUser(ownerId, "owner@example.com")
+        val otherId = Uuid.random()
+        TestUser.users[otherId] = TestUser(otherId, "other@example.com")
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+            }
+
+            val backupCodes = path.path("auth").path("backup") include BackupCodeEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours,
+                codeLength = 10,
+                generateCount = 5,
+            )
+        }.let { server ->
+            server.test({}) {
+                val table = server.backupCodes.modelInfo.table()
+                table.insert(
+                    listOf(
+                        BackupCodeSecret(
+                            code = "ownerscodeone",
+                            subjectId = TestUser.idString(ownerId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                        ),
+                        BackupCodeSecret(
+                            code = "ownerscodetwo",
+                            subjectId = TestUser.idString(ownerId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                        ),
+                    )
+                )
+                val ownersLiveCodes = condition<BackupCodeSecret> {
+                    it.subjectId.eq(TestUser.idString(ownerId)) and it.usedAt.eq(null)
+                }
+                assertEquals(
+                    listOf("ownerscodeone", "ownerscodetwo"),
+                    table.find(ownersLiveCodes).toList().map { it.code }.sorted(),
+                )
+
+                val otherAuth = Authentication(TestUser, otherId, sessionId = null).forEndpoint()
+                server.backupCodes.resetCodes.test(otherAuth, Unit)
+                assertEquals(
+                    listOf("ownerscodeone", "ownerscodetwo"),
+                    table.find(ownersLiveCodes).toList().map { it.code }.sorted(),
+                    "resetting one subject's codes revoked another subject's",
+                )
+
+                server.backupCodes.clearCodes.test(otherAuth, Unit)
+                assertEquals(
+                    listOf("ownerscodeone", "ownerscodetwo"),
+                    table.find(ownersLiveCodes).toList().map { it.code }.sorted(),
+                    "clearing one subject's codes revoked another subject's",
+                )
+            }
+        }
+    }
+
+    /**
+     * The scoping above only protects anyone if the caller has to be authenticated at all, so this
+     * goes through the real request pipeline rather than the typed `test` helper — the helper hands
+     * the endpoint an authentication directly and never consults its [proofMethodAuth] requirement.
+     */
+    @Test
+    fun `the revocation endpoints refuse an unauthenticated caller`() = runBlocking {
+        TestUser.users.clear()
+        val userId = Uuid.random()
+        TestUser.users[userId] = TestUser(userId, "test@example.com")
+
+        object : ServerBuilder() {
+            val database = setting("database", Database.Settings("ram"))
+            val cache = setting("cache", Cache.Settings("ram"))
+
+            init {
+                register(TestUser)
+                registerBasicMediaTypeCoders()
+            }
+
+            val backupCodes = path.path("auth").path("backup") include BackupCodeEndpoints(
+                database = database,
+                cache = cache,
+                proofSigner = RuntimeDeferred.Cached { testBasis.signer("proof") },
+                proofExpiration = 1.hours,
+            )
+        }.let { server ->
+            server.test({}) {
+                val table = server.backupCodes.modelInfo.table()
+                table.insert(
+                    listOf(
+                        BackupCodeSecret(
+                            code = "targetedcode",
+                            subjectId = TestUser.idString(userId),
+                            subjectType = TestUser.name,
+                            createdAt = now(),
+                        )
+                    )
+                )
+                assertEquals(1, table.find(Condition.Always).count())
+
+                // What is required is not merely "some authenticated caller" but a recent proof of this
+                // very method — the same bar as changing the credential these codes back up.
+                assertEquals(server.backupCodes.proofMethodAuth, server.backupCodes.resetCodes.auth)
+                assertEquals(server.backupCodes.proofMethodAuth, server.backupCodes.clearCodes.auth)
+
+                for (endpoint in listOf("reset-codes", "clear-codes")) {
+                    val response = runBlocking {
+                        serverRuntime.handle(
+                            HttpRequest<PathSpec>(
+                                path = RawHttpEndpoint(asString = "/auth/backup/$endpoint", method = HttpMethod.POST),
+                                queryParameters = QueryParameters.EMPTY,
+                                headers = HttpHeaders(),
+                                domain = "example.com",
+                                protocol = "https",
+                                sourceIp = "203.0.113.7",
+                            ),
+                            generateRequestId(),
+                        )
+                    }
+                    // Forbidden rather than Unauthorized is what AuthRequirement.assert raises for a
+                    // caller with no authentication at all; what matters here is that it refuses.
+                    assertEquals(
+                        HttpStatus.Forbidden,
+                        response.status,
+                        "/auth/backup/$endpoint answered an unauthenticated caller with ${response.status}",
+                    )
+                }
+
+                assertEquals(
+                    1,
+                    table.find(Condition.Always).count(),
+                    "an unauthenticated request revoked a code anyway",
+                )
             }
         }
     }
@@ -624,7 +1125,8 @@ class BackupCodeEndpointsTest {
                         BackupCodeSecret(
                             code = "validcode",
                             subjectId = TestUser.idString(userId),
-                            subjectType = TestUser.name
+                            subjectType = TestUser.name,
+                            createdAt = now()
                         )
                     )
                 )


### PR DESCRIPTION
**Stack: 8 of 16.** Based on `split/e7` — review that one first.
The session path recorded state, not history. A `Session` row says a session
*exists*; it could not say a login happened, failed, or was revoked. Every
distinction worth auditing was last-write-wins state, a counter deleted on
the next success, or a debug print.

Model changes:
- Only the ip and user agent actually observed are recorded. A blank user
  agent used to be stored as though it were an observation.
- `AuthFailureReason` names the rejections the path previously distinguished
  only as debug strings.
- The session table gains a signals seam.
- Sessions are terminated, never deleted, and a used backup code is retained
  and marked rather than removed. A deleted row is not evidence.

Auth events:
- `AuthEventReporter` in core is the seam; `SessionManager` and the proof
  endpoints fire it. Nothing consumes it yet.
- Each `AuthFailureReason` must declare `reachableWithoutCredentials`, with
  no default. A refresh token is not signed — `RefreshToken.valid` is a
  prefix check and the session id is read out of the caller's own string — so
  every rejection before the secret is hashed can be produced at will by
  anyone. Recording those would let an unauthenticated caller write one audit
  row per request. Measured before the fix: 25 forged requests, 25 rows.
- The forgeable attempt stays visible in the request log, so the evidence
  moves rather than disappears.

The no-default is the load-bearing part: this began as a two-value list
inside `authFailed`, and `NoSuchSession` was added to the enum afterwards
without being added to the list.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd