### PR TITLE
Make the typed test helper actually check authorization

### DIFF
--- a/demo/src/test/kotlin/com/lightningkite/lightningserver/demo/AuthExamplesEndpointsTest.kt
+++ b/demo/src/test/kotlin/com/lightningkite/lightningserver/demo/AuthExamplesEndpointsTest.kt
@@ -27,10 +27,13 @@ class AuthExamplesEndpointsTest {
         }
     }
 
-    // whoAmI requires auth: AuthRequirement<User> (non-optional), so .test() only accepts a real
-    // Authentication<User> - there is no way to even construct an unauthenticated call to it
-    // through the typed test helper. That's the point: the requirement is enforced by the type
-    // system, not just checked at runtime.
+    // whoAmI types its caller as a non-nullable User, so an unauthenticated call to it cannot be
+    // written: `.test(null, Unit)` does not compile. That is a property of this endpoint's signature
+    // and does not generalise — every endpoint beside it types callers as `HasId<*>?`, where a null
+    // call compiles fine and is refused at runtime by the AuthRequirement instead.
+    //
+    // Deliberately left as a comment rather than dressed up as a test: "this does not compile" is not
+    // something a test can assert, so a test claiming to prove it would be proving something else.
 
     @Test
     fun greetIsGenericForAnonymousCallers() = runBlocking {
@@ -52,8 +55,17 @@ class AuthExamplesEndpointsTest {
         }
     }
 
+    /**
+     * The rejection here comes from the **handler body**, not from the endpoint's [AuthRequirement].
+     *
+     * `adminOnly` requires only `UserAuth.require()` — any logged-in caller satisfies it — and then
+     * reads `isSuperUser` itself and throws. So this and its sibling below cover a role check, which
+     * is a normal and legitimate thing to demonstrate; they are named for that rather than for
+     * authorization, because a reader copying from the demo module should be able to tell which of
+     * the two mechanisms they are looking at.
+     */
     @Test
-    fun adminOnlyRejectsNonAdminsWith403() = runBlocking {
+    fun adminOnlyRejectsALoggedInNonAdminFromItsHandlerBody() = runBlocking {
         TestHelper.testServer {
             val user = Server.userInfo.table().insertOne(User(email = "regular@example.com"))!!
             val auth = Authentication(Server.UserAuth, id = user._id, sessionId = null)
@@ -65,8 +77,9 @@ class AuthExamplesEndpointsTest {
         }
     }
 
+    /** As above: the caller clears the requirement either way, and the body's role check admits them. */
     @Test
-    fun adminOnlyAllowsSuperUsers() = runBlocking {
+    fun adminOnlyAdmitsALoggedInSuperUserFromItsHandlerBody() = runBlocking {
         TestHelper.testServer {
             val admin = Server.userInfo.table().insertOne(User(email = "admin@example.com", isSuperUser = true))!!
             val auth = Authentication(Server.UserAuth, id = admin._id, sessionId = null)

--- a/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
+++ b/sessions/src/test/kotlin/com/lightningkite/lightningserver/sessions/SessionManagerTest.kt
@@ -370,7 +370,16 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `tokenSimple rejects not active user`() = runBlocking {
+    /**
+     * `permitAuthentication` returning false is what refuses this, not an [AuthRequirement].
+     *
+     * `tokenSimple` is `noAuth` — it has to be, since exchanging a refresh token is how a caller
+     * becomes authenticated in the first place — so nothing about the endpoint's requirement can
+     * reject anyone. The assertion below pins that, so a future change that moved the rejection into
+     * a requirement would fail here rather than quietly keep the test green under a different
+     * mechanism than its name describes.
+     */
+    fun `tokenSimple rejects a user permitAuthentication turned away`() = runBlocking {
         SessionTestUser.users.clear()
         val userId = Uuid.random()
         val user = SessionTestUser(userId, "test@example.com")
@@ -385,7 +394,14 @@ class SessionManagerTest {
                 val (_, refreshToken) = server.sessions.newSession(userId)
 
                 SessionTestUser.users[userId] = user.copy(active = false)
-                assertFailsWith<ForbiddenException>("Inactive User's refresh token should be rejected") {
+                // Nothing here can be an authorization failure: the endpoint demands no authentication.
+                assertEquals(
+                    noAuth,
+                    server.sessions.tokenSimple.auth,
+                    "tokenSimple gained an auth requirement, so the rejection below no longer proves " +
+                        "what this test claims — it could now be the requirement rather than permitAuthentication",
+                )
+                assertFailsWith<ForbiddenException>("an inactive user's refresh token must be refused") {
                     server.sessions.tokenSimple.test(null, refreshToken.string)
                 }
             }

--- a/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/testing.kt
+++ b/typed/src/main/kotlin/com/lightningkite/lightningserver/typed/testing.kt
@@ -1,6 +1,7 @@
 package com.lightningkite.lightningserver.typed
 
 import com.lightningkite.lightningserver.auth.Authentication
+import com.lightningkite.lightningserver.auth.assert
 import com.lightningkite.lightningserver.definition.generalSettings
 import com.lightningkite.lightningserver.http.*
 import com.lightningkite.lightningserver.pathing.*
@@ -98,6 +99,24 @@ import com.lightningkite.services.database.HasId
 //        with(it.server) { didConnect() }
 //    }
 //}
+/**
+ * Checks [presented] against this endpoint's own [auth] requirement, the way a real request does.
+ *
+ * These helpers used to hand the handler an [Access] built directly from whatever authentication the
+ * test supplied, which meant the endpoint's requirement was never consulted. Any test asserting "this
+ * caller is refused" therefore passed whether or not the endpoint required anything at all — it would
+ * have passed against an endpoint with no requirement, which is the opposite of what it read as.
+ *
+ * The real path does this inside [access]; going through the same check here is what makes an
+ * authorization test in a typed harness mean something. A rejected caller now gets the
+ * [com.lightningkite.lightningserver.ForbiddenException] the endpoint would really have produced.
+ */
+context(test: TestRunner<*>)
+private suspend fun <PATH : PathSpec, USER : HasId<*>?, INPUT, OUTPUT>
+    ApiHttpHandler<PATH, USER, INPUT, OUTPUT>.assertAuth(
+    presented: Authentication<*>?,
+): Authentication<USER & Any>? = with(test) { auth.assert(presented) }
+
 context(test: TestRunner<*>)
 public suspend fun <USER : HasId<*>, INPUT, OUTPUT> ApiHttpHandler<PathSpec0, USER, INPUT, OUTPUT>.test(
     auth: Authentication<USER>,
@@ -117,7 +136,7 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT> ApiHttpHandler<PathSpec0, US
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )
@@ -143,7 +162,7 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT, A> ApiHttpHandler<PathSpec1<
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )
@@ -170,7 +189,7 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT, A, B> ApiHttpHandler<PathSpe
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )
@@ -198,7 +217,7 @@ public suspend fun <USER : HasId<*>, INPUT, OUTPUT, A, B, C> ApiHttpHandler<Path
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )
@@ -223,7 +242,7 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT>
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )
@@ -249,7 +268,7 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT,
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )
@@ -276,7 +295,7 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT,
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )
@@ -304,7 +323,7 @@ context(test: TestRunner<*>) public suspend fun <USER : HasId<*>, INPUT, OUTPUT,
                     MediaType.Application.Json
                 ),
             ),
-            auth,
+            assertAuth(auth),
         ),
         input
     )

--- a/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/FunnelEndpointsTest.kt
+++ b/typed/src/test/kotlin/com/lightningkite/lightningserver/typed/FunnelEndpointsTest.kt
@@ -1,10 +1,12 @@
 // by Claude
 package com.lightningkite.lightningserver.typed
 
-import com.lightningkite.lightningserver.auth.AuthRequirement
+import com.lightningkite.lightningserver.ForbiddenException
+import com.lightningkite.lightningserver.auth.*
 import com.lightningkite.lightningserver.definition.GeneralServerSettings
 import com.lightningkite.lightningserver.definition.builder.ServerBuilder
 import com.lightningkite.lightningserver.definition.generalSettings
+import com.lightningkite.lightningserver.runtime.ServerRuntime
 import com.lightningkite.lightningserver.runtime.test.test
 import com.lightningkite.lightningserver.settings.set
 import com.lightningkite.services.data.HealthStatus
@@ -13,20 +15,58 @@ import com.lightningkite.services.database.*
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
 import kotlin.test.*
 import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.Uuid
 
 /**
  * Tests for FunnelEndpoints - user funnel tracking and analytics.
  */
 class FunnelEndpointsTest {
 
+    /** The admin these tests call [FunnelEndpoints.summaries] and [FunnelEndpoints.summarizeNow] as. */
+    @Serializable
+    data class AdminUser(override val _id: Uuid = Uuid.random()) : HasId<Uuid> {
+        companion object : PrincipalType<AdminUser, Uuid> {
+            override val idSerializer: KSerializer<Uuid> = Uuid.serializer()
+            override val subjectSerializer: KSerializer<AdminUser> = serializer()
+
+            context(server: ServerRuntime)
+            override suspend fun fetch(id: Uuid): AdminUser = AdminUser(id)
+        }
+    }
+
     object TestServer : ServerBuilder() {
         val database = setting("database", Database.Settings())
+
+        init {
+            register(AdminUser)
+            // IsAdmin is only a name until a server says what it means: left unconfigured it falls
+            // back to IsSuperUser, which has no default and so rejects everyone. Defining it here is
+            // what makes the reporting endpoints reachable at all - without it the only way these
+            // tests could pass would be by never having their auth checked.
+            AuthRequirement.isAdmin = AdminUser.require()
+        }
 
         // Use AuthRequirement.IsAdmin which has the correct type for FunnelEndpoints
         val funnel = path.path("funnel") include FunnelEndpoints(database, read = AuthRequirement.IsAdmin)
     }
+
+    /**
+     * An [AdminUser] authentication, in the static type the endpoints declare.
+     *
+     * [FunnelEndpoints] types its callers as `HasId<*>?` and [Authentication] is invariant, so a
+     * concrete `Authentication<AdminUser>` cannot be handed to `.test()` without widening. Nothing
+     * about the authentication changes; only its static type. Whether it satisfies
+     * [AuthRequirement.IsAdmin] is still decided by the endpoint.
+     */
+    @Suppress("UNCHECKED_CAST")
+    context(server: ServerRuntime)
+    private fun adminAuth(): Authentication<HasId<*>> =
+        AdminUser.testAuth(AdminUser()) as Authentication<HasId<*>>
 
     @Test
     fun start_creates_funnel_instance() = runBlocking {
@@ -155,6 +195,24 @@ class FunnelEndpointsTest {
         }
     }
 
+    /**
+     * The counterpart to the reporting tests below: the requirement is real, so a caller who cannot
+     * satisfy it is refused. Without this, dropping `read` from those endpoints entirely would leave
+     * every other test in this file green.
+     */
+    @Test
+    fun summarize_rejects_unauthenticated_callers() = runBlocking {
+        TestServer.test(settings = {
+            generalSettings set GeneralServerSettings()
+            database set Database.Settings()
+        }) {
+            assertFailsWith<ForbiddenException> {
+                TestServer.funnel.summarizeNow.test(null, LocalDate(2024, 5, 1))
+            }
+            Unit
+        }
+    }
+
     @Test
     fun summarize_creates_summary_from_instances() = runBlocking {
         TestServer.test(settings = {
@@ -228,7 +286,7 @@ class FunnelEndpointsTest {
             )
 
             // Run summarize for that date
-            TestServer.funnel.summarizeNow.test(null, targetDate)
+            TestServer.funnel.summarizeNow.test(adminAuth(), targetDate)
 
             // Verify summary was created
             val summaries =
@@ -297,7 +355,7 @@ class FunnelEndpointsTest {
             TestServer.funnel.summaryInfo.table().insertOne(summaryOtherDate)
 
             // Get summaries for target date
-            val result = TestServer.funnel.summaries.test(targetDate, null, Unit)
+            val result = TestServer.funnel.summaries.test(targetDate, adminAuth(), Unit)
 
             assertEquals(2, result.size)
             assertTrue(result.any { it.funnel == "funnel-a" })
@@ -351,7 +409,7 @@ class FunnelEndpointsTest {
                 )
             )
 
-            TestServer.funnel.summarizeNow.test(null, targetDate)
+            TestServer.funnel.summarizeNow.test(adminAuth(), targetDate)
 
             val summaries =
                 TestServer.funnel.summaryInfo.table().find(condition<FunnelSummary> { it.date.eq(targetDate) }).toList()
@@ -410,7 +468,7 @@ class FunnelEndpointsTest {
                 )
             }
 
-            TestServer.funnel.summarizeNow.test(null, targetDate)
+            TestServer.funnel.summarizeNow.test(adminAuth(), targetDate)
 
             val summaries =
                 TestServer.funnel.summaryInfo.table().find(condition<FunnelSummary> { it.date.eq(targetDate) }).toList()
@@ -469,7 +527,7 @@ class FunnelEndpointsTest {
                 )
             }
 
-            TestServer.funnel.summarizeNow.test(null, targetDate)
+            TestServer.funnel.summarizeNow.test(adminAuth(), targetDate)
 
             val summaries =
                 TestServer.funnel.summaryInfo.table().find(condition<FunnelSummary> { it.date.eq(targetDate) }).toList()
@@ -522,7 +580,7 @@ class FunnelEndpointsTest {
             }
 
             // Run summarize - should replace the existing summary
-            TestServer.funnel.summarizeNow.test(null, targetDate)
+            TestServer.funnel.summarizeNow.test(adminAuth(), targetDate)
 
             val summaries =
                 TestServer.funnel.summaryInfo.table().find(condition<FunnelSummary> { it.date.eq(targetDate) }).toList()


### PR DESCRIPTION
**Stack: 9 of 16.** Based on `split/e8` — review that one first.
`ApiHttpHandler.test(...)` invoked the handler body directly and never
evaluated the endpoint's `AuthRequirement`. Every authorization test written
through it was therefore vacuous: it passed whether or not the endpoint
admitted the caller.

Routing all eight overloads through `auth.assert(presented)` immediately
exposed six tests driving an endpoint that in fact rejects everyone.

Why it survived: `Authentication<SUBJECT>` is invariant, so writing the
correct check requires an unchecked widening cast for `HasId<*>?`-typed
endpoints. The vacuous version was simply easier to write than the real one.

Also renames three tests that claimed a different mechanism than the one they
exercise, and pins one of them. `tokenSimple rejects ...` asserts
`ForbiddenException` — which is also what an `AuthRequirement` throws, so
giving `tokenSimple` a requirement would have kept the test green while it
silently proved something else. The added assertion that the endpoint still
requires no authentication is what catches that.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd