### PR TITLE
Audit foundations: what is audited, and who asked

### DIFF
--- a/audit-shared/build.gradle.kts
+++ b/audit-shared/build.gradle.kts
@@ -1,0 +1,95 @@
+import com.lightningkite.deployhelpers.lkLibrary
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.dokka)
+    id("signing")
+    alias(libs.plugins.vanniktechMavenPublish)
+}
+
+kotlin {
+    explicitApi()
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+        optIn.add("kotlin.uuid.ExperimentalUuidApi")
+    }
+
+    applyDefaultHierarchyTemplate()
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
+
+    jvm {
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget = JvmTarget.JVM_1_8
+                }
+            }
+        }
+    }
+    js(IR) {
+        browser()
+    }
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosArm64()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(libs.kotlinx.serialization.json)
+                api(libs.services.database.shared)
+            }
+            kotlin {
+                srcDir(file("build/generated/ksp/common/commonMain/kotlin"))
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+            }
+            kotlin {
+                srcDir(file("build/generated/ksp/common/commonTest/kotlin"))
+            }
+        }
+    }
+}
+
+dependencies {
+    configurations.filter { it.name.startsWith("ksp") && it.name != "ksp" }.forEach {
+        add(it.name, libs.services.database.processor)
+    }
+}
+
+android {
+    namespace = "com.lightningkite.lightningserver"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 21
+    }
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    dependencies {
+        coreLibraryDesugaring(libs.androidDesugaring)
+    }
+}
+
+lkLibrary(
+    "lightningkite",
+    "lightning-server",
+    mavenAutomaticRelease = project.findProperty("mavenAutomaticRelease") as? Boolean ?: false
+) {
+    description.set("Markers and record shapes for the disclosure audit log, shared between server and client.")
+}

--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/Audited.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/Audited.kt
@@ -1,0 +1,48 @@
+package com.lightningkite.lightningserver.audit
+
+import kotlinx.serialization.SerialInfo
+
+/**
+ * Marks disclosure auditing, meaning one thing on a class and a narrower thing on a property.
+ *
+ * **On a class:** every instance that reaches a client — as a response body, inside a list, inside a
+ * `Partial`, nested in a wrapper, or pushed over a WebSocket — produces its own [DisclosureRecord]
+ * naming the record's id. This is what makes a model audited at all.
+ *
+ * **On a property:** that field is *itemised*. A bit is reserved for it, and each disclosure records
+ * whether the field carried a value in the payload the client received. Answers "which requests
+ * disclosed an SSN?" as opposed to merely "who saw this record?".
+ *
+ * ## Itemising is opt-in, and disclosure is not
+ *
+ * A record is logged whenever an audited model reaches a client, annotated fields or none. Marking
+ * properties adds resolution; it never decides whether a disclosure is recorded. So a model with no
+ * annotated properties still answers "who saw this record, under which request" completely — it just
+ * cannot answer "was the SSN among what they saw".
+ *
+ * That is why itemising is opt-in. Most fields of a real model are inconsequential to an audit, and
+ * reserving bits for `sortOrder` and `createdAt` costs permanent capacity (indices are never reused —
+ * see `AuditFieldRegistration`) while diluting the log with noise that makes the interesting query
+ * harder to write and harder to trust.
+ *
+ * An annotated property is picked up anywhere in the graph, including inside nested types that are
+ * not themselves audited — `@Audited val street: String` inside an `Address` becomes `address.street`
+ * on the record that holds it.
+ *
+ * ## The model must be keyed by `Uuid`
+ *
+ * One disclosure row is written per record disclosed, which makes the identifier the most-written
+ * column in the system. A `Uuid` is sixteen bytes in every backend; a string key is larger and
+ * indexed poorly. Marking a class whose `_id` is absent or is not a `Uuid` fails at deploy.
+ *
+ * ## Why `@SerialInfo`
+ *
+ * A plain Kotlin annotation is invisible to a `SerialDescriptor`. Disclosure detection walks
+ * descriptors rather than reflecting, so that it sees precisely what the serializer will emit and
+ * behaves identically on every target. `@SerialInfo` is what puts the marker where that walk can
+ * find it, which also means this only has an effect on `@Serializable` classes.
+ */
+@SerialInfo
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+public annotation class Audited

--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/DisclosureRecord.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/DisclosureRecord.kt
@@ -1,0 +1,112 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.data.GenerateDataClassPaths
+import com.lightningkite.services.data.Index
+import com.lightningkite.services.data.IndexSet
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.HasId
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * One record disclosed to one client, and exactly which of its fields carried a value.
+ *
+ * ## One row per record, deliberately
+ *
+ * An earlier design grouped records that shared a disclosed-field set into a single row with a list
+ * of ids, which collapsed a ten-thousand-row query into one or two rows. That was rejected: this is
+ * an audit log, and "most of these records were disclosed the same way" is not a thing an audit log
+ * gets to say. Every disclosure is its own row.
+ *
+ * The cost is paid down in the row itself rather than by grouping:
+ *
+ * - Request-constant data — who asked, from where, when, through which endpoint — lives once in the
+ *   access log and is referenced here by [requestId] alone. It is never repeated per row.
+ * - The field set is two `Int`s rather than more, because itemising fields is opt-in — see
+ *   [FieldBits.CAPACITY].
+ * - [recordId] is a `Uuid`, which every backend stores as sixteen bytes. This is why [Audited] is
+ *   restricted to models keyed by `Uuid`: a stringly-typed identifier column is both larger and, in
+ *   most engines, stored and indexed poorly.
+ * - There is no parent request id. A sub-request's parentage is recorded once in the request log,
+ *   so repeating it on every disclosure would be storing a join key twice.
+ *
+ * @property requestId Correlates to the access log entry holding who asked, from where, and when —
+ *   including, for a multiplexed sub-request, which request carried it.
+ * @property modelId The audited model's permanent id, from [AuditModelRegistration].
+ * @property recordId The `_id` of the disclosed record. Recorded here rather than as a field bit,
+ *   so an audited model never spends one of its bits restating its own identity.
+ */
+// Table-qualified because an explicit index name is passed through to the backend verbatim, and in
+// Postgres relation names are per-schema rather than per-table. "byRecord" is a generic enough name
+// that another model declaring it would have failed the deploy with an error naming neither table.
+// Every other IndexSet in this repository omits the name and gets a generated, table-qualified one.
+@IndexSet(fields = ["modelId", "recordId"], name = "DisclosureRecord_byRecord")
+@GenerateDataClassPaths
+@Serializable
+public data class DisclosureRecord(
+    override val _id: Uuid,
+    @Index val requestId: Uuid,
+    val modelId: Int,
+    /** Bits 0..31 of the disclosed-field set. See [FieldBits]. */
+    val fields0: Int = 0,
+    /** Bits 32..63 of the disclosed-field set. */
+    val fields1: Int = 0,
+    val recordId: Uuid,
+) : HasId<Uuid> {
+    public val fields: FieldBits get() = FieldBits.ofColumns(fields0, fields1)
+
+    /**
+     * The instant this disclosure was recorded, derived from the version-7 [_id].
+     *
+     * Kept in the id for the same reason [RequestRecord] does it — no column, no second index, and a
+     * row whose "when" cannot drift from its own key. It matters more here: [requestId] points at a
+     * socket's row rather than at the phase that disclosed (see `audit-logging.md` 5.8.2), so
+     * without this a disclosure on a long-lived connection could only be placed "sometime during
+     * this session".
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    public val at: Instant
+        get() = Instant.fromEpochMilliseconds(_id.epochMilliseconds)
+
+    public companion object
+}
+
+/**
+ * Disclosures whose field set contains **every** one of [indices] — "which requests disclosed both
+ * the SSN and the date of birth?".
+ *
+ * With no indices this is [Condition.Always], since every set vacuously contains none of them.
+ */
+public fun disclosedAll(indices: Iterable<Int>): Condition<DisclosureRecord> =
+    columnConditions(indices) { Condition.IntBitsSet(it) }
+        .let { if (it.isEmpty()) Condition.Always else Condition.And(it) }
+
+/**
+ * Disclosures whose field set contains **at least one** of [indices] — "which requests disclosed
+ * anything sensitive?".
+ *
+ * With no indices this is [Condition.Never].
+ */
+public fun disclosedAny(indices: Iterable<Int>): Condition<DisclosureRecord> =
+    columnConditions(indices) { Condition.IntBitsAnySet(it) }
+        .let { if (it.isEmpty()) Condition.Never else Condition.Or(it) }
+
+/**
+ * One condition per column that [indices] actually touches.
+ *
+ * The columns are independent `Condition<Int>`s, so a query spanning several of them is a
+ * combination of per-column conditions rather than a single one.
+ */
+private inline fun columnConditions(
+    indices: Iterable<Int>,
+    columnCondition: (mask: Int) -> Condition<Int>,
+): List<Condition<DisclosureRecord>> {
+    val bits = FieldBits.of(indices)
+    return (0 until FieldBits.COLUMNS)
+        .filter { bits.column(it) != 0 }
+        .map { Condition.OnField(disclosureFieldColumns[it], columnCondition(bits.column(it))) }
+}
+
+private val disclosureFieldColumns = listOf(DisclosureRecord_fields0, DisclosureRecord_fields1)

--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/FieldBits.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/FieldBits.kt
@@ -1,0 +1,79 @@
+package com.lightningkite.lightningserver.audit
+
+/**
+ * A set of field bit indices, laid out across two `Int`s.
+ *
+ * ## Why `Int` columns rather than a `Long` or a `ByteArray`
+ *
+ * `Int` is the only type the framework can query bitwise: the entire bitwise condition surface is
+ * `Condition<Int>` (`IntBitsSet`, `IntBitsClear`, `IntBitsAnySet`, `IntBitsAnyClear`). A `Long` or
+ * `ByteArray` bitfield would be storable but not queryable, so "which requests disclosed the SSN
+ * field?" would mean a full scan and client-side filtering — unusable at audit-table volume.
+ *
+ * Bit index `i` lives in column `i / 32` at bit `i % 32`.
+ */
+public class FieldBits private constructor(
+    public val fields0: Int,
+    public val fields1: Int,
+) {
+    /** This set plus the field at [index]. */
+    public operator fun plus(index: Int): FieldBits {
+        require(index in 0 until CAPACITY) { "Bit index $index is outside the 0..${CAPACITY - 1} range." }
+        val bit = 1 shl (index % 32)
+        return if (index < 32) FieldBits(fields0 or bit, fields1) else FieldBits(fields0, fields1 or bit)
+    }
+
+    /** Union of two sets. */
+    public operator fun plus(other: FieldBits): FieldBits =
+        FieldBits(fields0 or other.fields0, fields1 or other.fields1)
+
+    public operator fun contains(index: Int): Boolean {
+        require(index in 0 until CAPACITY) { "Bit index $index is outside the 0..${CAPACITY - 1} range." }
+        return column(index / 32) and (1 shl (index % 32)) != 0
+    }
+
+    /** The indices in this set, ascending. */
+    public fun indices(): List<Int> = buildList {
+        for (column in 0 until COLUMNS) {
+            val bits = column(column)
+            if (bits == 0) continue
+            for (bit in 0 until 32) if (bits and (1 shl bit) != 0) add(column * 32 + bit)
+        }
+    }
+
+    public fun column(index: Int): Int = when (index) {
+        0 -> fields0
+        1 -> fields1
+        else -> throw IndexOutOfBoundsException("Column $index does not exist; there are $COLUMNS.")
+    }
+
+    public val isEmpty: Boolean get() = fields0 == 0 && fields1 == 0
+
+    override fun equals(other: Any?): Boolean =
+        other is FieldBits && fields0 == other.fields0 && fields1 == other.fields1
+
+    override fun hashCode(): Int = fields0 * 31 + fields1
+
+    override fun toString(): String = "FieldBits${indices()}"
+
+    public companion object {
+        public const val COLUMNS: Int = 2
+
+        /**
+         * The number of distinct fields one audited model may itemise, ever.
+         *
+         * Two columns rather than more because itemising is opt-in ([Audited]), so a model reserves
+         * bits for the handful of fields that matter to an audit rather than for all of them. Adding
+         * a `fields2` column later is a benign migration — it defaults to `0`, which reads correctly
+         * for every historical row, since an absent bit means not disclosed — so buying headroom up
+         * front would cost eight bytes on every row of the highest-volume table for nothing.
+         */
+        public const val CAPACITY: Int = COLUMNS * 32
+
+        public val EMPTY: FieldBits = FieldBits(0, 0)
+
+        public fun of(indices: Iterable<Int>): FieldBits = indices.fold(EMPTY, FieldBits::plus)
+
+        internal fun ofColumns(fields0: Int, fields1: Int): FieldBits = FieldBits(fields0, fields1)
+    }
+}

--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/RequestRecord.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/RequestRecord.kt
@@ -1,0 +1,75 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.data.GenerateDataClassPaths
+import com.lightningkite.services.data.Index
+import com.lightningkite.services.database.HasId
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * What a [DisclosureRecord.requestId] points at: who asked, from where, when, and how it went.
+ *
+ * Disclosure records repeat none of this — they carry a request id and nothing else about the
+ * request — so without this table those references dangle. It is the reason the audit package owns a
+ * request log at all rather than leaning on
+ * [com.lightningkite.lightningserver.auth.AccessLogInterceptor], which writes log lines and is
+ * deliberately fail-open: "the access log must never be the reason a request fails" is the opposite
+ * of what a fail-closed log needs from the thing it references.
+ *
+ * ## When is embedded in the id, not stored
+ * There is no `at` column. The execution id is a version-7 UUID minted at the instant an execution
+ * began (see [com.lightningkite.lightningserver.http.generateRequestId]), so the mint time is in the
+ * id itself and [at] is derived from it. Keeping the instant out of the row means the id's
+ * time-ordering (its reason for being v7) and the row's timestamp can never disagree, and time-window
+ * queries range over the primary key rather than an indexed copy of the same instant. The single
+ * thing this trades away is sub-millisecond precision: v7 encodes whole milliseconds, the instant
+ * that once lived here could have carried nanoseconds, and a lost request will now name the
+ * millisecond it began in rather than its exact tick.
+ *
+ * @property _id The execution id itself. Using it as the primary key means no second column and no
+ *   second index, and it makes a duplicate id a primary-key violation rather than a silent merge of
+ *   two principals' activity under one identifier.
+ * @property rootExecutionId The execution at the head of this row's causal chain, equal to [_id] when
+ *   [parentRequestId] is null. Carried as well as the parent so that "everything that happened
+ *   because of request X" is one indexed lookup rather than a recursive walk of parent pointers —
+ *   which is the query this table exists to answer.
+ * @property endpoint The matched route pattern rather than the literal target. The literal target
+ *   carries record ids, which would duplicate — and spread — data the disclosure log already records
+ *   precisely, and would give this column unbounded cardinality.
+ * @property outcome Status code, or a WebSocket close reason. Null until the request completes.
+ * @property durationMs Null until the request completes.
+ * @property principal The resolved subject, or null when anonymous or unresolvable. [outcome]
+ *   distinguishes the two.
+ * @property engineRequestId The identifier the gateway or proxy in front of us minted for this
+ *   request — API Gateway's `requestContext.requestId`, or a connection id for a socket. It is the
+ *   join key back to that gateway's own access log, and it is trusted because the engine handed it
+ *   to us rather than the caller. Deliberately a separate column from [upstreamRequestId]: one is a
+ *   fact from our own infrastructure, the other is an unverified claim by whoever called us, and
+ *   conflating them would let a caller forge a value that reads as infrastructure-supplied.
+ * @property upstreamRequestId Whatever identifier the caller claimed, kept for diagnostics only.
+ *   Never trusted, never used to correlate.
+ */
+@GenerateDataClassPaths
+@Serializable
+public data class RequestRecord(
+    override val _id: Uuid,
+    @Index val parentRequestId: Uuid? = null,
+    @Index val rootExecutionId: Uuid,
+    @Index val principal: String? = null,
+    val sourceIp: String,
+    val endpoint: String,
+    val method: String,
+    val outcome: String? = null,
+    val durationMs: Long? = null,
+    val engineRequestId: String? = null,
+    val upstreamRequestId: String? = null,
+) : HasId<Uuid> {
+    /** The instant this execution began, derived from the version-7 [_id]'s embedded timestamp. */
+    @OptIn(ExperimentalUuidApi::class)
+    public val at: Instant
+        get() = Instant.fromEpochMilliseconds(_id.epochMilliseconds)
+
+    public companion object
+}

--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/uuidTimestamp.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/uuidTimestamp.kt
@@ -1,0 +1,22 @@
+package com.lightningkite.lightningserver.audit
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * The epoch-millisecond timestamp a version-7 UUID embeds, or 0 for any other version.
+ *
+ * V7 lays the 48-bit millisecond timestamp into the top bits of the most-significant word, so a
+ * right-shift by 16 recovers it. Any other version (an adopted proxy id, a legacy v4) stores no
+ * timestamp there, so reading the bits blindly would report a plausible-looking but meaningless
+ * instant; we check the version nibble first and return 0 instead, which the audit records render as
+ * the epoch — candid about "unknown" rather than wrong.
+ *
+ * Shared by every audit row that derives its own "when" from its primary key rather than storing a
+ * separate column.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal val Uuid.epochMilliseconds: Long
+    get() = toULongs { mostSignificantBits, _ ->
+        if (((mostSignificantBits shr 12) and 0xFUL) != 0x7UL) 0L else (mostSignificantBits shr 16).toLong()
+    }

--- a/audit-shared/src/commonTest/kotlin/com/lightningkite/lightningserver/audit/FieldBitsTest.kt
+++ b/audit-shared/src/commonTest/kotlin/com/lightningkite/lightningserver/audit/FieldBitsTest.kt
@@ -1,0 +1,129 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.database.Condition
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class FieldBitsTest {
+
+    @Test
+    fun `a bit index lands in the column and position the layout promises`() {
+        for (index in 0 until FieldBits.CAPACITY) {
+            val bits = FieldBits.EMPTY + index
+            assertEquals(1 shl (index % 32), bits.column(index / 32), "index $index landed wrong")
+            for (other in 0 until FieldBits.COLUMNS) {
+                if (other != index / 32) assertEquals(0, bits.column(other), "index $index leaked into column $other")
+            }
+        }
+    }
+
+    @Test
+    fun `every index round-trips through the whole capacity`() {
+        val all = (0 until FieldBits.CAPACITY).toList()
+        assertEquals(all, FieldBits.of(all).indices())
+    }
+
+    @Test
+    fun `contains reports exactly the indices that were added`() {
+        val bits = FieldBits.of(listOf(0, 31, 32, 63))
+        listOf(0, 31, 32, 63).forEach { assertTrue(it in bits, "$it should be present") }
+        listOf(1, 30, 33, 62).forEach { assertFalse(it in bits, "$it should be absent") }
+    }
+
+    @Test
+    fun `union merges every column`() {
+        val merged = FieldBits.of(listOf(1, 40)) + FieldBits.of(listOf(7, 60))
+        assertEquals(listOf(1, 7, 40, 60), merged.indices())
+    }
+
+    @Test
+    fun `an index outside the capacity is rejected rather than silently wrapping`() {
+        assertFailsWith<IllegalArgumentException> { FieldBits.EMPTY + FieldBits.CAPACITY }
+        assertFailsWith<IllegalArgumentException> { FieldBits.EMPTY + -1 }
+    }
+
+    private fun record(vararg indices: Int): DisclosureRecord {
+        val bits = FieldBits.of(indices.toList())
+        return DisclosureRecord(
+            _id = Uuid.NIL,
+            requestId = Uuid.NIL,
+            modelId = 0,
+            fields0 = bits.fields0,
+            fields1 = bits.fields1,
+            recordId = Uuid.NIL,
+        )
+    }
+
+    /**
+     * Asserted against the in-memory evaluator rather than by comparing condition trees, so the test
+     * pins what the query *means* rather than how it happens to be built.
+     */
+    @Test
+    fun `disclosedAll matches only records holding every requested field`() {
+        val condition: Condition<DisclosureRecord> = disclosedAll(listOf(3, 40))
+
+        assertTrue(condition(record(3, 40)))
+        assertTrue(condition(record(3, 40, 50)), "extra disclosed fields must not exclude a record")
+        assertFalse(condition(record(3)))
+        assertFalse(condition(record(40)))
+        assertFalse(condition(record()))
+    }
+
+    @Test
+    fun `disclosedAny matches a record holding any one of the requested fields`() {
+        val condition: Condition<DisclosureRecord> = disclosedAny(listOf(3, 40))
+
+        assertTrue(condition(record(3)))
+        assertTrue(condition(record(40)))
+        assertTrue(condition(record(3, 40)))
+        assertFalse(condition(record(4, 41)))
+        assertFalse(condition(record()))
+    }
+
+    /** A field past the first column is the case a single-Int layout would silently drop. */
+    @Test
+    fun `queries reach fields in the second column`() {
+        assertTrue(disclosedAny(listOf(40))(record(40)))
+        assertTrue(disclosedAll(listOf(40, 50))(record(40, 50)))
+        assertFalse(disclosedAll(listOf(40, 50))(record(40)))
+    }
+
+    /**
+     * The top bit of each column is asserted on the condition that gets built rather than on what
+     * evaluating it returns.
+     *
+     * Bit 31 of a column makes the mask a negative Int, and whether a query engine handles that
+     * correctly is the database layer's contract, not this module's. What is this module's job is
+     * putting the bit in the right column with the right mask, which is what these check.
+     */
+    @Test
+    fun `the top bit of a column produces the mask and column the layout promises`() {
+        assertEquals(
+            Condition.OnField(DisclosureRecord_fields1, Condition.IntBitsAnySet(1 shl 31)),
+            (disclosedAny(listOf(63)) as Condition.Or).conditions.single(),
+        )
+        assertEquals(
+            Condition.OnField(DisclosureRecord_fields0, Condition.IntBitsSet(1 shl 31)),
+            (disclosedAll(listOf(31)) as Condition.And).conditions.single(),
+        )
+    }
+
+    @Test
+    fun `a query spanning columns produces one condition per column touched`() {
+        val any = disclosedAny(listOf(1, 33)) as Condition.Or
+        assertEquals(2, any.conditions.size, "expected one condition per column; was $any")
+
+        val all = disclosedAll(listOf(1, 2)) as Condition.And
+        assertEquals(1, all.conditions.size, "same-column indices belong in one mask; was $all")
+    }
+
+    @Test
+    fun `an empty query is the identity of its operator`() {
+        assertEquals(Condition.Always, disclosedAll(emptyList()))
+        assertEquals(Condition.Never, disclosedAny(emptyList()))
+    }
+}

--- a/audit/build.gradle.kts
+++ b/audit/build.gradle.kts
@@ -1,0 +1,46 @@
+import com.lightningkite.deployhelpers.lkLibrary
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.dokka)
+    id("signing")
+    alias(libs.plugins.vanniktechMavenPublish)
+    alias(libs.plugins.kover)
+}
+
+dependencies {
+    api(project(":core"))
+    api(project(":typed"))
+    api(project(":audit-shared"))
+    api(libs.services.database)
+
+    ksp(libs.services.database.processor)
+    kspTest(libs.services.database.processor)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit)
+}
+
+kotlin {
+    explicitApi()
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+        optIn.add("kotlin.uuid.ExperimentalUuidApi")
+    }
+    sourceSets.main {
+        kotlin.srcDir("build/generated/ksp/main/kotlin")
+    }
+    sourceSets.test {
+        kotlin.srcDir("build/generated/ksp/test/kotlin")
+    }
+}
+
+lkLibrary(
+    "lightningkite",
+    "lightning-server",
+    mavenAutomaticRelease = project.findProperty("mavenAutomaticRelease") as? Boolean ?: false
+) {
+    description.set("Audit logging for Lightning Server: what was asked, seen, and changed.")
+}

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditCore.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditCore.kt
@@ -1,0 +1,136 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.definition.PreDeployTask
+import com.lightningkite.lightningserver.definition.Runtime
+import com.lightningkite.lightningserver.definition.RuntimeDeferred
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.typed.ApiHttpHandler
+import com.lightningkite.lightningserver.typed.ApiWebSocketHandler
+import com.lightningkite.lightningserver.typed.DatabaseTableRegistration
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.services.database.Database
+import kotlinx.serialization.descriptors.SerialDescriptor
+
+/**
+ * The foundation the other audit layers join to: who asked, from where, and when.
+ *
+ * Include this, then whichever layers a deployment actually wants:
+ *
+ * ```kotlin
+ * object Server : ServerBuilder() {
+ *     val database = setting("database", DatabaseSettings())
+ *
+ *     val audit = path.path("audit") include AuditCore(database)
+ *     val disclosures = path.path("audit-disclosure") include DisclosureLog(audit)
+ *     val authEvents = path.path("audit-auth") include AuthEventLog(audit)
+ * }
+ * ```
+ *
+ * Every other layer's records carry a `requestId` that points at a [RequestRecord] here, so this is
+ * the one piece that is not optional once anything else is included.
+ *
+ * ## Why auditing is a switch and not a default
+ *
+ * Nothing audits until a layer is included, and [Audited] on a model does nothing on its own. The
+ * circumvention this design guards against is an *endpoint* built without auditing, not a deployment
+ * that chose not to audit — and once a layer is included, no endpoint escapes it. A per-deployment
+ * switch is a decision made once, in the open; a per-endpoint one would be made a hundred times,
+ * silently.
+ *
+ * ## Failure behaviour
+ *
+ * The opening write is fail-closed: a request whose record cannot be written does not proceed. The
+ * completion write, which fills in outcome and duration, cannot be — the response has already been
+ * produced by then, so there is nothing left to prevent. Each layer documents its own behaviour; see
+ * `plans/audit-logging.md` 5.6.
+ *
+ * @property requests Who asked, from where, and when. What every other layer's `requestId` refers to.
+ * @property registry What every model id and every bit permanently mean. Needed to read a disclosure:
+ *   a [DisclosureRecord]'s bits are meaningless without it.
+ */
+public class AuditCore(
+    internal val database: Runtime<Database>,
+) : ServerBuilder() {
+    public val requests: DatabaseTableRegistration<RequestRecord> =
+        database.registerTable("AuditRequest", RequestRecord.serializer())
+
+    private val registrations: DatabaseTableRegistration<AuditModelRegistration> =
+        database.registerTable("AuditModelRegistration", AuditModelRegistration.serializer())
+
+    private val fieldRegistrations: DatabaseTableRegistration<AuditFieldRegistration> =
+        database.registerTable("AuditFieldRegistration", AuditFieldRegistration.serializer())
+
+    /**
+     * Assigns permanent ids and bit indices to anything audited that lacks them.
+     *
+     * A pre-deploy task rather than a startup task, so assignment happens once per deploy and
+     * instances never race to allocate the same index. It is convergent, so re-running it on every
+     * deploy — which is what the framework does — is a no-op.
+     */
+    private val assignBits: PreDeployTask = path.path("assign-audit-bits") bind PreDeployTask(
+        dependencies = { listOf(registrations.preDeployTask, fieldRegistrations.preDeployTask) },
+    ) {
+        reconcileAuditRegistry(registrations(), fieldRegistrations(), auditedModelsOnServer())
+    }
+
+    /**
+     * Loaded from the tables on first use and cached for the life of the process, which is correct
+     * because assignments only ever change during a deploy.
+     */
+    public val registry: RuntimeDeferred<AuditRegistry> =
+        RuntimeDeferred.Cached(RuntimeDeferred { loadAuditRegistry(registrations(), fieldRegistrations()) })
+
+    private val claimedLayers = mutableSetOf<String>()
+
+    /**
+     * Registers a layer against this core, refusing a second attachment of the same one.
+     *
+     * Attaching a layer twice installs its writer twice, and every writer here appends to the
+     * builder's interceptor list without deduplication — so the result is silently *two rows per
+     * event*, with no error and no warning. A doubled audit log is worse than a missing one: it reads
+     * as evidence of activity that did not happen.
+     *
+     * Reachable through ordinary public API: a deployment that includes a layer twice over the same
+     * core, or includes one from a helper of its own and again by hand, attaches twice.
+     */
+    internal fun claim(layer: String) {
+        if (!claimedLayers.add(layer)) throw IllegalStateException(
+            "$layer is already attached to this AuditCore. Attaching a layer twice installs its " +
+                "writer twice and silently doubles every row it produces. Include each layer once."
+        )
+    }
+
+    init {
+        install(RequestRecordInterceptor(requests))
+    }
+}
+
+/**
+ * Every audited model this server can disclose, found by walking the serializers its endpoints
+ * declare.
+ *
+ * **Endpoints only, deliberately.** An earlier version also scanned the registered tables, which
+ * picked up a few models that reach clients through a serializer too dynamic to resolve statically —
+ * but only when the model happened to be a table. Inconsistent coverage is worse than none here: it
+ * hides the gap instead of failing on it. A model no endpoint's serializer reaches gets no bits, and
+ * disclosing it fails the request — see [AuditRegistry.modelId].
+ *
+ * Auditing keys off serializers throughout, never tables. A disclosure is observed with a serializer
+ * in hand and nothing else, so the serializer is the only thing that can be detected consistently.
+ */
+context(server: ServerRuntime)
+internal fun auditedModelsOnServer(): Map<String, SerialDescriptor> = buildMap {
+    for (endpoints in server.server.endpoints.values) {
+        for (handler in endpoints.http.values) {
+            if (handler !is ApiHttpHandler<*, *, *, *>) continue
+            putAll(handler.inputType.descriptor.auditedModels())
+            putAll(handler.outputType.descriptor.auditedModels())
+        }
+        val socket = endpoints.webSocket
+        if (socket is ApiWebSocketHandler<*, *, *, *, *>) {
+            putAll(socket.inputType.descriptor.auditedModels())
+            putAll(socket.outputType.descriptor.auditedModels())
+        }
+    }
+}

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditRegistry.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditRegistry.kt
@@ -1,0 +1,205 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.data.GenerateDataClassPaths
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.HasId
+import com.lightningkite.services.database.Table
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.toList
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlin.uuid.Uuid
+
+private val logger = KotlinLogging.logger("com.lightningkite.lightningserver.audit.AuditRegistry")
+
+/**
+ * The permanent meaning of one model id.
+ *
+ * Never deleted. A model that stops being served keeps its id so that historical
+ * [DisclosureRecord]s stay interpretable.
+ *
+ * @property _id The model's serial name. Serial names are used rather than table names because a
+ *   disclosure is observed with a serializer in hand and nothing else — the table a value came from
+ *   is not knowable at that point, and an audited model need not be a table at all.
+ */
+@GenerateDataClassPaths
+@Serializable
+public data class AuditModelRegistration(
+    override val _id: String,
+    val modelId: Int,
+) : HasId<String>
+
+/**
+ * The permanent meaning of one bit.
+ *
+ * Never deleted, and never reassigned. A field that is renamed or removed simply stops being
+ * written; its row remains, so old records keep resolving to the field they actually disclosed. A
+ * rename therefore allocates a fresh bit, and the two bits are both correct — the old one for
+ * records written before the rename, the new one for records written after.
+ *
+ * @property fieldPath Dotted path from the audited model's root — `ssn`, `address.street`,
+ *   `phones[].number`. See [auditFieldPaths].
+ */
+@GenerateDataClassPaths
+@Serializable
+public data class AuditFieldRegistration(
+    override val _id: String,
+    val modelId: Int,
+    val fieldPath: String,
+    val bitIndex: Int,
+) : HasId<String>
+
+/**
+ * The bit assignments in force for this process, loaded once from the registry tables.
+ *
+ * Assignments only ever grow, and only during a deploy, so a snapshot taken at first use stays
+ * correct for the life of the process.
+ */
+public class AuditRegistry internal constructor(
+    private val modelIds: Map<String, Int>,
+    private val bitIndices: Map<Int, Map<String, Int>>,
+) {
+
+    /**
+     * The permanent id of an audited model.
+     *
+     * Throws when the model was never registered, which fails the request that disclosed it. That is
+     * deliberate: a disclosure that cannot be recorded must not happen. It means a model reached a
+     * client through a path the deploy-time scan could not see — an open-polymorphic or contextual
+     * serializer — and the fix is to make that model reachable from a registered table or endpoint.
+     */
+    public fun modelId(serialName: String): Int = modelIds[serialName] ?: throw IllegalStateException(
+        // An empty registry is a different failure with a different fix, and saying so saves an hour:
+        // it means bit assignment never ran, which normally means AuditCore was constructed but never
+        // included in the server, so its pre-deploy task was never registered. The message below
+        // would send the reader hunting a polymorphic serializer that is not the problem.
+        if (modelIds.isEmpty()) "The audit registry is empty, so \"$serialName\" — and every other " +
+            "audited model — has no entry. Bit assignment never ran. Check that AuditCore is " +
+            "included in the server definition, not merely constructed, and that pre-deploy tasks " +
+            "run before serving."
+        else
+        "Audited model \"$serialName\" has no registry entry, so its disclosure cannot be recorded. " +
+            "It reached a client through a serializer the deploy-time scan could not resolve statically."
+    )
+
+    internal fun bitIndexOrNull(modelId: Int, fieldPath: String): Int? = bitIndices[modelId]?.get(fieldPath)
+
+    public fun bitIndex(modelId: Int, fieldPath: String): Int =
+        bitIndexOrNull(modelId, fieldPath) ?: throw IllegalStateException(
+            "Field \"$fieldPath\" of model $modelId has no registered bit index."
+        )
+
+    /** Every registered field of a model, as path to bit index. */
+    public fun fields(modelId: Int): Map<String, Int> = bitIndices[modelId].orEmpty()
+}
+
+/** Reads the current assignments out of the registry tables. */
+internal suspend fun loadAuditRegistry(
+    models: Table<AuditModelRegistration>,
+    fields: Table<AuditFieldRegistration>,
+): AuditRegistry = AuditRegistry(
+    modelIds = models.find(Condition.Always).toList().associate { it._id to it.modelId },
+    bitIndices = fields.find(Condition.Always).toList()
+        .groupBy { it.modelId }
+        .mapValues { (_, rows) -> rows.associate { it.fieldPath to it.bitIndex } },
+)
+
+/**
+ * Assigns permanent ids and bit indices to anything audited that does not have them yet.
+ *
+ * Append-only and convergent: existing assignments are never changed, so this is safe to re-run on
+ * every deploy, which is exactly how pre-deploy tasks behave.
+ *
+ * @param audited Every audited model found on the server, as serial name to descriptor.
+ */
+internal suspend fun reconcileAuditRegistry(
+    models: Table<AuditModelRegistration>,
+    fields: Table<AuditFieldRegistration>,
+    audited: Map<String, SerialDescriptor>,
+) {
+    audited.forEach { (serialName, descriptor) -> descriptor.requireUuidKeyed(serialName) }
+
+    val existingModels = models.find(Condition.Always).toList()
+    val modelIds = existingModels.associate { it._id to it.modelId }.toMutableMap()
+    var nextModelId = (existingModels.maxOfOrNull { it.modelId } ?: -1) + 1
+
+    val newModels = audited.keys.filter { it !in modelIds }.map { serialName ->
+        AuditModelRegistration(_id = serialName, modelId = nextModelId++)
+            .also { modelIds[serialName] = it.modelId }
+    }
+    if (newModels.isNotEmpty()) models.insert(newModels)
+
+    val existingFields = fields.find(Condition.Always).toList().groupBy { it.modelId }
+    val newFields = audited.flatMap { (serialName, descriptor) ->
+        val modelId = modelIds.getValue(serialName)
+        val assigned = existingFields[modelId].orEmpty()
+        val byPath = assigned.associate { it.fieldPath to it.bitIndex }
+        var nextBit = (assigned.maxOfOrNull { it.bitIndex } ?: -1) + 1
+
+        descriptor.auditFieldPaths().filter { it !in byPath }.map { path ->
+            if (nextBit >= FieldBits.CAPACITY) throw IllegalStateException(
+                "Audited model \"$serialName\" has run out of field bits at \"$path\": " +
+                    "${assigned.size} of ${FieldBits.CAPACITY} are already assigned. Indices are never " +
+                    "reused, so renamed and removed fields still hold theirs. Remove @Audited from " +
+                    "properties that do not need itemising, or mark a nested entity type @Audited so " +
+                    "it becomes its own disclosure record."
+            )
+            AuditFieldRegistration(
+                _id = "$modelId/$path",
+                modelId = modelId,
+                fieldPath = path,
+                bitIndex = nextBit++,
+            )
+        }
+    }
+    if (newFields.isNotEmpty()) fields.insert(newFields)
+
+    warnOnLowCapacity(modelIds, existingFields, newFields)
+}
+
+/**
+ * Warns while there is still room to act.
+ *
+ * Running out of bits fails a deploy, and finding out then is the worst time to find out. Bits are
+ * consumed permanently, so a model creeps towards the ceiling over its life rather than jumping.
+ */
+private fun warnOnLowCapacity(
+    modelIds: Map<String, Int>,
+    existing: Map<Int, List<AuditFieldRegistration>>,
+    added: List<AuditFieldRegistration>,
+) {
+    val total = existing.mapValues { it.value.size }.toMutableMap()
+    added.groupBy { it.modelId }.forEach { (modelId, rows) -> total[modelId] = total.getOrElse(modelId) { 0 } + rows.size }
+    val names = modelIds.entries.associate { it.value to it.key }
+    total.filter { it.value >= FieldBits.CAPACITY * 3 / 4 }.forEach { (modelId, used) ->
+        logger.warn {
+            "Audited model \"${names[modelId] ?: modelId}\" has used $used of ${FieldBits.CAPACITY} " +
+                "field bits. Indices are never reused, so this only grows."
+        }
+    }
+}
+
+/**
+ * An audited model must be keyed by a `Uuid`.
+ *
+ * Without an `_id` a disclosure record could not say *which* record was disclosed. Requiring that id
+ * to be a `Uuid` is a storage decision: there is one disclosure row per record disclosed, so the
+ * identifier column is written more than anything else in the system and needs to stay sixteen
+ * bytes wide rather than a string a backend will index poorly.
+ */
+private fun SerialDescriptor.requireUuidKeyed(serialName: String) {
+    val idIndex = (0 until elementsCount).firstOrNull { getElementName(it) == "_id" }
+        ?: throw IllegalStateException(
+            "Audited model \"$serialName\" has no _id field, so a disclosure record could not say " +
+                "which record was disclosed. Give it an _id, or drop @Audited."
+        )
+    val idType = getElementDescriptor(idIndex).auditSerialName
+    if (idType != UUID_SERIAL_NAME) throw IllegalStateException(
+        "Audited model \"$serialName\" is keyed by $idType, but auditing requires a Uuid _id. " +
+            "One disclosure row is written per record disclosed, so the id column has to stay " +
+            "sixteen bytes wide. Re-key the model, or drop @Audited."
+    )
+}
+
+private val UUID_SERIAL_NAME = serializer<Uuid>().descriptor.serialName

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/RequestRecordInterceptor.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/RequestRecordInterceptor.kt
@@ -1,0 +1,174 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.auth.Authentication
+import com.lightningkite.lightningserver.data.Request
+import com.lightningkite.lightningserver.data.get
+import com.lightningkite.lightningserver.definition.Runtime
+import com.lightningkite.lightningserver.http.HttpLogicalInterceptor
+import com.lightningkite.lightningserver.http.HttpRequest
+import com.lightningkite.lightningserver.http.HttpResponse
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.websockets.DelegatingWebSocketHandler
+import com.lightningkite.lightningserver.websockets.WebSocketClose
+import com.lightningkite.lightningserver.websockets.WebSocketConnectRequest
+import com.lightningkite.lightningserver.websockets.WebSocketConnection
+import com.lightningkite.lightningserver.websockets.WebSocketHandler
+import com.lightningkite.lightningserver.websockets.WebSocketLogicalInterceptor
+import com.lightningkite.services.database.Table
+import com.lightningkite.services.database.modification
+import com.lightningkite.services.database.updateOneByIdIgnoringResult
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlin.time.TimeSource
+import kotlin.uuid.Uuid
+
+private val logger = KotlinLogging.logger("com.lightningkite.lightningserver.audit.RequestRecordInterceptor")
+
+/**
+ * Writes the [RequestRecord] that every [DisclosureRecord] of this request refers to.
+ *
+ * Logical scope, so each sub-request of a multiplexed request gets its own row — otherwise a bulk
+ * request would record one row no matter how much was disclosed inside it.
+ *
+ * ## Two writes, and why they fail differently
+ *
+ * The row is written **before** the handler runs and updated **after** it finishes, because outcome
+ * and duration are not known until the end while disclosures are written throughout. Writing first
+ * guarantees the referent exists before anything points at it, and the same shape works for a
+ * WebSocket, whose connection is recorded at connect and updated at close.
+ *
+ * The opening write is **fail-closed**: if it fails, the request fails, because nothing may be
+ * disclosed under a request id that names no request.
+ *
+ * The closing update is **best-effort and logged**. By then the audit trail already answers who
+ * received what; only outcome and duration are missing, and they are operational metadata rather
+ * than disclosure facts. Failing a request whose disclosures were correctly recorded would destroy
+ * more information than it protects.
+ */
+public class RequestRecordInterceptor(
+    private val table: Runtime<Table<RequestRecord>>,
+) : HttpLogicalInterceptor, WebSocketLogicalInterceptor {
+    override val name: String = "RequestRecord"
+
+    context(runtime: ServerRuntime)
+    override suspend fun intercept(
+        request: HttpRequest<*>,
+        cont: suspend context(ServerRuntime) (HttpRequest<*>) -> HttpResponse,
+    ): HttpResponse {
+        val started = TimeSource.Monotonic.markNow()
+        table().insert(listOf(request.opening(endpoint = request.route(), method = request.path.method.toString())))
+
+        var outcome = "failed"
+        try {
+            return cont(request).also { outcome = it.status.code.toString() }
+        } finally {
+            complete(runtime.initiator.requestRecordId, outcome, started.elapsedNow().inWholeMilliseconds)
+        }
+    }
+
+    override fun <PATH : PathSpec, T> intercept(handler: WebSocketHandler<PATH, T>): WebSocketHandler<PATH, T> =
+        object : DelegatingWebSocketHandler<PATH, T>(handler) {
+            context(serverRuntime: ServerRuntime)
+            override suspend fun willConnect(request: WebSocketConnectRequest<PATH>): T {
+                table().insert(listOf(request.opening(endpoint = request.route(), method = "WEBSOCKET")))
+                return wrapped.willConnect(request)
+            }
+
+            context(serverRuntime: ServerRuntime)
+            override suspend fun disconnect(connection: WebSocketConnection<PATH, T>, reason: WebSocketClose) {
+                try {
+                    wrapped.disconnect(connection, reason)
+                } finally {
+                    // A socket's duration is its whole lifetime, which no monotonic mark taken here
+                    // could measure, so it is left to be derived from `at` and the close time.
+                    complete(serverRuntime.initiator.requestRecordId, reason.toString(), durationMs = null)
+                }
+            }
+        }
+
+    context(runtime: ServerRuntime)
+    private suspend fun Request<*>.opening(endpoint: String, method: String) = RequestRecord(
+        _id = runtime.initiator.requestRecordId,
+        parentRequestId = runtime.initiator.causedBy,
+        rootExecutionId = runtime.initiator.rootExecutionId,
+        principal = principalOrNull(),
+        sourceIp = sourceIp,
+        endpoint = endpoint,
+        method = method,
+        engineRequestId = engineRequestId,
+        upstreamRequestId = upstreamRequestId,
+    )
+
+    context(runtime: ServerRuntime)
+    private suspend fun complete(requestId: Uuid, outcome: String, durationMs: Long?) {
+        try {
+            table().updateOneByIdIgnoringResult(requestId, modification(RequestRecord.path) {
+                it.outcome assign outcome
+                it.durationMs assign durationMs
+            })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error(e) { "Could not complete the audit request record for $requestId" }
+        }
+    }
+}
+
+/**
+ * The matched route pattern, falling back to the literal target when nothing matched.
+ *
+ * Matching needs the server definition, hence the context; the same resolution telemetry uses.
+ */
+context(runtime: ServerRuntime)
+private fun HttpRequest<*>.route(): String = try {
+    path.match.path.pathSpec.toString()
+} catch (_: Exception) {
+    "/" + path.pathSegments.toString()
+}
+
+context(runtime: ServerRuntime)
+private fun WebSocketConnectRequest<*>.route(): String = try {
+    path.match.path.pathSpec.toString()
+} catch (_: Exception) {
+    "/" + path.pathSegments.toString()
+}
+
+/**
+ * The resolved subject, or null when the request is anonymous or its credentials could not be
+ * resolved at all.
+ *
+ * Resolved here, at the start of the request, rather than at the end: a request that dies mid-flight
+ * should still be attributable. Resolution is memoized, so the handler's own auth check reuses it.
+ */
+context(runtime: ServerRuntime)
+private suspend fun Request<*>.principalOrNull(): String? = try {
+    this[Authentication.CacheKey]?.toString()
+} catch (e: CancellationException) {
+    throw e
+} catch (_: Exception) {
+    null
+}
+
+/**
+ * The id the request log row for this execution is keyed by.
+ *
+ * For a socket that is the socket id rather than the phase's own execution id: the row is opened at
+ * connect and completed at disconnect, which are separate executions on a serverless engine, and a
+ * row keyed by either one of them could not be found by the other. It is also what every disclosure
+ * on that socket points at, so the two must agree — hence one definition rather than two.
+ *
+ * ## The attribution this gives up
+ * A socket's message phases are executions in their own right and can disclose. Keying by the socket
+ * means their disclosures attribute to the socket, so the audit answer for a long-lived connection is
+ * "sometime during this session" rather than "in response to this message". That is exactly what the
+ * server did before the initiator existed — a socket's correlation id was deliberately constant for
+ * its whole lifetime — so this is non-regressing rather than a new gap.
+ *
+ * Closing it would mean a row per phase execution, which for a chatty socket is a row per client
+ * message. That is an audit-design decision with a real cost, and it belongs with the rest of the
+ * audit work in `plans/audit-logging.md` (§5.8), not with the refactor that made it visible.
+ */
+internal val Initiator.requestRecordId: Uuid
+    get() = (this as? Initiator.WebSocket)?.socketId ?: executionId

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/descriptorWalk.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/descriptorWalk.kt
@@ -1,0 +1,121 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.lightningkite.lightningserver.audit
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.elementDescriptors
+
+/** Whether this descriptor's *class* is marked [Audited], meaning its instances get their own records. */
+internal val SerialDescriptor.isAudited: Boolean get() = annotations.any { it is Audited }
+
+/** Whether the property at [index] is marked [Audited], meaning it gets a bit of its own. */
+internal fun SerialDescriptor.isElementAudited(index: Int): Boolean =
+    getElementAnnotations(index).any { it is Audited }
+
+/**
+ * The serial name with any nullability marker removed.
+ *
+ * kotlinx wraps a nullable descriptor in a delegate that appends `?` to the serial name and changes
+ * nothing else. Registry keys must be the same whether a model appears nullable or not.
+ */
+internal val SerialDescriptor.auditSerialName: String get() = serialName.removeSuffix("?")
+
+/**
+ * Every [Audited] model reachable through this descriptor, keyed by [auditSerialName].
+ *
+ * Finds audited models wherever they are: bare, in a `List`, as map values, nested inside a wrapper,
+ * or as a sealed subclass. Open polymorphism and contextual serializers are opaque here — their
+ * concrete types are not known statically — which is why an audited model that arrives at runtime
+ * with no registry entry fails the request rather than being logged as unknown.
+ */
+internal fun SerialDescriptor.auditedModels(): Map<String, SerialDescriptor> {
+    val found = LinkedHashMap<String, SerialDescriptor>()
+    val visited = HashSet<SerialDescriptor>()
+
+    fun walk(descriptor: SerialDescriptor) {
+        if (!visited.add(descriptor)) return
+        if (descriptor.isAudited) found[descriptor.auditSerialName] = descriptor
+        descriptor.auditChildren().forEach(::walk)
+    }
+
+    walk(this)
+    return found
+}
+
+/**
+ * The dotted paths of the properties an audited model itemises, in declaration order — the paths
+ * that get permanent bit indices.
+ *
+ * **Only properties marked [Audited] get a path.** The walk still descends through everything, so an
+ * annotated property is found however deeply it is nested, including inside types that are not
+ * themselves audited. An unannotated property contributes nothing but is still traversed.
+ *
+ * The walk descends through structures that have no record of their own and stops at anything that
+ * does:
+ *
+ * | Shape | Result |
+ * |---|---|
+ * | Property | a path, always |
+ * | Nested non-audited class | the container's path, then one per field beneath it |
+ * | Nested [Audited] model | nothing — it produces its own `DisclosureRecord` |
+ * | List/Set | descends into the element, marked `[]` |
+ * | Map | descends into the value, marked `{}` |
+ * | Sealed class | descends into each subclass, marked `(SubclassSerialName)` |
+ * | Open polymorphic, contextual, primitive | nothing beneath — there is no static structure |
+ *
+ * Keeping a path for the container as well as its leaves is what distinguishes "no address was
+ * disclosed" from "an address was disclosed, all of whose fields held defaults".
+ */
+internal fun SerialDescriptor.auditFieldPaths(): List<String> = FieldPathWalk().also { it.members(this, "") }.paths
+
+/**
+ * Mutual recursion between "list the members of this structure" and "descend into one member",
+ * which local functions cannot express.
+ */
+private class FieldPathWalk {
+    val paths = ArrayList<String>()
+
+    /** Guards against a structure that contains itself; entries are released as the walk unwinds. */
+    private val ancestry = HashSet<SerialDescriptor>()
+
+    fun members(descriptor: SerialDescriptor, prefix: String) {
+        for (index in 0 until descriptor.elementsCount) {
+            val path = prefix + descriptor.getElementName(index)
+            if (descriptor.isElementAudited(index)) paths.add(path)
+            descend(descriptor.getElementDescriptor(index), path)
+        }
+    }
+
+    private fun descend(descriptor: SerialDescriptor, path: String) {
+        // An audited model beneath an audited model is a separate record, not more bits on the parent.
+        if (descriptor.isAudited) return
+        if (!ancestry.add(descriptor)) return
+        when (descriptor.kind) {
+            StructureKind.CLASS, StructureKind.OBJECT -> members(descriptor, "$path.")
+            StructureKind.LIST -> descend(descriptor.getElementDescriptor(0), "$path[]")
+            StructureKind.MAP -> descend(descriptor.getElementDescriptor(1), "$path{}")
+            PolymorphicKind.SEALED -> descriptor.auditChildren()
+                .forEach { members(it, "$path(${it.auditSerialName}).") }
+
+            else -> {}
+        }
+        ancestry.remove(descriptor)
+    }
+}
+
+/**
+ * The descriptors nested directly inside this one, or none for anything opaque.
+ *
+ * A sealed class is special: its subclasses hang off its second element rather than being elements
+ * themselves.
+ */
+private fun SerialDescriptor.auditChildren(): List<SerialDescriptor> = when (kind) {
+    is PrimitiveKind, SerialKind.ENUM, SerialKind.CONTEXTUAL, PolymorphicKind.OPEN -> emptyList()
+    PolymorphicKind.SEALED -> getElementDescriptor(1).elementDescriptors.toList()
+    else -> elementDescriptors.toList()
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/AuditRegistryTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/AuditRegistryTest.kt
@@ -1,0 +1,203 @@
+package com.lightningkite.lightningserver.audit
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.Database
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import org.slf4j.LoggerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The registry is the only record of what a bit means, so its one hard promise is that an
+ * assignment, once made, never changes. These tests are mostly about what stays put across
+ * successive deploys of a changing model.
+ */
+class AuditRegistryTest {
+
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val models = database.registerTable("AuditModelRegistration", AuditModelRegistration.serializer())
+        val fields = database.registerTable("AuditFieldRegistration", AuditFieldRegistration.serializer())
+    }
+
+    /** Runs [block] against a fresh in-memory database. */
+    private fun onServer(block: suspend context(ServerRuntime) Fixture.() -> Unit) = runBlocking {
+        TestServer.test(settings = { database set Database.Settings() }) {
+            block(serverRuntime, Fixture())
+        }
+    }
+
+    private class Fixture {
+        context(server: ServerRuntime)
+        suspend fun deploy(vararg serializers: KSerializer<*>) = reconcileAuditRegistry(
+            TestServer.models(),
+            TestServer.fields(),
+            serializers.flatMap { it.descriptor.auditedModels().entries }.associate { it.key to it.value },
+        )
+
+        context(server: ServerRuntime)
+        suspend fun registry() = loadAuditRegistry(TestServer.models(), TestServer.fields())
+
+        context(server: ServerRuntime)
+        suspend fun allFields() = TestServer.fields().find(Condition.Always).toList()
+    }
+
+    /** Collects WARN lines from the registry's logger for the duration of a test. */
+    private class Warnings {
+        private val logger = LoggerFactory.getLogger(
+            "com.lightningkite.lightningserver.audit.AuditRegistry"
+        ) as Logger
+        private val appender = ListAppender<ILoggingEvent>().apply { start() }
+
+        init {
+            logger.addAppender(appender)
+        }
+
+        fun messages(): List<String> = appender.list.filter { it.level == Level.WARN }.map { it.formattedMessage }
+
+        fun stop() {
+            logger.detachAppender(appender)
+            appender.stop()
+        }
+    }
+
+    private fun captureWarnings(): Warnings = Warnings()
+
+    @Test
+    fun `a first deploy assigns bits in declaration order`() = onServer {
+        deploy(VersionedV1.serializer())
+
+        val registry = registry()
+        val modelId = registry.modelId("Versioned")
+        assertEquals(mapOf("a" to 0), registry.fields(modelId))
+    }
+
+    @Test
+    fun `deploying the same model again changes nothing`() = onServer {
+        deploy(VersionedV1.serializer())
+        val before = allFields().sortedBy { it.bitIndex }
+        deploy(VersionedV1.serializer())
+
+        assertEquals(before, allFields().sortedBy { it.bitIndex }, "a re-deploy must be a no-op")
+    }
+
+    @Test
+    fun `a new field takes the next bit and leaves the existing ones alone`() = onServer {
+        deploy(VersionedV1.serializer())
+        deploy(VersionedV2.serializer())
+
+        val registry = registry()
+        val modelId = registry.modelId("Versioned")
+        assertEquals(mapOf("a" to 0, "b" to 1), registry.fields(modelId))
+    }
+
+    /**
+     * A rename is indistinguishable from a removal plus an addition, and that is fine: the old bit
+     * keeps its old meaning for records written before the rename, and the new field gets a new one.
+     * Nothing written in the past changes meaning, which is the only property that matters.
+     */
+    @Test
+    fun `a renamed field gets a new bit while the old one stays resolvable`() = onServer {
+        deploy(VersionedV2.serializer())
+        deploy(VersionedV3.serializer())
+
+        val registry = registry()
+        val modelId = registry.modelId("Versioned")
+        assertEquals(
+            mapOf("a" to 0, "b" to 1, "renamed" to 2),
+            registry.fields(modelId),
+            "the retired name must still resolve, and the new one must not reuse its bit",
+        )
+    }
+
+    @Test
+    fun `a nested audited model gets its own id rather than bits on its parent`() = onServer {
+        deploy(Patient.serializer())
+
+        val registry = registry()
+        val patient = registry.modelId(Patient.serializer().descriptor.serialName)
+        val doctor = registry.modelId(Doctor.serializer().descriptor.serialName)
+        assertTrue(patient != doctor, "the two models shared an id")
+        assertEquals(setOf("name"), registry.fields(doctor).keys)
+        assertTrue("doctor" in registry.fields(patient).keys, "the parent still records that a doctor was disclosed")
+    }
+
+    @Test
+    fun `an audited model with no id is rejected at deploy`() = onServer {
+        val failure = assertFailsWith<IllegalStateException> { deploy(Anonymous.serializer()) }
+        assertTrue("_id" in failure.message.orEmpty(), "the message should name what is missing; was ${failure.message}")
+    }
+
+    /**
+     * One disclosure row per record disclosed makes the id column the most-written column in the
+     * system, so a string key is rejected rather than quietly accepted.
+     */
+    @Test
+    fun `an audited model not keyed by Uuid is rejected at deploy`() = onServer {
+        val failure = assertFailsWith<IllegalStateException> { deploy(StringKeyed.serializer()) }
+        assertTrue(
+            "Uuid" in failure.message.orEmpty(),
+            "the message should name the required key type; was ${failure.message}",
+        )
+    }
+
+    @Test
+    fun `a model too wide for the available bits is rejected with the remedy`() = onServer {
+        val failure = assertFailsWith<IllegalStateException> { deploy(Wide.serializer()) }
+        assertTrue(
+            "@Audited" in failure.message.orEmpty() && "reused" in failure.message.orEmpty(),
+            "the message should name the way out and why bits are scarce; was ${failure.message}",
+        )
+    }
+
+    /**
+     * Running out of bits fails a deploy, and finding out then is the worst possible time. Bits are
+     * consumed permanently, so a model creeps towards the ceiling rather than jumping at it.
+     */
+    @Test
+    fun `a model approaching the bit ceiling is warned about while there is room to act`() = onServer {
+        val warnings = captureWarnings()
+        try {
+            deploy(Roomy.serializer())
+        } finally {
+            warnings.stop()
+        }
+
+        assertTrue(
+            warnings.messages().any { "Roomy" in it && "50 of 64" in it },
+            "expected a capacity warning naming the model and its usage; saw ${warnings.messages()}",
+        )
+    }
+
+    @Test
+    fun `a model with room to spare is not warned about`() = onServer {
+        val warnings = captureWarnings()
+        try {
+            deploy(VersionedV1.serializer())
+        } finally {
+            warnings.stop()
+        }
+
+        assertEquals(emptyList(), warnings.messages())
+    }
+
+    @Test
+    fun `an unregistered model fails loudly rather than being recorded as unknown`() = onServer {
+        deploy(VersionedV1.serializer())
+        assertFailsWith<IllegalStateException> { registry().modelId("NeverDeployed") }
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DescriptorWalkTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DescriptorWalkTest.kt
@@ -1,0 +1,61 @@
+package com.lightningkite.lightningserver.audit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DescriptorWalkTest {
+
+    @Test
+    fun `an audited model is found through wrappers, lists and nullability`() {
+        val found = Patient.serializer().descriptor.auditedModels().keys
+        assertTrue(found.any { it.endsWith("Patient") }, "the root audited model was missed; found $found")
+        assertTrue(found.any { it.endsWith("Doctor") }, "a nested audited model was missed; found $found")
+    }
+
+    @Test
+    fun `an audited model is found inside a sealed hierarchy`() {
+        val found = Order.serializer().descriptor.auditedModels().keys
+        assertTrue(found.any { it.endsWith("Order") }, "found $found")
+    }
+
+    /**
+     * Only annotated properties get paths, but the walk still traverses everything — `phones` is not
+     * itemised yet `phones[].number` beneath it is, and the whole `tags` subtree contributes nothing.
+     */
+    @Test
+    fun `paths are the annotated properties, found however deeply they nest`() {
+        assertEquals(
+            listOf("name", "ssn", "address", "address.street", "phones[].number", "doctor"),
+            Patient.serializer().descriptor.auditFieldPaths(),
+        )
+    }
+
+    /** `_id` is recorded as the disclosure's `recordId`, so spending a bit on it would be redundant. */
+    @Test
+    fun `an unannotated id gets no bit`() {
+        assertTrue("_id" !in Patient.serializer().descriptor.auditFieldPaths())
+    }
+
+    @Test
+    fun `a sealed field gets a path per annotated subclass field`() {
+        assertEquals(
+            listOf("payment", "payment(Card).last4"),
+            Order.serializer().descriptor.auditFieldPaths(),
+            "Cash.amount is not annotated, so it contributes nothing",
+        )
+    }
+
+    /** A model that contains itself must not walk forever. */
+    @Test
+    fun `a self-referential structure terminates`() {
+        val paths = Tree.serializer().descriptor.auditFieldPaths()
+        assertTrue(paths.contains("root.label"), "did not descend at all; was $paths")
+        assertTrue(paths.size < 20, "the walk did not converge; produced ${paths.size} paths")
+    }
+
+    @Test
+    fun `an unaudited model contributes nothing`() {
+        assertEquals(emptyMap(), Address.serializer().descriptor.auditedModels())
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DisclosureRecordTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DisclosureRecordTest.kt
@@ -1,0 +1,46 @@
+package com.lightningkite.lightningserver.audit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class DisclosureRecordTest {
+
+    private fun record(id: Uuid) = DisclosureRecord(
+        _id = id,
+        requestId = Uuid.random(),
+        modelId = 1,
+        recordId = Uuid.random(),
+    )
+
+    /**
+     * Like RequestRecord, a disclosure row carries no `at` column and derives its instant from the
+     * version-7 `_id`. This matters more here than there: `requestId` points at a socket's row
+     * rather than at the phase that disclosed, so this is the only thing that places a disclosure on
+     * a long-lived connection at a specific moment.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `at derives the id's embedded timestamp`() {
+        val instant = Instant.fromEpochMilliseconds(1_700_000_123_456)
+        assertEquals(instant, record(Uuid.generateV7NonMonotonicAt(instant)).at)
+    }
+
+    /** A non-v7 id has no embedded timestamp; at degrades to the epoch rather than inventing one. */
+    @Test
+    fun `a non-v7 id degrades to the epoch`() {
+        assertEquals(Instant.fromEpochMilliseconds(0), record(Uuid.random()).at)
+    }
+
+    /** Ordering by id is ordering by time — the property the append-mostly table relies on. */
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `v7 ids sort in mint order`() {
+        val base = 1_700_000_000_000
+        val ids = (0..20).map { Uuid.generateV7NonMonotonicAt(Instant.fromEpochMilliseconds(base + it * 1_000L)) }
+
+        assertEquals(ids, ids.shuffled().sortedBy { it.toString() })
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/RequestRecordTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/RequestRecordTest.kt
@@ -1,0 +1,48 @@
+package com.lightningkite.lightningserver.audit
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class RequestRecordTest {
+
+    /**
+     * RequestRecord carries no `at` column; the instant is derived from the version-7 `_id`. This
+     * test pins that derivation so the two can never silently drift apart. V7 embeds whole
+     * milliseconds, so the round trip is exact at that precision.
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `at derives the id's embedded timestamp`() {
+        val instant = Instant.fromEpochMilliseconds(1_700_000_123_456)
+        val id = Uuid.generateV7NonMonotonicAt(instant)
+
+        val record = RequestRecord(
+            _id = id,
+            rootExecutionId = id,
+            sourceIp = "1.2.3.4",
+            endpoint = "/x",
+            method = "GET",
+        )
+
+        assertEquals(instant, record.at)
+    }
+
+    /** A legacy (non-v7) id has no embedded timestamp; at must degrade to the epoch rather than throw. */
+    @OptIn(ExperimentalUuidApi::class)
+    @Test
+    fun `a non-v7 id degrades to the epoch`() {
+        val v4 = Uuid.random()
+        val record = RequestRecord(
+            _id = v4,
+            rootExecutionId = v4,
+            sourceIp = "1.2.3.4",
+            endpoint = "/x",
+            method = "GET",
+        )
+
+        assertEquals(Instant.fromEpochMilliseconds(0), record.at)
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/testModels.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/testModels.kt
@@ -1,0 +1,213 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.data.GenerateDataClassPaths
+import com.lightningkite.services.database.HasId
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+@Serializable
+@GenerateDataClassPaths
+@Audited
+data class Patient(
+    override val _id: Uuid,
+    @Audited val name: String,
+    @Audited val ssn: String,
+    @Audited val address: Address? = null,
+    // Not itemised itself, but the walk still descends: `phones[].number` is.
+    val phones: List<Phone> = listOf(),
+    // Nothing beneath is itemised, so this whole subtree costs no bits.
+    val tags: Map<String, String> = mapOf(),
+    @Audited val doctor: Doctor? = null,
+) : HasId<Uuid>
+
+@Serializable
+data class Address(@Audited val street: String, val city: String)
+
+@Serializable
+data class Phone(@Audited val number: String, val label: String)
+
+/** Audited in its own right, so it must not consume bits of the model that carries it. */
+@Serializable
+@Audited
+data class Doctor(override val _id: Uuid, @Audited val name: String) : HasId<Uuid>
+
+@Serializable
+sealed class Payment {
+    @Serializable
+    @SerialName("Card")
+    data class Card(@Audited val last4: String) : Payment()
+
+    @Serializable
+    @SerialName("Cash")
+    data class Cash(val amount: Int) : Payment()
+}
+
+@Serializable
+@Audited
+data class Order(override val _id: Uuid, @Audited val payment: Payment) : HasId<Uuid>
+
+@Serializable
+data class Node(@Audited val label: String = "", val child: Node? = null)
+
+@Serializable
+@Audited
+data class Tree(override val _id: Uuid, @Audited val root: Node = Node()) : HasId<Uuid>
+
+/** No `_id`, so no disclosure record could say which record was disclosed. */
+@Serializable
+@Audited
+data class Anonymous(@Audited val value: String)
+
+/** Keyed by a String, which is too wide for a table written to once per record disclosed. */
+@Serializable
+@Audited
+data class StringKeyed(override val _id: String, @Audited val value: String) : HasId<String>
+
+/** Exercises descent into map *values*, whose path separator differs from a list's. */
+@Serializable
+@Audited
+data class Contact(
+    override val _id: Uuid,
+    val label: String = "",
+    @Audited val numbers: Map<String, Phone> = mapOf(),
+) : HasId<Uuid>
+
+@Serializable
+enum class Severity { Low, High }
+
+@Serializable
+@Audited
+data class Reading(
+    override val _id: Uuid,
+    @Audited val severity: Severity? = null,
+    @Audited val count: Int = 0,
+    @Audited val flagged: Boolean = false,
+) : HasId<Uuid>
+
+@Serializable
+data class Deep3(
+    @Audited val d0: String = "",
+    @Audited val d1: String = "",
+    @Audited val d2: String = "",
+    @Audited val d3: String = "",
+    @Audited val d4: String = "",
+    @Audited val d5: String = "",
+    @Audited val d6: String = "",
+    @Audited val d7: String = "",
+    @Audited val d8: String = "",
+    @Audited val d9: String = "",
+    @Audited val d10: String = "",
+    @Audited val d11: String = "",
+)
+
+@Serializable
+data class Deep2(
+    val n0: Deep3 = Deep3(),
+    val n1: Deep3 = Deep3(),
+    val n2: Deep3 = Deep3(),
+    val n3: Deep3 = Deep3(),
+    val n4: Deep3 = Deep3(),
+    val n5: Deep3 = Deep3(),
+    val n6: Deep3 = Deep3(),
+    val n7: Deep3 = Deep3(),
+    val n8: Deep3 = Deep3(),
+    val n9: Deep3 = Deep3(),
+    val n10: Deep3 = Deep3(),
+    val n11: Deep3 = Deep3(),
+)
+
+/** 144 itemised paths — deliberately past the 64 available to one model. */
+@Serializable
+@Audited
+data class Wide(override val _id: Uuid, val root: Deep2 = Deep2()) : HasId<Uuid>
+
+// Three shapes of the same audited model over time, sharing a serial name so that they share a
+// model id: fields added, then a field renamed.
+@Serializable
+@SerialName("Versioned")
+@Audited
+data class VersionedV1(override val _id: Uuid, @Audited val a: String) : HasId<Uuid>
+
+@Serializable
+@SerialName("Versioned")
+@Audited
+data class VersionedV2(override val _id: Uuid, @Audited val a: String, @Audited val b: String) : HasId<Uuid>
+
+@Serializable
+@SerialName("Versioned")
+@Audited
+data class VersionedV3(override val _id: Uuid, @Audited val renamed: String, @Audited val b: String) : HasId<Uuid>
+
+/** 50 itemised paths — past the 75% mark of the 64 available, but not past the ceiling. */
+@Serializable
+@Audited
+data class Roomy(
+    override val _id: Uuid,
+    @Audited val f0: String = "",
+    @Audited val f1: String = "",
+    @Audited val f2: String = "",
+    @Audited val f3: String = "",
+    @Audited val f4: String = "",
+    @Audited val f5: String = "",
+    @Audited val f6: String = "",
+    @Audited val f7: String = "",
+    @Audited val f8: String = "",
+    @Audited val f9: String = "",
+    @Audited val f10: String = "",
+    @Audited val f11: String = "",
+    @Audited val f12: String = "",
+    @Audited val f13: String = "",
+    @Audited val f14: String = "",
+    @Audited val f15: String = "",
+    @Audited val f16: String = "",
+    @Audited val f17: String = "",
+    @Audited val f18: String = "",
+    @Audited val f19: String = "",
+    @Audited val f20: String = "",
+    @Audited val f21: String = "",
+    @Audited val f22: String = "",
+    @Audited val f23: String = "",
+    @Audited val f24: String = "",
+    @Audited val f25: String = "",
+    @Audited val f26: String = "",
+    @Audited val f27: String = "",
+    @Audited val f28: String = "",
+    @Audited val f29: String = "",
+    @Audited val f30: String = "",
+    @Audited val f31: String = "",
+    @Audited val f32: String = "",
+    @Audited val f33: String = "",
+    @Audited val f34: String = "",
+    @Audited val f35: String = "",
+    @Audited val f36: String = "",
+    @Audited val f37: String = "",
+    @Audited val f38: String = "",
+    @Audited val f39: String = "",
+    @Audited val f40: String = "",
+    @Audited val f41: String = "",
+    @Audited val f42: String = "",
+    @Audited val f43: String = "",
+    @Audited val f44: String = "",
+    @Audited val f45: String = "",
+    @Audited val f46: String = "",
+    @Audited val f47: String = "",
+    @Audited val f48: String = "",
+    @Audited val f49: String = "",
+) : HasId<Uuid>
+
+/** Not audited, so the data access log must pass it through untouched. */
+@Serializable
+@GenerateDataClassPaths
+data class PlainThing(override val _id: Uuid, val value: String) : HasId<Uuid>
+
+/**
+ * Not audited itself, but reaches an audited model through a field.
+ *
+ * The shape that used to slip past the data access log: gating on the table's own descriptor found no
+ * `@Audited` here and returned the table undecorated, so every read of the Patient inside went
+ * unrecorded.
+ */
+@Serializable
+@GenerateDataClassPaths
+data class PatientWrapper(override val _id: Uuid, val patient: Patient) : HasId<Uuid>

--- a/plans/audit-implementation-risks.md
+++ b/plans/audit-implementation-risks.md
@@ -1,0 +1,260 @@
+# Audit system: what could go wrong
+
+A register of known problems in the audit implementation as of 2026-09, written by the person who
+built it. Ordered by how much damage each could do. Companion to `audit-logging.md`, which says what
+the system is *meant* to do; this says where the built thing falls short of that.
+
+Two things are worth knowing before reading. First, several of the designs below were decided **while
+implementing**, not specified in advance — those are marked. Second, nothing here has run in
+production or under concurrent load; the evidence is unit and integration tests only.
+
+An independent adversarial review has since run over all four implementation commits. It found one
+silent bypass and several data gaps, all now fixed (`494f65eb`), and it independently confirmed the
+two things I most wanted confirmed: `Table` coverage has no holes (21 of 23 members overridden, the
+three others touch no data), and nothing in either repository unwraps `.wraps`. Where its findings
+changed the picture below, the sections say so.
+
+---
+
+## 1. Fail-closed on reads can take the whole server down — including at boot
+
+**Severity: highest. This is the one to think about before deploying.**
+
+The data access log fails closed: a query against an audited model whose record cannot be written
+does not run. That is the correct rule for a compliance log, and it is the same rule the disclosure
+log follows — but the blast radius is much larger here.
+
+The disclosure log only fails requests that actually disclose. The data access log sits at the
+database layer and therefore covers **privileged internal reads too**: startup tasks, schedule ticks,
+one service reading another's model. So an audit-database outage does not degrade the server, it
+stops it — and if the outage is present at boot, a startup task that reads an audited model fails and
+the server may not come up at all.
+
+Nothing about this is accidental, and `audit-logging.md` 6.2 says it plainly. But the plan reasoned
+about fail-closed in the context of *disclosure*, where the argument is airtight ("a disclosure that
+cannot be recorded must not happen"). Extending the same rule to a privileged internal read is a
+bigger claim, and it deserves an explicit decision rather than inheriting one.
+
+**Options if that is unacceptable:** scope the decorator to user-facing tables only (weakens the
+guarantee the layer exists for), or make failure policy configurable per model.
+
+## 2. Integrity rests on the server behaving, and always did
+
+A statement of what this system is, not a gap in it. **The only integrity mechanism is whether the
+server does what it says it does.** Code running in the server can lie about what the server did, and nothing in the server can
+prevent that.
+
+What a hash chain *would* defend is narrower than it first sounds: an adversary who can write the
+audit tables but cannot read the key. Since the server would compute the chain, the key lives with the
+application's runtime secrets — so the defence exists only where database write and that secret are
+genuinely separate principals, which is a deployment property nothing here can verify. And even then
+it catches edits and middle deletions but not truncation, because nothing in process knows how long
+the chain should have been.
+
+The implementation actually available in process is worse than that narrow case: an unkeyed hash in
+the database it protects, recomputable by exactly the adversary it is meant to catch, while putting a
+second write on the path of every audited read. For the same threat, prevention beats detection — see
+below — which is why chaining here is not merely out of scope but wrong.
+
+So this is a deliberate scope decision, not an oversight: **that narrower guarantee is bought with
+deployment controls, not code.** Restrict who can write the audit tables; make the store append-only
+at the infrastructure level where that is available; keep the audit principal distinct from the
+application's. None of it is enforced here, and #4 raises the stakes, since these tables now hold the
+sensitive values they audit.
+
+If those controls prove insufficient, the emergency total-log outside the server is the answer — and a
+better one than a chain, provided it is *externally driven* and treats silence as an alarm. See
+`audit-logging.md` section 10.
+
+## 4. The audit log now stores the sensitive values it exists to audit
+
+`DataAccessRecord.condition` holds the serialized query. A probe like `find(ssn eq "123-45-6789")`
+therefore writes that SSN into the audit table in the clear.
+
+This is inherent to recording conditions — the value *is* the evidence, and redacting it would defeat
+the oracle detection the layer exists for. But it means the audit database becomes a second copy of
+sensitive data, with different access controls, different retention, and no masking. Section 11.4
+concluded that reads of the audit log need no special mechanism; that conclusion was reached before
+conditions were stored, and is worth revisiting.
+
+It also interacts with erasure (#6): shredding a subject's records does not shred a condition in a
+data access row that happens to contain their identifier.
+
+## 4b. Bypassing the audit log — mostly closed, one surface left
+
+**Found by review, now largely fixed.** `ModelInfo.baseTable()` sat below the `log` decorator, so
+anything holding a `ModelInfo` could read or mutate an audited model with no record — and
+`media/.../processing.kt:128` was doing exactly that.
+
+`baseTable()` now goes through the decorator: it means "without permissions", which is what callers
+actually want, not "without a record". The genuine bypass moved to `dangerouslyDirectTable()`, which
+requires opting in to `@UnauditedDatabaseAccess` (a `RequiresOptIn` **error**). The point is not to
+forbid it — migrations legitimately need it — but to make every bypass greppable:
+`grep -rn UnauditedDatabaseAccess` now answers "where is an audited model touched without a record",
+which was previously unanswerable. The media call site is audited as a side effect.
+
+**What remains open:** `DatabaseTableRegistration.invoke()` — i.e. calling `myTable()` on a registered
+table — returns the undecorated table and is the *documented normal way* to use a table. It carries no
+annotation and cannot reasonably carry one, since it is the primary API for every table in every app.
+So the hardening covers `ModelInfo`, which is where audited models are conventionally reached, and not
+the registration surface underneath it.
+
+## 5. An audited model that no endpoint returns cannot be read at all
+
+Model ids are assigned by scanning **endpoint serializers**, never tables — deliberately, because
+scanning tables once made disclosure coverage look complete when it was not. The data access log keys
+off the `@Audited` annotation and then resolves the id, which throws when there is none.
+
+The consequence: an `@Audited` model that no endpoint's serializer can reach has no id, so **every
+read of it fails**, including internal ones. A model that is only ever read internally — which is
+exactly the case this layer was built to cover — cannot be data-access-logged until something makes it
+reachable.
+
+Failing loudly is right; the state that produces the failure is not. Resolving it means either a
+second registration space for table-only models or an explicit opt-in list, and neither is decided.
+
+## 5b. The typed `.test` helper did not enforce authorization (fixed)
+
+An endpoint's `AuthRequirement` is asserted inside `request.access(auth)` on the real HTTP path
+(`ApiHttpHandler.kt:115`). The typed test helper built `HttpAccess(request, auth)` directly, so the
+requirement was never consulted and **every authorization assertion written through it was vacuous** —
+it would have passed against an endpoint with no requirement at all.
+
+Fixed: all eight overloads now go through an `assertAuth` helper that calls `auth.assert(presented)`,
+the same check the real path makes. A rejected caller gets the `ForbiddenException` the endpoint
+would really have produced.
+
+It found something immediately. `FunnelEndpointsTest` built its server with `read =
+AuthRequirement.IsAdmin` and never configured `AuthRequirement.isSuperUser`, which has no default —
+so that endpoint rejected *every* caller, and six tests exercised it with a null auth and passed.
+They now configure what `IsAdmin` means and supply an admin, and a new negative test asserts the
+rejection. Confirmed by mutation: with the old helper the original tests pass 13/13, which is the
+vacuity demonstrated rather than asserted.
+
+**A structural reason such a test could not previously exist.** `Authentication<SUBJECT>` is
+invariant (`Authentication.kt:125`) while library endpoints type their callers as `HasId<*>?`, so
+passing a satisfying auth to an `IsAdmin`-guarded endpoint through the typed helper requires an
+unchecked widening cast. There is already one precedent for that cast in the repo. Making
+`Authentication` covariant would remove the need, but `PrincipalType` holds a `KSerializer<SUBJECT>`,
+so it is not a one-line change. Not attempted.
+
+A sweep of 70 rejection assertions and 19 non-null-auth call sites found no other authorization
+assertion going through the helper — every other rejection test covers a domain failure raised inside
+a handler body, which this change does not affect.
+
+## 6. Erasure is a contract with nothing behind it
+
+There is no `AuditSubjectKey` and no deploy guard demanding one. The design for both is recorded in
+`audit-logging.md` 11.2 and still stands, but it is deliberately not implemented: nothing would read
+the map, so its only effect would be to fail a deploy unless it was populated — charging every
+deployment a declaration in exchange for nothing while pinning guesses about an unbuilt feature into
+public API.
+
+**Nothing about erasure works, and nothing prompts for it either.** No encryption is performed,
+there is no shred operation, and no deploy fails for want of a subject key. The decision still cannot
+be retrofitted — records written before a key exists stay unshreddable — so a deployment that may
+face an erasure request has to decide early on its own. The mutation log makes this larger, not
+smaller: its `old`/`new` columns put record contents somewhere erasure would also have to reach.
+
+## 7. The auth event log does not fail closed, unlike everything else
+
+Deliberate, and argued in 7.3.1: an auth event has already happened when it is reported, usually from
+a path that is itself rejecting something, and throwing there would replace a clean "your login
+failed" with an unrelated server error and lose the original reason.
+
+The cost, stated plainly: **an attacker who can make the audit database unavailable can make
+authentication events go unrecorded while authentication keeps working.** That is the opposite of the
+guarantee the other two layers give. Whether that asymmetry is acceptable is a policy question, not a
+technical one.
+
+**Coverage is also partial.** Only rejected authentications currently report. Issuance, refresh,
+termination, per-method proof results and masquerade are listed in 7.3 and are not yet raised at their
+call sites — the reporter will record them the moment they are.
+
+## 7b. Unauthenticated writes into a fail-closed store
+
+Found by review. Any request carrying a token this server cannot parse used to produce an auth event
+row, before any authentication resolved — so an unauthenticated attacker spraying nonsense
+`Authorization` headers wrote one audit row per request. Because the disclosure and data access logs
+are **fail-closed on the same database**, degrading that store does not merely lose audit records, it
+takes the server down. That is amplification from "send garbage" to "outage".
+
+Closed by not treating unparseable input as an authentication event: `TokenMalformed` and
+`TokenTypeMismatch` no longer report. Neither names an account, which is what an auth event is about,
+and the request log already records that the request happened.
+
+**The general shape remains**, and is worth keeping in mind for any layer added later: anything that
+writes to the audit store on an unauthenticated path is a lever on the availability of everything that
+shares it. Rate limiting the auth event writer, or giving it a separate store from the fail-closed
+layers, would both harden this further.
+
+## 8. Volume, and no retention story
+
+One data access row per query against an audited model, one disclosure row per record disclosed, one
+chain entry per `sealThreshold` records. A single `find` returning ten thousand audited records writes
+ten thousand disclosure rows plus one access row.
+
+There is no retention, archival, or partitioning design anywhere in the plan or the implementation.
+For an append-mostly table on a fail-closed write path, that is a capacity problem that becomes an
+availability problem — see #1.
+
+## 9. Smaller things, and latent hazards
+
+- **`DataAccessLogTable` exposes the undecorated table through `wraps`.** Confirmed by review that
+  nothing in either repository unwraps it, and that `Table` has no sub-interfaces or downcasts that
+  would. Latent only — see 4b for the surface that is not latent.
+- **`groupBy` is recorded via `DataClassPath.toString()`**, which is not a documented stable format.
+  If it changes, historical rows become harder to interpret. The same applies to the `aggregate`
+  column, which now holds `Aggregate.toString()` and search params.
+- **Coverage of `Table` was verified by enumeration** — 21 of 23 members overridden, the two skipped
+  (`fullCondition`, `mask`) return metadata rather than data. That check should be repeated whenever
+  `Table` gains a member, and nothing enforces it. A test that fails when an un-overridden data
+  method appears would be worth more than the manual check.
+- **An unrecognised event type string is dropped after logging**, which is the price of the stringly
+  typed seam between `core` and the audit module. A typo silently loses events.
+- **`DisclosureRecord` still does not carry `executionId`**, so a disclosure on a long-lived socket is
+  placed within the session rather than at a message. Its v7 id timestamps it to the millisecond,
+  which in practice identifies the message, but that is inference rather than attribution.
+
+## 9b. Engine shutdown: two gaps left open
+
+Both found by review of the socket work, both deliberately not fixed here.
+
+**A connection accepted mid-shutdown is never disconnected.** `openChannels.close()` runs before
+`bossGroup.shutdownGracefully()`, so a connection arriving in between joins the group after it was
+closed and is neither closed nor awaited. It would get `willConnect` and `didConnect` and never
+`disconnect` — the same class of loss the rest of this work fixed. Closing it properly means holding
+the server channel and closing it first, so acceptance stops before active channels do. That is a
+real change to the shutdown sequence and was not worth making immediately after reworking it.
+
+**An in-flight HTTP request is still truncated by shutdown** (`unexpected end of stream`). Confirmed
+pre-existing: a probe fails identically before and after this branch's socket work, so the channel
+group did not cause it. Websocket disconnects are now delivered; plain HTTP requests in flight are
+not drained.
+
+## 10. Breaking changes shipped alongside
+
+Not defects, but they will surprise someone:
+
+- `DELETE /auth/sessions/{id}` no longer works. Sessions are terminated, never deleted.
+- `BackupCodeSecret` requires `createdAt`. Deliberately not defaulted: a model cannot read the
+  engine's selected clock, and a wall-clock default would reintroduce the fabricated value the
+  neighbouring change removed.
+- `SessionManager` gained a constructor parameter (defaulted, so source-compatible).
+
+---
+
+## What I would do first
+
+1. Decide #1 — whether fail-closed on privileged reads is acceptable, because it gates whether this
+   can be turned on at all.
+2. Treat #2 as a deployment requirement, not a code one: decide who can write the audit tables and
+   whether the store is append-only at the infrastructure level. That is where the narrower
+   tamper-resistance is bought, and nothing in this repository enforces it.
+3. Revisit 11.4 in light of #2 and #4 — its "no special mechanism needed" resolution rested partly on
+   a hash chain, which this system deliberately does not have.
+
+#3 in the original list — "get this reviewed by someone who did not write it" — has now happened, and
+found a silent bypass plus four data gaps that my own reading missed. The three defects I had already
+found in the chain, it found independently. That is the strongest available argument for doing the
+same to whatever is built next.

--- a/plans/audit-logging.md
+++ b/plans/audit-logging.md
@@ -62,6 +62,16 @@ covers endpoints that happen to be built from it.
 the serializer for the outgoing value (`outputType`). Hooking there means a new endpoint is audited
 by construction.
 
+**The two layers are complements, not alternatives**, and each covers the other's blind spot:
+
+| | Sees | Cannot see |
+|---|---|---|
+| Typed layer ([5](#5-layer-2-the-disclosure-log-audited)) | what actually reached a client, field by field | a privileged read that never leaves the server |
+| Database layer ([6](#6-layer-3-the-data-access-log)) | every query and mutation, whoever issued it | whether any of it reached a client |
+
+So disclosure is recorded at the typed layer, and *access* — every condition and sort applied to the
+data — is recorded at the database layer. Neither alone is sufficient.
+
 ### 2.2 Why record disclosed fields rather than masked fields
 
 An earlier version of this design proposed deriving the record from the `Mask` that was applied
@@ -157,10 +167,20 @@ there is no separate untrusted claim, so `upstreamRequestId` stays null.
 out-of-the-box behaviour is to trust nothing. It deliberately mirrors the existing `realIpHeader`
 setting, which solves the same trust problem for source IP.
 
-**AWS serverless needs no such setting.** API Gateway mints `requestContext.requestId` itself, so it
-is authoritative with no configuration, and it matches the ID in the gateway's own access logs. For
-WebSockets the adapter uses `requestContext.connectionId`, which is stable for the socket's whole
-lifetime — exactly the correlation scope wanted for a connection.
+**AWS serverless needs no such setting either, but for a different reason.** An earlier version of
+this plan had the adapter adopt `requestContext.requestId` (and `requestContext.connectionId` for
+WebSockets) as the authoritative id. That was abandoned when request ids became `Uuid`s: API Gateway
+ids are not UUIDs and not even 128 bits, so there is nothing to adopt. The adapter now mints its own
+`Uuid` on both paths.
+
+The join to the gateway's own access log is preserved rather than lost. The gateway's id is kept in
+`RequestRecord.engineRequestId` — trusted, because the engine supplied it rather than the caller, and
+therefore deliberately a separate column from the untrusted `upstreamRequestId`. The join is:
+gateway log `requestId` → `engineRequestId` → our `Uuid`. For WebSockets the connection id already
+lives in `engineSocketId` and is surfaced through the same property, so a socket keeps one identity
+for its whole lifetime without storing the value twice.
+
+See [`execution-context-refactor.md`](execution-context-refactor.md) §2.6.
 
 ### 3.3 Aligning with the proxy and with telemetry
 
@@ -338,96 +358,205 @@ value. The real reasons to emit late are outcome and duration.
 
 The layer that delivers the actual compliance value.
 
+**Status: implemented.** `:audit`, `:audit-shared`, and `TypedOutputInterceptor` in `core`. Turned on
+by including the layers a deployment wants — `path.path("audit") include AuditCore(database)` plus
+each log over that core — and nothing audits until they are. It is an ordinary [ServerBuilder] module like `ModelRestEndpoints`,
+which is what it should be: everything it registers (tables, pre-deploy tasks, interceptors) is what
+a module carries, and mounting it at a path namespaces its pre-deploy tasks instead of scattering
+them at the root.
+
 ### 5.1 Marking
 
 ```kotlin
-/** Records disclosure of this model whenever it leaves through a typed endpoint. */
-@Target(AnnotationTarget.CLASS)
+@SerialInfo
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
 public annotation class Audited
-
-/** Records invocation of this endpoint, including its input, as an auditable operation. */
-@Target(AnnotationTarget.CLASS)
-public annotation class AuditedOperation
 ```
 
-`@Audited` on a model covers data disclosure. `@AuditedOperation` on an endpoint covers actions that
-are not model reads at all — triggering a payment, exporting a report, revoking a session. Both use
-the same interception point, so this costs no additional machinery.
+One annotation, two scopes. **On a class:** every instance that reaches a client produces its own
+[DisclosureRecord]. **On a property:** that field is *itemised* — a bit is reserved for it, and each
+disclosure records whether it carried a value.
 
-The annotation establishes the **floor**. The effective level is resolved at registration and may be
-raised by configuration (metadata only → include IDs → include values) but never lowered, so a
-deployment can tighten auditing without a recompile and cannot loosen it by accident.
+`@SerialInfo` is not decoration. A plain Kotlin annotation is invisible to a `SerialDescriptor`, and
+this whole design walks descriptors rather than reflecting — so that it sees exactly what the
+serializer will emit and behaves the same on every target. It also means the marker only has an
+effect on `@Serializable` classes, which audited models always are.
 
-### 5.2 Interception
+#### 5.1.1 Itemising is opt-in; disclosure is not
 
-In `ApiHttpHandler.handle` (the interface's default implementation), after the endpoint's typed
-`handle` returns and before serialization.
+**Resolved after initially getting this backwards.** The first design itemised every field of an
+audited model automatically, on the reasoning that opt-in would let an engineer add a sensitive field
+and leave it silently unaudited.
 
-**Precompute the audit plan per endpoint at registration**, by walking the `outputType` descriptor to
-determine whether the output graph contains audited models and at what paths. `@Audited` models must
-be found anywhere in the graph — bare, in `List<T>`, in `Partial<T>`, nested inside a wrapper, as map
-values. At runtime the plan is a direct walk of the value with no reflection, keeping the hot path
-cheap.
+That reasoning was wrong on the facts. Because one row is written per record disclosed
+([5.3](#53-record-shape--one-row-per-record-disclosed)), **the disclosure record exists whether or
+not any property is annotated** — it is driven by `@Audited` on the *class*. So "who saw this record,
+under which request, when" stays completely covered regardless. Field bits are refinement on top:
+*which fields were in the payload*. Opt-in makes that refinement coarser by default; it does not make
+a disclosure disappear.
 
-Endpoints whose output graph contains no audited models get a null plan and pay nothing.
+The residual risk is narrow and reviewable: someone adds a regulated element to a model already
+marked `@Audited` and forgets to mark the property, so "which requests disclosed an SSN" misses it.
+That is a code-review concern on a model already flagged sensitive.
 
-### 5.3 Record shape — normalisation is the whole game
+Against that, automatic itemising cost real things:
 
-The naive shape (one row per disclosed record, each carrying IP, principal, timestamp, and bitfield)
-is unaffordable: a 10k-row query produces 10k rows, each redundantly repeating request-constant data.
+- **Bits, permanently.** Indices are never reused ([5.4](#54-the-field-registry--append-only-and-the-sole-record-of-what-a-bit-means)),
+  so a model accumulates dead bits through every rename and removal. Headroom shrinks monotonically
+  over a model's life, and nested paths grow faster than property counts. Reserving indices for
+  `sortOrder` and `createdAt` spends capacity that never comes back.
+- **Signal.** A field-set where forty of forty-five bits are noise makes the interesting query harder
+  to write and harder to trust.
 
-Two reductions, together roughly two orders of magnitude:
+Two consequences worth stating so they are not read as bugs later:
 
-1. **Request-constant data lives once.** IP, principal, timestamp, endpoint, and outcome are
-   properties of the request, recorded once in the layer-1 record and referenced by `requestId`.
-   Disclosure records never repeat them.
-2. **Group by bitfield.** Within one query result nearly every row shares the same disclosed-field
-   set. So the unit is not a record, it is a *(request, table, field-set)* group with an ID list.
+- **A disclosure with no bits set is normal and correct** — "this record was disclosed, and none of
+  the fields we track were in its payload".
+- **`_id` gets no bit.** It is already recorded as `recordId` on every row, so itemising it would
+  spend a bit restating the row's own identity.
+
+An annotated property is found anywhere in the graph, including inside types that are not themselves
+audited: `@Audited val street: String` inside an `Address` becomes `address.street` on the record
+holding it. The walk traverses unannotated properties too — it just allocates nothing for them.
+
+**`@AuditedOperation` was dropped.** It was specified as a class annotation on an endpoint, but
+endpoints in this framework are not classes — they are `ApiHttpHandler(...)` factory calls producing
+a private data class, so there is nothing to annotate. Auditing non-disclosure operations is
+deferred; if it returns it belongs as a parameter on the handler factories, not as an annotation.
+
+**The model must be keyed by `Uuid`.** One disclosure row is written per record disclosed, which
+makes the identifier the most-written column in the system. A `Uuid` is sixteen bytes in every
+backend; a string key is larger and indexed poorly. Marking a class whose `_id` is absent or is not a
+`Uuid` fails at deploy.
+
+### 5.2 Interception: a new typed-output layer
+
+Disclosure cannot be observed from an `HttpInterceptor`: by the time one sees a response it is
+bytes, and no statement about *which fields* a client received is possible any more. So there is a
+third interception system alongside the HTTP and WebSocket ones:
 
 ```kotlin
-@Serializable
-public data class DisclosureRecord(
-    val requestId: String,
-    val tableId: Int,          // from the table registry
-    val fields0: Int,          // bits 0..31   } disclosed-field bitfield;
-    val fields1: Int,          // bits 32..63  } see 5.4 for indices,
-    val fields2: Int,          // bits 64..95  } 5.4.1 for why three Ints
-    val ids: List<String>,     // records disclosed with exactly this field set
-)
+public interface TypedOutputInterceptor {
+    public val name: String get() = this::class.simpleName ?: "anonymous"
+
+    context(runtime: ServerRuntime)
+    public suspend fun <T> outputProduced(request: Request<*>, serializer: KSerializer<T>, value: T)
+}
 ```
 
-A 10k-row query collapses from 10k records to typically one to three.
+Installed on `ServerBuilder` like any other interceptor and exposed as
+`ServerDefinition.typedOutputInterceptors`. Unlike the other two it is a flat list rather than a
+compiled chain: these observe, they do not wrap, so there is nothing to short-circuit and no
+order-dependent post-processing. `emitTypedOutput` returns immediately when nothing is installed, so
+a server that does not audit pays nothing per response.
 
-#### 5.3.1 Why three `Int`s and not `Long`, `ULong`, or `ByteArray`
+**Observation only.** An implementation may not alter the value. It *may* throw, and throwing aborts
+the send — which is how [5.6](#56-failure-behaviour-fail-closed) is enforced.
+
+**Installation is explicit, and that is the right granularity.** Nothing audits until a deployment
+includes the audit layers, and likewise nothing records conditions until it installs the
+table interceptor ([6.1](#61-extend-it-to-reads-every-condition-and-every-sort)). `@Audited` on a
+model does nothing on its own. The circumvention this design guards against is an *endpoint* built
+without auditing, not a deployment that chose not to audit — and once installed, no endpoint can
+escape either interceptor. A per-deployment switch is a decision made once, in the open; a
+per-endpoint one would be made a hundred times, silently.
+
+#### Coverage
+
+Every typed output funnels through exactly two places, which is what makes "no exceptions"
+achievable rather than aspirational:
+
+| Seam | Covers |
+|---|---|
+| `ApiHttpHandler.handle`, between the handler returning and `toTypedData` | every typed HTTP response, and every `/meta/bulk` sub-response, since those re-enter through `handleSubRequest` |
+| `ConnectionWrapper.send`, before `encoder.ws(...)` | every typed WebSocket frame, model update streams and multiplexed sockets included |
+
+**The one inherent exception**: raw `HttpHandler`s and signed file downloads emit bytes with no
+serializer. There is no typed value to inspect, so no field-level disclosure statement is possible
+there at any layer. This is a property of untyped endpoints, not a gap in the mechanism.
+
+The precomputed per-endpoint audit plan described in earlier drafts is not needed for the seam
+itself; it belongs to extraction (not yet built) as an optimisation.
+
+### 5.3 Record shape — one row per record disclosed
+
+**Rejected: grouping by field set.** An earlier draft made the unit a *(request, model, field-set)*
+group carrying a list of ids, collapsing a ten-thousand-row query into one or two rows. It was
+rejected on the grounds that settle it: this is an audit log, and "most of these records were
+disclosed the same way" is not a claim an audit log gets to make. Every disclosure is its own row.
+
+The volume is paid down inside the row instead:
+
+1. **Request-constant data lives once.** IP, principal, endpoint, and outcome are
+   properties of the request, recorded once in the layer-1 record and referenced by `requestId`.
+   Disclosure records never repeat them. The row's own instant is the exception, and it costs
+   nothing: `_id` is a version-7 UUID, so `DisclosureRecord.at` derives the moment of disclosure from
+   the key itself. That is worth having here rather than deferring to the request record, because a
+   socket's `requestId` names the socket rather than the phase that disclosed
+   ([5.8.2](#582-a-sockets-row-is-keyed-by-the-socket-not-by-the-phase-resolved)) — without it, a
+   disclosure on a long-lived connection can only be placed "sometime during this session".
+2. **The field set is two `Int`s, not four.** Itemising is opt-in ([5.1.1](#511-itemising-is-opt-in-disclosure-is-not)),
+   so a model reserves bits for the handful of fields that matter rather than for all of them.
+3. **The identifier is a `Uuid`, not a string.** Sixteen bytes in every backend, and indexable.
+   A list of stringly-typed ids is both larger and, in most engines, stored poorly — which is why
+   [`@Audited` is restricted to models keyed by `Uuid`](#51-marking), enforced at deploy.
+4. **No parent request id.** A sub-request's parentage is recorded once in the request log; carrying
+   it on every disclosure row would be storing the same join key twice.
+
+```kotlin
+@IndexSet(fields = ["modelId", "recordId"], name = "byRecord")
+@Serializable
+public data class DisclosureRecord(
+    override val _id: Uuid,    // v7: `at` derives the disclosure instant from it
+    @Index val requestId: Uuid,
+    val modelId: Int,          // from the registry
+    val fields0: Int,          // bits 0..31   } disclosed-field bitfield; see 5.4 for
+    val fields1: Int,          // bits 32..63  } indices, 5.3.1 for why Int columns
+    val recordId: Uuid,        // the _id of the record disclosed
+) : HasId<Uuid>
+```
+
+The two indexes are the two questions an investigation actually asks: *what did this request
+disclose* (`requestId`) and *who has seen this record* (`modelId, recordId`).
+
+`modelId` is keyed on the descriptor's **serial name**, not on a table name. A disclosure is
+observed with a serializer in hand and nothing else — the table a value came from is not knowable at
+that point, and an audited model need not be a table at all.
+
+#### 5.3.1 Why `Int` columns and not `Long`, `ULong`, or `ByteArray`
 
 **Because `Int` is the only type the framework can query bitwise.** The entire bitwise condition
-surface is `Condition<Int>` (`Condition.kt:254-275`):
+surface is `Condition<Int>`:
 
 | Condition | Semantics |
 |---|---|
 | `IntBitsClear(mask)` | all mask bits clear — `on and mask == 0` |
 | `IntBitsSet(mask)` | all mask bits set — `on and mask == mask` |
-| `IntBitsAnyClear(mask)` | at least one mask bit clear — `on and mask < mask` |
-| `IntBitsAnySet(mask)` | at least one mask bit set — `on and mask > 0` |
+| `IntBitsAnyClear(mask)` | at least one mask bit clear — `on and mask != mask` |
+| `IntBitsAnySet(mask)` | at least one mask bit set — `on and mask != 0` |
 
 There are no `Long`, `ULong`, or `ByteArray` equivalents. A `ULong` or `ByteArray` bitfield would be
 **storable but not queryable** — "which requests disclosed the SSN field?" would require a full scan
 and client-side filtering, which is unusable at audit-table volume.
 
-Layout: bit index `i` lives in column `i / 32` at bit `i % 32`. "Was field `i` disclosed" is
-`IntBitsAnySet(1 shl (i % 32))` on the corresponding column; a query spanning several fields is an
-`Or` of per-column conditions. All expressible in the existing condition set.
+Layout: bit index `i` lives in column `i / 32` at bit `i % 32`. `FieldBits` owns this arithmetic;
+`disclosedAll(indices)` and `disclosedAny(indices)` build one condition per column touched and
+combine them with `And` / `Or`.
 
-96 bits is the working ceiling. Extending later means adding a `fields3` column defaulting to `0`,
-which is automatically correct for historical records — absent means not disclosed.
+**64 bits is the working ceiling, and two columns is deliberate.** Adding a `fields2` column later
+defaults to `0`, which reads correctly for every historical record — absent means not disclosed — so
+the migration out is benign. Buying headroom up front would cost eight bytes on every row of the
+highest-volume table in the system to insure against a problem that is cheap to fix if it arrives.
 
-#### 5.3.2 Blocking prerequisite: the bitwise conditions are broken in every SQL engine
+#### 5.3.2 Blocking prerequisite: the bitwise conditions were broken in every engine
 
-**This must be fixed before the disclosure log is built, because the whole queryability argument in
-5.3.1 rests on it.**
+**Fixed in `service-abstractions`, in two rounds.** Both rounds were live correctness bugs affecting
+anyone using bitwise conditions, independent of audit logging.
 
-`SqlFieldSet.single(value)` returns `(column, maskLiteral)` (`SqlConditionMapping.kt:48`). Two of the
-four mappings use `col.first` (the column) where `col.second` (the mask literal) was intended:
+**Round one — the mask/column confusion.** `SqlFieldSet.single(value)` returns
+`(column, maskLiteral)`. Two of four SQL mappings compared against the column where the mask was
+intended, and MongoDB had all four All↔Any transposed:
 
 | Condition | Intended | Emitted by SQL + Postgres | |
 |---|---|---|---|
@@ -436,45 +565,74 @@ four mappings use `col.first` (the column) where `col.second` (the mask literal)
 | `IntBitsAnyClear` | `col & mask < mask` | `col & mask < col` | ✗ |
 | `IntBitsAnySet` | `col & mask > 0` | `col & mask > 0` | ✓ |
 
-Sites: `SqlConditionMapping.kt:263` and `:271`; `ConditionMapping.kt:265` and `:289` (Postgres
-repeats the same error). Failing case: `field = 0b0011`, `mask = 0b0001`. `IntBitsSet` should be
-true; the emitted `0b0001 = 0b0011` is false.
+The in-memory `invoke()` implementations were correct, so any test running against an in-memory
+table passed while the real database returned different rows. The fix shipped with conformance tests
+that run the full truth table against **each real engine**.
 
-MongoDB (`bson.kt:151-154`) has a different bug — all four are transposed All↔Any:
+**Round two — the sign bit.** Found while testing `FieldBits`, and *not* catchable by round one's
+tests, because those compare each engine against the in-memory reference and the reference itself
+was wrong:
 
-```kotlin
-is Condition.IntBitsAnyClear -> into.sub(key)["\$bitsAllClear"] = mask   // should be $bitsAnyClear
-is Condition.IntBitsAnySet   -> into.sub(key)["\$bitsAllSet"]   = mask   // should be $bitsAnySet
-is Condition.IntBitsClear    -> into.sub(key)["\$bitsAnyClear"] = mask   // should be $bitsAllClear
-is Condition.IntBitsSet      -> into.sub(key)["\$bitsAnySet"]   = mask   // should be $bitsAllSet
-```
+- `IntBitsAnySet` was `on and mask > 0`. Any mask containing bit 31 is a **negative** `Int`, so
+  `on and mask` is negative when the bit is set and the comparison returns false. `disclosedAny` on
+  field index 31, 63, 95, or 127 silently matched nothing.
+- `IntBitsAnyClear` was `on and mask < mask`, wrong the same way.
 
-The in-memory `invoke()` implementations in `Condition.kt` are all correct, so any test running
-against an in-memory table passes while the real database returns different rows. That is almost
-certainly how this survived, and it means the fix must come with **conformance tests that run against
-each real engine**, not in-memory ones. Cassandra's `ConditionNormalizer.kt:101-104` negation table is
-logically correct and needs no change.
+Both are now stated as exact negations — `!= 0` and `!= mask` — in the reference and in the SQL and
+Postgres emission. MongoDB now passes the mask as a **list of bit positions** rather than a number,
+because Mongo rejects a negative numeric bitmask outright.
 
-This is a live correctness bug in `service-abstractions` affecting anyone using bitwise conditions
-today, independent of audit logging, and should be reported and fixed there on its own merits.
+The lesson is recorded in a new `BitwiseConditionSemanticsTest`: a conformance test that compares
+drivers to a reference can only catch a driver that disagrees with the reference, never a reference
+that is wrong. The semantics need their own test, stated against a literal definition.
 
-### 5.4 The field registry — append-only, not versioned
+Cassandra's `ConditionNormalizer` negation table is logically correct and needed no change in either
+round.
+
+> **Version coordination:** the round-two fix lives in `service-abstractions` and is not yet in a
+> release `lightning-server` depends on. Until the version is bumped, field indices 31, 63, 95, and
+> 127 are storable but not queryable at runtime.
+
+#### 5.3.3 Partial queries must carry `_id` (resolved)
+
+One row per record means extraction needs each item's `_id`, and a `Partial<T>` can omit it.
+Resolved in two places, because one alone is not enough:
+
+- **`ModelRestEndpoints.queryPartial` forces `_id` into the requested field set** for audited models,
+  so ordinary use simply works rather than failing.
+- **Extraction fails closed** on an audited instance that arrives without an `_id`. `ModelRestEndpoints`
+  is circumventable — a custom endpoint can call `findPartial` directly — so the guarantee has to live
+  at the seam. The first is convenience on the common path; this is the actual guarantee.
+
+### 5.4 The field registry — append-only, and the sole record of what a bit means
 
 A bitfield keyed to declaration order is fragile: inserting or reordering a property shifts every
 bit, and all historical records silently change meaning. Storing a schema version per record fixes
 correctness but adds a lookup to every read and a version bump to every model change.
 
-**Use an append-only field registry instead.** Each field of each audited model is assigned a
-permanent bit index the first time it is seen; indices are never reused and never shift.
+**Use an append-only registry instead**, held in the database. Each field of each audited model is
+assigned a permanent bit index the first time it is seen; indices are never reused and never shift.
 
 ```kotlin
 @Serializable
+public data class AuditModelRegistration(
+    override val _id: String,   // descriptor serial name
+    val modelId: Int,
+) : HasId<String>
+
+@Serializable
 public data class AuditFieldRegistration(
-    val tableId: Int,
-    val fieldName: String,
+    override val _id: String,   // "$modelId/$fieldPath"
+    val modelId: Int,
+    val fieldPath: String,
     val bitIndex: Int,
-)
+) : HasId<String>
 ```
+
+Assignment runs as a **pre-deploy task**, once per deploy rather than at startup, so instances never
+race to allocate the same index. It is convergent: existing assignments are never altered, so
+re-running it is a no-op. The snapshot is loaded once per process, which is correct because
+assignments only change during a deploy.
 
 Consequences:
 
@@ -482,13 +640,50 @@ Consequences:
 - Adding or reordering fields never invalidates existing records.
 - A per-record schema reference becomes unnecessary, saving bytes in the highest-volume table.
 
-Registration happens at startup from the serializer descriptors. A **removed** field keeps its index
-permanently reserved — the registry is append-only, so a field is retired rather than deleted, and
-records that referenced it remain interpretable.
+**A rename allocates a new bit, and that is the whole story.** An earlier draft proposed an
+`@AuditRetired` marker plus a startup check that failed loudly when a registered field vanished from
+the descriptor. That was rejected, correctly: the registry table *is* the retirement record. A field
+that disappears simply stops being written; its row remains, so records written before the rename
+still resolve to the field they actually disclosed. Nothing that was written in the past changes
+meaning, which is the only property that matters. The cost is that a query for a semantic field
+after a rename must consider both bits — a query-time concern, not a correctness one.
 
-Startup must fail loudly if a registered field name is absent from the current descriptor *and* has
-not been explicitly marked retired, so that a rename is caught rather than silently allocating a new
-bit and orphaning history.
+#### 5.4.1 Nested fields
+
+Bit indices are assigned to **dotted paths**, not property names. The walk descends through
+everything, but only annotates what was asked for:
+
+| Shape | Rule | Example path |
+|---|---|---|
+| Property marked `@Audited` | a path | `ssn` |
+| Property not marked | no path, but still descended into | — |
+| Nested `@Audited` class | **stop** — it produces its own record under its own `modelId` | `doctor` |
+| List/Set | descend into the element with `[]` | `phones[].number` |
+| Map | descend into the value with `{}` | `tags{}.label` |
+| Sealed | descend per subclass | `payment(Card).last4` |
+| Open polymorphic, contextual | nothing beneath — the concrete type is not known statically | `blob` |
+
+Descending regardless of annotation is what lets `@Audited val street: String` inside a plain
+`Address` become `address.street` on the record holding it, without `Address` itself having to be
+audited or `address` itself having to be annotated.
+
+Annotating a container *as well as* its leaves is what distinguishes "no address was disclosed" from
+"an address was disclosed, all of whose fields held defaults" — worth a bit when that distinction
+matters, and skippable when it does not.
+
+Three failures fall out, all deliberate:
+
+- A model that runs out of bits **fails at deploy**. The message names how many of the 64 are already
+  assigned and says that indices are never reused, so renamed and removed fields still hold theirs —
+  which is usually the surprising part. The remedies are to drop `@Audited` from properties that do
+  not need itemising, or to mark a nested *entity* type `@Audited` so it becomes its own record.
+  A **warning fires at 75% of capacity**, because running out at deploy time is the worst moment to
+  discover it and the ceiling is approached gradually rather than all at once.
+- An `@Audited` class with no `Uuid` `_id` **fails at deploy** — a disclosure record that can name no
+  record is close to worthless, and a string key is too wide for this table.
+- An audited model reaching the encoder with no registry entry **fails the request**. Registration
+  scans every endpoint input/output descriptor, which covers everything but a contextual serializer
+  resolving to an unregistered audited type. That case should be loud, not silent.
 
 ### 5.5 Field presence semantics
 
@@ -500,65 +695,213 @@ question, and it is measurable at the typed layer without reaching below it. The
 consequence is that a field whose true value equals its default is indistinguishable from a masked
 one. That is acceptable — in both cases the client learned nothing beyond the default.
 
+### 5.5.1 The layers are independently includable (resolved)
+
+`AuditCore` carries the request log and the bit registry; `DisclosureLog`, `DataAccessLog` and
+`AuthEventLog` and `MutationLog` are separate modules a deployment includes or does not. There is
+deliberately **no all-in-one bundle**, because a helper that installs everything hides which layers a
+deployment is paying for, and the data access and mutation logs are far too voluminous to acquire by
+reflex. Naming each layer at its point of inclusion is also what
+makes the set reviewable.
+
+The reason is volume. The data access log writes a row per *query* rather than per disclosure, so on a
+read-heavy model it dwarfs every other layer combined — and since these tables sit on fail-closed
+write paths, including a layer is also taking on a dependency for availability, not just for storage.
+A deployment that wants disclosure auditing should not be made to pay either cost for a layer it did
+not ask for. This mirrors the split every cloud provider already makes: GCP separates always-on Admin
+Activity logs from Data Access logs that are off by default and billed.
+
 ### 5.6 Failure behaviour: fail-closed
 
 If the audit write fails, the request fails. For audited models the disclosure must not happen unless
-it was recorded.
+it was recorded. This is why the interception point sits *before* serialization: throwing there
+prevents the body from ever being built.
 
-This is consistent with the framework's fail-fast stance, but it has a hard architectural
-consequence: **the audit sink is in the availability path**, so it cannot be a network call. It must
-be a local append-only file with fsync, with a separate shipper draining it. This is the same
-durability design the external capture layer uses.
+**Confirmed to include the database sink.** The queryable log is a database table, so an audit
+database outage is an outage for audited endpoints. That is the intended trade.
 
-Configurable, defaulting to fail-closed whenever any `@Audited` model is registered.
+**Per layer, and not configurable (resolved).** Disclosure and data access fail closed: the thing they
+guard must not happen unrecorded. Authentication events fail open, because the event has already
+happened by the time it is reported and throwing would replace a clean "your login failed" with an
+unrelated error while losing the original reason. The request log's *completion* write cannot fail
+closed at all — the response is already produced.
 
-### 5.7 Integrity
+There is deliberately **no fail-open switch**. The happy-path cost is identical either way, so nothing
+is bought by the option; what it would cost is real. A security control with an off switch gets
+switched off during the first incident and stays off, and it makes "was this deployment fail-open at
+the time?" a question whose answer lives in configuration rather than in the log. The cases where
+fail-open is genuinely right are handled structurally instead: auth events hard-code it, targeted
+bypasses go through `dangerouslyDirectTable()` where they are greppable, and a deployment that wants
+no auditing simply does not include the layer.
 
-Records are hash-chained: each carries the hash of its predecessor, with per-instance sequence
-numbers. This makes both tampering and **truncation** detectable — truncation being the realistic
-attack, since an append-only sink cannot be edited but can be silently stopped.
+### 5.7 Integrity: out of scope here
 
-### 5.8 Anchoring: extending external assurance to channels the proxy cannot see
+Hash chaining and tamper-evidence belong to the **emergency total-log**, a separate system outside
+Lightning Server. It exists for the case where these logs are later found insufficient or bypassable;
+it is not a component of this design and nothing in this repository implements it.
 
-This is the mechanism that makes streaming audited models over WebSockets acceptable, and it
-generalises to any disclosure the external capture layer cannot observe.
+#### Where the boundary actually is
 
-The problem: layer 2 is written by the application, so on its own it carries no defence against the
-application operator rewriting history. That defence is exactly what the external capture layer
-provides — but the proxy cannot see WebSocket frames (see
-[section 10](#10-out-of-scope-external-capture-layer)), so WS disclosures get layer-2 assurance only.
+The system's integrity has always rested on one thing: **whether the server does what it says it
+does.** That was true before any of this was written and no amount of in-process machinery changes it.
+Code running in the server can always lie about what the server did.
 
-The proxy cannot see WS frames, **but it can see HTTP requests.** So:
+But the boundary is not quite "inside the server, therefore nothing" — it is *who controls the
+server*, and there are two different adversaries hiding in that:
 
-> Periodically emit the layer-2 hash-chain head as an ordinary HTTP request through the proxy.
+| Adversary | In-process chain | External capture |
+|---|---|---|
+| Can write the audit tables, cannot deploy code (a DBA, a leaked DB credential, an operator editing rows after the fact) | **Helps, if built properly** — an HMAC keyed from a secret store the DB principal cannot read makes silent edits detectable | Helps |
+| Can run code on the server (deploy access, RCE, a malicious change) | **Useless** — they hold the key and the code, and can recompute anything | Helps, but see below |
 
-The proxy captures that request into the un-tamperable store like any other. The chain head is a
-cryptographic commitment to every layer-2 record written before it — including the WebSocket ones the
-proxy never saw. Once a head is anchored, the application cannot retroactively alter or delete any
-record preceding it without producing a chain that fails to reproduce an already-captured head.
+That first row is narrower than it looks, and the "if built properly" is carrying most of the weight.
+The key has to be readable by the server, since the server computes the chain — so it lives wherever
+the application's runtime secrets live, and the defence exists only where some principal holds
+database write *without* that secret. That separation is a deployment property the framework can
+neither create nor verify. It collapses entirely against code execution, against anyone who can read
+the app's environment, and against a vault compromise that yields both credentials.
 
-Assurance this does and does not provide:
+Even where it holds it is **partial**: an HMAC chain catches an edited row and a deletion from the
+middle, but not truncation — delete everything after time T and the surviving prefix verifies clean,
+because nothing in process knows how long the chain should have been. The DBA who edits one row to
+cover a specific access is caught; the one who drops the tail is not.
 
-- **Does** prevent retroactive tampering, deletion, and truncation of WS audit records — the same
-  guarantee the external layer gives for HTTP, bounded by the anchor interval.
-- **Does not** prevent fabrication at write time: an already-compromised application can write a
-  false record and anchor it honestly. Layer 1's direct capture is stronger in that specific respect,
-  which is why it remains the backstop for HTTP.
+The version actually reachable in process is worse than the narrow case anyway: an unkeyed hash,
+stored in the database it protects, recomputable by exactly the adversary it is meant to catch — while
+adding a second write to the path of every audited read, including privileged internal ones, where a
+hash failure could halt a schedule tick or a startup task.
 
-Anchor interval is a tradeoff between request overhead and the size of the retroactively-editable
-window; the window is bounded by the interval, so a short interval on a low-volume channel is cheap.
-The interval belongs in configuration.
+**So the conclusion is not "integrity is impossible in-process" but that the in-process version is a
+bad trade.** For the same adversary, the better answer is prevention rather than detection: restrict
+who can write the audit tables, and make the store append-only at the infrastructure level where that
+is available. That stops the tampering instead of detecting a subset of it afterwards, costs nothing
+on the audited path, and adds no subsystem to get wrong. Where prevention is not achievable, the
+answer is the emergency total-log ([section 10](#10-out-of-scope-external-capture-layer)), outside the
+server, not a chain inside it.
 
-Because the anchor is just an HTTP request, this needs no proxy support beyond what layer 1 already
-does, and no WebSocket frame parsing anywhere.
+### 5.8 The request record — what `requestId` points at
+
+Every disclosure references a `requestId` and repeats nothing else, so a table holding what that id
+*means* is not optional; without it the reference dangles.
+
+`AccessLogInterceptor` cannot be that table. It writes log lines, and it is deliberately fail-open —
+"the access log must never be the reason a request fails" — which is the opposite of what a
+fail-closed log needs from its referent. The audit package carries its own:
+
+```kotlin
+@Serializable
+public data class RequestRecord(
+    override val _id: Uuid,            // the execution id itself: no extra column, join on the PK
+    val parentRequestId: Uuid? = null,
+    val rootExecutionId: Uuid,         // the head of this row's causal chain
+    // no `at` column — see below
+    val principal: String? = null,
+    val sourceIp: String,
+    val endpoint: String,              // the route pattern, not the literal target
+    val method: String,
+    val outcome: String? = null,       // null while the request is still in flight
+    val durationMs: Long? = null,
+    val engineRequestId: String? = null, // the gateway's own id, for joining back to its logs
+    val upstreamRequestId: String? = null,
+) : HasId<Uuid>
+```
+
+A duplicate `_id` **fails the request**. A repeated trusted request id means a misconfigured proxy is
+about to merge two principals' activity under one identifier, which is exactly what
+[3.2](#32-sourcing-and-the-trust-rule)'s trust rule exists to prevent, so it must be loud.
+
+**The timestamp is in the id, not a column.** Every execution id is a version-7 UUID minted at the
+instant the execution began (see `execution-context-refactor.md` §2.6), so `_id` embeds its own mint
+time and `RequestRecord.at` is a derived property that recovers it. This is why the id is v7 at all:
+it orders the append-mostly log by insertion time (range queries over the PK instead of an indexed
+copy) and keeps the row's "when" permanently consistent with its id. The price is whole-millisecond
+precision only. Ids that were *adopted* from a trusted proxy (which may be any version) carry no
+timestamp and degrade to the epoch rather than misreporting — honest about "unknown."
+
+#### 5.8.1 Write ordering (resolved)
+
+Disclosures are written *during* a request, but outcome and duration are only known at the end, so
+the ordering has to be chosen rather than assumed.
+
+**Resolved: write the record at request start, update it at completion.** Two writes per request.
+The referent always exists before anything references it, and the same shape works for a WebSocket,
+where the record is written at connect and updated at close. Requests in flight are visible for free.
+
+Rejected: buffering disclosures and writing everything at the end. It is tempting for HTTP, where the
+response is not sent until the end anyway — but it is wrong for WebSockets, whose frames are
+delivered as they are sent and whose connections can live for hours, leaving delivered data
+unrecorded in memory. A per-protocol split was not worth two code paths.
+
+Disclosures within one request batch into a single `insert`, so the per-request cost is two writes
+plus one.
+
+#### 5.8.2 A socket's row is keyed by the socket, not by the phase (resolved)
+
+Since the [execution-context refactor](execution-context-refactor.md), each of a WebSocket's five
+lifecycle phases is a separate execution with its own `executionId` — on a serverless engine they are
+literally separate invocations. The record for a socket is nonetheless keyed by `Initiator.WebSocket.socketId`.
+
+It has to be, for [5.8.1](#581-write-ordering-resolved) to work at all: the row is written at connect
+and updated at close, and those are two different executions. A row keyed by either one's
+`executionId` could not be found by the other, and every socket record would sit at `outcome = null`
+forever.
+
+**What that gives up.** `messageFromClient` and `messageFromSubscription` are executions that can
+disclose. With socket-keyed rows their disclosures point at the socket, so the audit answer for a
+long-lived connection is "sometime during this session" rather than "in response to this message".
+
+**Why it is not a regression.** Before the refactor a socket's correlation id was deliberately
+constant for the socket's whole lifetime, so disclosures on a socket already attributed to the
+session rather than to a frame. Socket-keying reproduces that exactly.
+
+**Resolved: keep socket-keyed rows, and carry the execution id on the records instead.**
+
+The question was whether per-phase attribution justified a `RequestRecord` row per phase execution —
+for a chatty socket, a row per client message, against a fail-closed write path. It does not, because
+the precision that was actually wanted can be had without those rows. Both record types written
+during a socket's life now carry `executionId` alongside `requestId`:
+[`DataAccessRecord`](#62-record-shape-and-installation-resolved) from the outset, and any record that
+needs it can follow. `requestId` still names the socket, so the join to the request record is
+unchanged and one row per socket remains; `executionId` names the phase, so "which message caused
+this" is answerable by reading the record rather than by multiplying request records.
+
+`DisclosureRecord` does **not** yet carry it, and that is the remaining gap: a disclosure on a
+long-lived socket can still only be placed within the session, though its own v7 `_id` now timestamps
+it to the millisecond, which in practice identifies the message. Adding the column is 16 bytes on the
+highest-volume table in the system and should be weighed against that.
 
 ### 5.9 Sinks
 
 The audit stream is a typed event stream with pluggable sinks, not a single log. Auditors need to
 *query*; an encrypted object store is unqueryable by design. Expect at minimum a queryable sink
-(Postgres or a SIEM) for investigation alongside the tamper-evident sink as system of record.
+(Postgres or a SIEM) for investigation alongside the tamper-evident total-log as system of record.
+
+**Shipped:** the database sink, written by `DisclosureLogInterceptor` straight into the
+`DisclosureRecord` table. It catches nothing, so an extraction that cannot resolve a model, a record
+with no `_id`, or a sink that will not take the write all abort the send before the value is
+serialized.
+
+### 5.10 How extraction works
+
+`DisclosureExtractor` walks the outgoing value with its own serializer, as a custom `Encoder`. Using
+the serializer rather than reflection means what is observed is exactly what the client will receive,
+and that a model cannot slip through a shape the walk does not understand.
+
+Three things are worth knowing about it:
+
+- **Field presence is judged on the value, not on the format.** A default is a default whether or not
+  the encoder in use would have elided it, which keeps [5.5](#55-field-presence-semantics) true
+  regardless of content negotiation.
+- **Paths are resolved once per (model, position, descriptor) and cached.** A list of ten thousand
+  records enters the same descriptor at the same path ten thousand times; without the cache every
+  field of every record would rebuild its path string and hash it against the registry.
+- **`Partial` is unwrapped explicitly.** `PartialSerializer` builds a descriptor named for `Partial`
+  that carries none of the model's class annotations, so `@Audited` is invisible on it. The extractor
+  reads `PartialSerializer.source` instead. Without that, a partial query would have disclosed an
+  audited model with no record at all — the exact hole this design exists to close.
 
 ---
+
 
 ## 6. Layer 3: the data access log
 
@@ -568,11 +911,119 @@ never reach a user.
 
 One architectural advantage worth exploiting: `Modification<T>` is a first-class serializable value
 in this stack. Logging `(condition, modification, affected ids)` is far more compact than before/after
-images and strictly more informative about intent. Reads at this layer, where enabled, should record
-the `Condition<T>` for the same reason.
+images and strictly more informative about intent.
 
-Operations that are neither model reads nor model writes are covered by `@AuditedOperation`
-([section 5.1](#51-marking)) and, as a backstop, by the action log.
+### 6.1 Extend it to reads: every condition and every sort
+
+**This is what closes the aggregation hole, and it is a prerequisite rather than a refinement.**
+
+`groupCount` and `groupAggregate` return `Map<String, _>` **whose keys are field values**.
+`groupCount(condition = Always, groupBy = ssn)` returns the distinct SSNs — not an inference channel
+but a bulk read, and one that produces no disclosure record at all, because there is no record to
+attach it to. `count` and `aggregate` are oracles in the ordinary way: `count(ssn eq "X")` answers
+1 or 0.
+
+Restricting aggregation does not close this. **`find` is the same oracle** — `find(ssn eq "X")`
+returning nothing discloses nothing under the field-presence rule ([5.5](#55-field-presence-semantics))
+and tells an attacker the same bit. A sort is an oracle too: ordering plus `skip` walks values
+without ever matching one.
+
+**Resolved: record the `Condition<T>` and the sort for every query against an audited model**, at the
+database layer, alongside the mutation recording that already lives there. Aggregation then stops
+being a special case — `groupCount` passes its condition and its group-by path through the same
+choke point as everything else, and a binary search appears as thousands of recorded queries whose
+conditions walk a value: detectable and attributable.
+
+The database layer is the right level for this specifically because it is *not* the typed layer. It
+sees every query whoever issued it, including the privileged internal reads the typed layer never
+observes — see the table in [2.1](#21-why-the-typed-layer-and-not-the-database-layer-for-disclosure).
+
+**Known gap, accepted:** recording a condition records that a bulk read happened, not what came back.
+For `groupCount` by a sensitive field the log says "someone enumerated this field", without the
+values or any record ids — because by construction there are none to name. A deployment that cannot
+accept that should deny the grouping through permissions rather than expect the framework to forbid
+it.
+
+Two things that effort has to settle:
+
+- ~~**`requestId` must be reachable from the database layer**~~ — **no longer a prerequisite, and the
+  proposed signature change is unnecessary.** Since the execution-context refactor a `ServerRuntime`
+  carries `initiator.executionId`, and every seam below already runs in one. Nothing needs to travel
+  with the table.
+- **The insertion point already exists and is unused.** `ModelInfo` declares a `log` decorator slot
+  (`typed/.../ModelInfo.kt:103`):
+
+  ```kotlin
+  log: context(ServerRuntime) AuthAccess<USER>?.(Table<T>) -> Table<T> = { it },
+  ```
+
+  It defaults to identity, nothing in either repository passes it, and it is applied in **both**
+  `table(auth)` and `table()` — so a decorator installed here sees the privileged internal reads that
+  [2.1](#21-why-the-typed-layer-and-not-the-database-layer-for-disclosure) requires this layer to
+  cover, as well as user-facing ones. It sits below permissions, which is where a recorder of
+  *attempted* access belongs.
+
+  Consequence for sizing: this is a `Table` decorator in `lightning-server`, wrapping the read and
+  write methods and recording `(condition, sort, modification)`. **No `service-abstractions` change
+  is required** — `Table` is the interface, and the decorator lives on this side of it. What is still
+  unspecified is the record shape.
+- **Scope and failure mode.** Recording every query on every model would be a firehose; this should
+  be scoped to audited models, and should be fail-closed there for the same reason disclosure is.
+
+Operations that are neither model reads nor model writes rely on the action log for now, since
+`@AuditedOperation` was dropped ([section 5.1](#51-marking)).
+
+### 6.2 Record shape and installation (resolved)
+
+```kotlin
+@Serializable
+public data class DataAccessRecord(
+    override val _id: Uuid,               // v7: `at` derives the query's instant from the key
+    @Index val requestId: Uuid,           // joins to RequestRecord, socket-keyed like a disclosure
+    @Index val executionId: Uuid,         // the precise execution, which requestId blurs for sockets
+    @Index val modelId: Int,              // same registry as DisclosureRecord
+    val operation: DataAccessOperation,
+    val condition: String,                // serialized Condition<T>
+    val sort: String? = null,             // serialized List<SortPart<T>>, where the operation takes one
+    val modification: String? = null,     // serialized Modification<T>, for writes
+    val groupBy: String? = null,          // the field path an aggregation grouped on
+) : HasId<Uuid>
+```
+
+**Why the query is stored as text.** `Condition<T>` and `Modification<T>` are serializable, but only
+against the model's own serializer, and this table holds rows for every audited model at once. A
+generic record type would mean a table per model. The condition is serialized with the model's
+serializer at write time and stored as JSON, which stays readable and greppable and gives up only
+the ability to query *inside* a recorded condition — an investigation reads these rows, it does not
+join on their contents.
+
+**Both ids are recorded.** `requestId` matches [5.8](#58-the-request-record--what-requestid-points-at)
+so a query joins to the same request record as a disclosure — which for a socket names the socket.
+`executionId` is the phase that actually issued the query. Carrying both costs 16 bytes and recovers
+the per-phase precision [5.8.2](#582-a-sockets-row-is-keyed-by-the-socket-not-by-the-phase-resolved)
+gives up, without a `RequestRecord` row per phase.
+
+**Installation is the `log` slot, and scope is the registry.** The decorator is passed as
+`ModelInfo`'s `log` parameter (see 6.1), and no-ops for any model the audit registry does not know —
+so passing it uniformly is safe, and only audited models generate rows. This keeps the "which models
+are audited" decision in exactly one place, the `@Audited` annotation, rather than splitting it
+between the annotation and a list of decorated tables.
+
+**An audited model needs an endpoint before it can be logged here — a real limitation.** Model ids
+are assigned by scanning **endpoint serializers**, never tables (scanning tables made disclosure
+coverage look complete when it was not). The decorator keys off the
+`@Audited` annotation and then resolves the id, which *throws* when there is none. So an audited model
+that no endpoint's serializer can reach has no id, and its reads fail rather than going unrecorded —
+correct as a fail-closed rule, but it means a model that is only ever read internally cannot be
+data-access-logged until something makes it reachable. Resolving this properly means either a second
+registration space for table-only models or an explicit opt-in list on the module; **not decided**.
+
+**Fail-closed, with the same reasoning as 5.6.** A read of an audited model whose query cannot be
+recorded does not happen. That makes an outage of the audit database an outage for reads of audited
+models, which is a strictly larger blast radius than the disclosure log's — that one only fails
+requests that actually disclose, while this one fails privileged internal reads too, including ones
+made during startup or a schedule tick. **This is the single riskiest thing in this plan** and is
+called out again in the deployment notes.
 
 ---
 
@@ -650,8 +1101,8 @@ logging"). Why each apparent seam fails:
 
 ### 7.3 Design
 
-Auth events are their own record type, sharing the request ID, hash chain (5.7), anchoring (5.8), and
-sinks (5.9) with the disclosure log — but not its shape, since they are not model disclosures.
+Auth events are their own record type, sharing the request ID and sinks (5.9) with the disclosure
+log — but not its shape, since they are not model disclosures.
 
 Minimum event set, each carrying request ID, timestamp, source IP, user agent, outcome, and both
 acting and target principal where they differ:
@@ -667,6 +1118,27 @@ Two ordering notes for implementation. **Failure reasons already exist** as the 
 `SessionManager.kt:357-388` — that is a direct map to the failure-reason enum, not new analysis.
 And **`sessionInfo` gaining a `signals` parameter is the cheapest first step**, since it makes
 session creation, update, and termination observable without touching sealed methods.
+
+#### 7.3.1 The seam, and one deliberate asymmetry
+
+`AuthEventReporter` lives in `core` rather than in `sessions` or `audit`, because those two do not
+depend on each other and should not have to: `sessions` raises events, an audit module installs a
+reporter that records them, and a deployment with no reporter installed pays a null check. Events are
+passed as strings so `core` does not own the taxonomy.
+
+**Reporters must not throw, and that is a real weakening.** The disclosure and data access logs gate
+*disclosure* — the guarded thing must not happen unless it was recorded, so they fail closed. An
+authentication event has already happened by the time it is reported, and is usually reported from a
+path that is itself rejecting something; throwing there would replace a clean "your login failed"
+with an unrelated server error and lose the original reason. So `AuthEventLogReporter` logs and
+swallows write failures. The consequence, stated plainly: **an attacker who can make the audit
+database unavailable can make authentication events go unrecorded while authentication keeps
+working.** That is the opposite of the guarantee the other two layers give, and it is a choice, not
+an oversight.
+
+**Coverage so far is partial.** The seam exists and rejected authentications report through it. The
+remaining events in the list above — issuance, refresh, termination, per-method proof results,
+masquerade — are not yet raised; the reporter will record them as soon as the call sites do.
 
 The three adverse findings in 7.1 should be fixed alongside: session rows want `delete =
 Condition.Never` with soft-termination only, backup-code use wants a soft-disable with a timestamp
@@ -726,35 +1198,85 @@ Sequenced so each step is independently shippable and testable, and so prerequis
    `Request` base class, `requestIdentity` resolution with the trust rule, `requestIdHeader` on the
    Ktor/Netty/JDK settings, API Gateway's own IDs on AWS, and `subRequest`/`subConnection` for
    derived requests. Covered by `core/src/test/.../http/RequestIdentityTest.kt`.
-2. **Multiplex dispatch fix** ([section 4.1](#41-metabulk-bypasses-the-entire-interceptor-chain)) —
-   correctness bug in security controls beyond logging. Includes `InterceptorScope`.
-3. **WebSocket permission staleness** ([section 8](#8-websocket-permission-staleness)) — live
-   permissions bug.
-4. **Access log completeness** ([sections 4.2–4.3](#42-websockets-are-not-access-logged-at-all)) —
-   websocket coverage, post-hoc emission with outcome.
-5. **Fix the bitwise conditions in `service-abstractions`**
-   ([section 5.3.2](#532-blocking-prerequisite-the-bitwise-conditions-are-broken-in-every-sql-engine))
+2. ~~**Multiplex dispatch fix**~~ ([section 4.1](#41-metabulk-bypasses-the-entire-interceptor-chain))
+   — **DONE.** Correctness bug in security controls beyond logging. Shipped as a split of the
+   interceptor types rather than the rejected `InterceptorScope` enum.
+3. ~~**WebSocket permission staleness**~~ ([section 8](#8-websocket-permission-staleness)) —
+   **DONE.**
+4. ~~**Access log completeness**~~ ([sections 4.2–4.3](#42-websockets-are-not-access-logged-at-all))
+   — **DONE.** WebSocket coverage, post-hoc emission with outcome.
+5. ~~**Fix the bitwise conditions in `service-abstractions`**~~ — **DONE, twice.**
+   ([section 5.3.2](#532-blocking-prerequisite-the-bitwise-conditions-were-broken-in-every-engine))
    — blocks the disclosure log's queryability, and is a live bug worth fixing on its own merits.
    Must ship with per-engine conformance tests, not in-memory ones.
-6. **Disclosure log** ([section 5](#5-layer-2-the-disclosure-log-audited)) — the largest piece.
-   Field registry and record shape first, then interception, then hash chaining, then sinks.
-7. **Anchoring** ([section 5.8](#58-anchoring-extending-external-assurance-to-channels-the-proxy-cannot-see))
-   — small once the chain exists, and it is what lets audited models stream over WebSockets.
-8. **Data access log alignment** ([section 6](#6-layer-3-the-data-access-log)) — extend existing
-   write auditing to record conditions, share the record format.
+6. ~~**Disclosure log**~~ ([section 5](#5-layer-2-the-disclosure-log-audited)) — **DONE.** Typed-output
+   interception, the marker, the record shape and bit registry, the recording `Encoder`, the
+   [`RequestRecord`](#58-the-request-record--what-requestid-points-at) table with its two-write
+   lifecycle, the fail-closed database sink, and the `_id`-in-partials rule from 5.3.3. Included as
+   `AuditCore`.
+7. ~~**Data access log: conditions and sorts**~~ ([section 6.1](#61-extend-it-to-reads-every-condition-and-every-sort))
+   — **DONE**, to the record shape and installation in 6.2. Two limitations recorded there: an
+   audited model that no endpoint's serializer reaches has no id and its reads fail rather than going
+   unrecorded, and fail-closed here covers privileged internal reads so its blast radius exceeds the
+   disclosure log's. Originally described as an extension of existing write auditing, which
+   **did not exist**: Section 6 opens by asserting "write auditing already
+   exists at `ModelPermissionsTable`". Verified 2026-09: it does not. That class enforces permissions
+   and records nothing; `simpleSignals.kt` provides generic `postCreate`/`postChange`/`postDelete`
+   decorators, but nothing in either repository writes an audit record from the database layer. So
+   this step is a build of the recording layer for reads *and* writes, not an extension of an
+   existing one, and no record shape is specified anywhere yet.
+
+   The `requestId`-reachability blocker below is, however, largely resolved: `ModelInfo.table()` is
+   already `context(ServerRuntime)`, and since the execution-context refactor a `ServerRuntime`
+   carries `initiator.executionId`. The remaining question is placement — `ModelPermissionsTable`
+   lives in service-abstractions and cannot see Lightning Server types, so the recording decorator
+   belongs on this side.
+   — moved ahead of the total-log, because it is what closes the aggregation and oracle channels
+   rather than a later refinement. Extends the existing write auditing at the database layer to
+   record every condition and sort applied to an audited model.
+8. ~~**Total-log: hash chaining and anchoring**~~ ([section 5.7](#57-integrity-out-of-scope-here))
+   — **removed from scope.** The emergency total-log is a separate system outside Lightning Server,
+   reached for only if these logs prove insufficient or bypassable. Nothing here implements it.
 9. **Auth event log** ([section 7](#7-layer-4-the-authentication-event-log)) — the largest greenfield
-   piece, since nothing exists to extend. Start with the two cheap unblocking changes: give
-   `sessionInfo` a `signals` parameter ([7.2](#72-no-usable-extension-point-exists)), and turn the
-   existing debug `println` failure strings into a failure-reason enum
-   ([7.3](#73-design)). The three adverse findings in
-   [7.1](#71-survey-findings) — hard-deletable session rows, self-destroying backup-code evidence,
-   and the fabricated `"test"` IP — are independently worth fixing and can ship ahead of the rest.
+   piece, since nothing exists to extend. **Groundwork done; the event log itself is not.** Both
+   cheap unblockers have shipped: `sessionInfo` now takes a `signals` parameter
+   ([7.2](#72-no-usable-extension-point-exists)), and the debug `println` failure strings are now the
+   `AuthFailureReason` enum behind a single seam ([7.3](#73-design)). All three adverse findings in
+   [7.1](#71-survey-findings) are fixed: session rows are no longer deletable (termination remains),
+   a redeemed backup code is retained and marked rather than deleted, and the fabricated `"test"` IP
+   and empty user agent are no longer recorded. What remains is the event record type, its sinks,
+   and emission at each of the events listed in [7.3](#73-design).
+
+   Correction found while doing that work: 7.2 says the table-decoration approach is unavailable for
+   `sessionInfo`. That is true of `signals` specifically, but `ModelInfo.registerChangeListener` is
+   public, already applied to the session table, and already sufficient to observe creates, updates
+   and deletes. The `signals` seam is still the wider one — it also sees reads.
 
 ## 10. Out of scope: external capture layer
 
 Not covered here, but it constrains the above. The requirement is a capture that is **provably
 outside application control**, so that the operator cannot be accused of tampering. That forces it
-out of process — into the reverse proxy — and the code-side implications are:
+out of process — into the reverse proxy — and the code-side implications are below.
+
+Three properties do the actual work, and it is worth naming them separately because only the first is
+obvious:
+
+1. **It is outside the trust domain.** Whoever compromises the server does not thereby control the
+   capture. This is the whole point.
+2. **It is externally driven, not pushed.** A capture the server *reports to* inherits the server's
+   compromise: a compromised server simply stops reporting. A capture that taps or pulls does not ask
+   the server's permission. If the total-log is ever built as a push, it loses most of its value.
+3. **Silence must be alarming.** Following from (2): the external side has to detect *absence* of
+   expected traffic, not merely verify what it received. Otherwise the cheapest attack on an
+   unforgeable log is to stop feeding it.
+
+Being simpler and not our code helps for a fourth, softer reason: our bugs do not become its bugs.
+Three defects shipped in the in-process chain during a single session's work, and that code was far
+smaller than the system it was protecting.
+
+The residual gap that none of this closes is **fabrication at write time**. If the server lies, an
+unforgeable capture faithfully records the lie. No external mechanism can distinguish a truthful
+server from a convincing one; that is a property of the application, not of the log.
 
 - Envoy's `tap` filter is the correct primitive (nginx `mirror` re-issues requests to a second
   upstream, duplicating side effects and capturing no responses).
@@ -764,10 +1286,9 @@ out of process — into the reverse proxy — and the code-side implications are
 
   **Resolved: build neither.** High-sensitivity deployments today already do not stream audited
   models, and the goal is to lift that restriction rather than entrench it. The
-  [anchoring mechanism](#58-anchoring-extending-external-assurance-to-channels-the-proxy-cannot-see)
-  achieves that without any WS parsing: WS disclosures are recorded by layer 2 and made
-  tamper-evident by committing the chain head through the HTTP path the proxy already captures.
-  The residual gap versus direct capture is fabrication-at-write-time, documented in 5.8.
+  emergency total-log, if it is ever needed, achieves that without any WS parsing: WS disclosures are
+  recorded by layer 2, and making them tamper-evident is that separate system's job rather than this
+  one's. The residual gap versus direct capture is fabrication-at-write-time.
 - If the proxy stamps `x-request-id` and forwards the same value, the external capture and the
   in-process logs join for free (see [3.3](#33-aligning-with-the-proxy-and-with-telemetry)).
 
@@ -805,6 +1326,26 @@ This must be decided per model *before* its sinks receive their first record, be
 how records are encrypted at rest. It cannot be retrofitted to existing records — that is the whole
 point of crypto-shredding.
 
+> **The shape above is the intended design, not code. Crypto-shredding does not exist here.**
+> It is recorded so that it does not have to be re-derived, and deliberately left undeclared, because
+> declaring it now would be worse than leaving it out.
+>
+> **Why it is not declared yet.** Nothing would read `subjectKeys`. Its only runtime effect would be a
+> pre-deploy task failing the deploy unless the map was populated, charging every deployment a
+> declaration in exchange for nothing — and an unread declaration is a checkbox rather than a
+> decision. Worse, it would pin three guesses into public API for a feature that does not exist: the
+> extractor above returns a `String` where crypto-shredding wants a key id, a record about two people
+> has two subjects, and no such map can express that a key's type matches its model. Declaring it
+> now makes it likelier that the eventual real API gets bent to fit it.
+>
+> **What that costs, honestly.** A deploy guard would be the one thing forcing an erasure decision at
+> deploy time,
+> and that decision genuinely cannot be retrofitted — records written before a key exists stay
+> unshreddable forever. A deployment that will need erasure still needs to decide early; it just has
+> no mechanical prompt now. The right time to design this API is when the wrapping and shredding are
+> being built, against real requirements — including what the mutation log's `old`/`new` columns
+> imply, since those put record contents in a second place that erasure has to reach.
+
 ### 11.3 Auth events — resolved, see section 7
 
 The working assumption was that `SessionManager` already handled much of this and the work would be
@@ -821,17 +1362,33 @@ evidence, and a fabricated `"test"` IP placeholder.
 ### 11.4 Auditing reads of the audit log — no special mechanism needed (resolved)
 
 Earlier drafts called for a separate credential path. That was overcomplicated. Reading the audit log
-is just an `@AuditedOperation` endpoint, and its records land in the same stream as everything else.
-The hash chain (5.7) and the append-only sink mean a reader cannot erase the evidence of their own
-read, which is the property that actually matters. Self-reference is not a problem here: the log only
-ever appends, so recording a read of the log simply produces one more record.
+is an ordinary endpoint, and its records land in the same stream as everything else. Self-reference is
+not a problem: the log only ever appends, so recording a read of the log simply produces one more
+record.
+
+**Weaker than it sounds, on two counts.** The argument would be much stronger with a hash chain
+making it impossible for a reader to erase the evidence of their own read; chaining is
+[out of scope](#57-integrity-out-of-scope-here), so what remains is an append-only *convention*, not an
+enforced property — anyone with write access to the audit tables can delete their own row. And
+[6.2](#62-record-shape-and-installation-resolved) now stores serialized query conditions, so the audit
+log holds the sensitive values it audits and is worth protecting more carefully than "an ordinary
+endpoint" implies. The resolution still stands for framework *design* — no special credential path is
+needed — but the deployment-side controls it assumes are doing more work than this section credits.
 
 Separation of duties between reading the log and administering it remains worth having, but it is an
 IAM/deployment concern, not a framework design concern.
 
-### 11.5 Bitfield width — three `Int`s (resolved)
+### 11.5 Bitfield width — two `Int`s (resolved)
 
-96 bits across three `Int` columns. See [5.3.1](#531-why-three-ints-and-not-long-ulong-or-bytearray)
-for the reasoning — `Int` is the only bitwise-queryable type in the framework — and
-[5.3.2](#532-blocking-prerequisite-the-bitwise-conditions-are-broken-in-every-sql-engine) for the
-engine bugs that must be fixed first.
+64 bits across two `Int` columns. See
+[5.3.1](#531-why-int-columns-and-not-long-ulong-or-bytearray) for the reasoning — `Int` is the only
+bitwise-queryable type in the framework — and
+[5.3.2](#532-blocking-prerequisite-the-bitwise-conditions-were-broken-in-every-engine) for the two
+rounds of engine bugs that had to be fixed first.
+
+Went 96 → 128 → 64 during implementation. It was widened when every field was itemised automatically,
+because nested paths ([5.4.1](#541-nested-fields)) grow faster than property counts and dead indices
+accumulate forever. Making itemising opt-in
+([5.1.1](#511-itemising-is-opt-in-disclosure-is-not)) removed the pressure entirely: a model reserves
+bits for the few fields that matter to an audit, so two columns is ample and saves eight bytes on
+every row.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,9 @@ include(":core-shared")
 include(":typed")
 include(":typed-shared")
 
+include(":audit")
+include(":audit-shared")
+
 include(":auth")
 include(":auth-shared")
 


### PR DESCRIPTION
**Stack: 10 of 16.** Based on `split/e9` — review that one first.
Two new modules. `audit-shared` holds record shapes and markers that a client
may also need; `audit` holds the server side. Nothing outside these two
modules ever refers back to them — the dependency is one-directional, so a
deployment that includes nothing pays nothing.

This PR is the part every later layer joins to:

- `@Audited` marks a model, and `FieldBits` gives each of its fields a
  permanent bit index. Bits rather than field names so a record stays small
  and stays interpretable after a rename.
- `DisclosureRecord` is the shape those bits index, with the `disclosedAny` /
  `disclosedAll` query helpers. It lives here rather than with the disclosure
  log because the bit machinery is meaningless without it — the registry's
  whole purpose is keeping a record's bits readable.
- `AuditRegistry` assigns and persists those ids. Assignment runs as a
  pre-deploy task, so instances never race to allocate the same index, and it
  is convergent, so re-running it every deploy is a no-op.
- `descriptorWalk` finds audited models by walking the serializers the
  server's endpoints declare — endpoints only, deliberately. An earlier
  version also scanned registered tables, which produced coverage that was
  inconsistent depending on whether a model happened to be a table.
  Inconsistent coverage hides a gap instead of failing on it.
- `AuditCore` carries the request log: who asked, from where, and when. Every
  other layer's `requestId` points here. Its records have no `at` column; the
  time comes out of the version-7 id minted earlier in this stack.

The two plan documents describe the whole design, including layers that
arrive later in this stack, and record the decisions taken against it.

Included layers are named one at a time on purpose — there is no all-in-one
helper. A bundle would hide which layers a deployment is paying for, and the
data access and mutation logs are far too voluminous to acquire by reflex.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd