### PR TITLE
Layer 2: the disclosure log — which fields of which records left the server

### DIFF
--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
@@ -1,0 +1,32 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.typed.DatabaseTableRegistration
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.services.database.Table
+
+/**
+ * Layer 2: one row per audited record that reaches a client, and no endpoint can opt out.
+ *
+ * The question this answers is "who has seen this record", which nothing below the typed layer can
+ * answer — by the time a value reaches the database layer it is a query, not a disclosure.
+ *
+ * ## Failure behaviour: fail-closed
+ * A disclosure that cannot be recorded does not happen. The interception point sits before
+ * serialization precisely so that throwing there prevents the body from ever being built. An outage
+ * of the audit database is therefore an outage for every endpoint that returns an audited model.
+ * That is the intended trade — see `plans/audit-logging.md` 5.6.
+ *
+ * @property disclosures One row per audited record that reached a client.
+ */
+public class DisclosureLog(private val core: AuditCore) : ServerBuilder() {
+    public val disclosures: DatabaseTableRegistration<DisclosureRecord> =
+        core.database.registerTable("AuditDisclosure", DisclosureRecord.serializer())
+
+    init {
+        core.claim("DisclosureLog")
+        install(DisclosureLogInterceptor(core.registry, disclosures))
+    }
+}
+

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DisclosureExtractor.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DisclosureExtractor.kt
@@ -1,0 +1,279 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.database.PartialSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.uuid.Uuid
+
+/** One audited record that reached a client, and which of its fields carried a value. */
+internal data class Disclosure(
+    val modelId: Int,
+    val recordId: Uuid,
+    val bits: FieldBits,
+)
+
+/**
+ * Finds the audited records inside a value by walking it with its own serializer.
+ *
+ * Using the serializer rather than reflection means what is observed is exactly what the client will
+ * receive — through lists, maps, `Partial`s, wrappers, and sealed hierarchies alike — and that a
+ * model cannot be disclosed through a shape the walk fails to understand.
+ *
+ * Safe to share across requests: the only mutable state is a cache of resolved bit indices, which is
+ * a pure function of the registry.
+ */
+internal class DisclosureExtractor(private val registry: AuditRegistry) {
+    private val plans = ConcurrentHashMap<PlanKey, PathPlan>()
+
+    fun <T> extract(
+        serializer: KSerializer<T>,
+        value: T,
+        serializersModule: SerializersModule = EmptySerializersModule(),
+    ): List<Disclosure> {
+        val found = ArrayList<Disclosure>()
+        Walk(serializersModule, found).encodeSerializableValue(serializer, value)
+        return found
+    }
+
+    /** Marks an element that is not itemised: it is walked, but sets no bit. */
+    private val NO_BIT: Int get() = -1
+
+    private data class PlanKey(val modelId: Int, val basePath: String, val descriptor: SerialDescriptor)
+
+    /**
+     * The resolved bit index and child path for every element of one descriptor at one position
+     * inside one audited model.
+     *
+     * Cached because a list of ten thousand records enters the same descriptor at the same path ten
+     * thousand times; without this, every field of every record would rebuild its path string and
+     * hash it against the registry.
+     */
+    private class PathPlan(
+        val bitIndexes: IntArray,
+        val childPaths: Array<String>,
+        val idElementIndex: Int,
+    )
+
+    private fun planFor(modelId: Int, basePath: String, descriptor: SerialDescriptor): PathPlan =
+        plans.getOrPut(PlanKey(modelId, basePath, descriptor)) {
+            val count = descriptor.elementsCount
+            val childPaths = Array(count) { index ->
+                val name = descriptor.getElementName(index)
+                if (basePath.isEmpty()) name else "$basePath.$name"
+            }
+            PathPlan(
+                bitIndexes = IntArray(count) { registry.bitIndexOrNull(modelId, childPaths[it]) ?: NO_BIT },
+                childPaths = childPaths,
+                idElementIndex = (0 until count).firstOrNull { descriptor.getElementName(it) == "_id" } ?: -1,
+            )
+        }
+
+    /** The record being assembled for one audited instance. */
+    private class RecordBuilder(val modelId: Int) {
+        var bits: FieldBits = FieldBits.EMPTY
+        var recordId: Uuid? = null
+    }
+
+    private class Frame(
+        val descriptor: SerialDescriptor,
+        val basePath: String,
+        /** The audited record this frame's fields belong to, or null when outside any audited model. */
+        val record: RecordBuilder?,
+        /** Non-null exactly when this frame both belongs to a record and names its elements. */
+        val plan: PathPlan?,
+        /** True when this frame opened [record] and must emit it on close. */
+        val ownsRecord: Boolean,
+    ) {
+        var currentIndex: Int = -1
+    }
+
+    private inner class Walk(
+        override val serializersModule: SerializersModule,
+        private val out: MutableList<Disclosure>,
+    ) : AbstractEncoder() {
+        private val frames = ArrayList<Frame>()
+
+        /**
+         * Set when the value about to be encoded is a `Partial`, whose descriptor is named for
+         * `Partial` and carries none of the model's class annotations. The source descriptor stands
+         * in, so a partial is treated as what it is: some fields of that model.
+         */
+        private var partialSource: SerialDescriptor? = null
+
+        private val top: Frame? get() = frames.lastOrNull()
+
+        override fun encodeValue(value: Any) {}
+
+        override fun encodeNull() {}
+
+        override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+            (serializer as? PartialSerializer<*>)?.let { partialSource = it.source.descriptor }
+            super.encodeSerializableValue(serializer, value)
+        }
+
+        override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+            val effective = partialSource?.also { partialSource = null } ?: descriptor
+            val parent = top
+            val newRecord =
+                if (effective.isAudited) RecordBuilder(registry.modelId(effective.auditSerialName)) else null
+            val record = newRecord ?: parent?.record
+            val basePath = if (newRecord != null) "" else parent.childPathFor(effective)
+            val named = effective.kind == StructureKind.CLASS || effective.kind == StructureKind.OBJECT
+
+            frames.add(
+                Frame(
+                    descriptor = effective,
+                    basePath = basePath,
+                    record = record,
+                    plan = if (record != null && named) planFor(record.modelId, basePath, effective) else null,
+                    ownsRecord = newRecord != null,
+                )
+            )
+            return this
+        }
+
+        override fun endStructure(descriptor: SerialDescriptor) {
+            val frame = frames.removeLast()
+            if (!frame.ownsRecord) return
+            val record = frame.record!!
+            val recordId = record.recordId ?: throw IllegalStateException(
+                "An audited ${frame.descriptor.auditSerialName} reached a client without its _id, so the " +
+                    "disclosure could not name which record was disclosed. A partial query on an audited " +
+                    "model must include _id."
+            )
+            out.add(Disclosure(record.modelId, recordId, record.bits))
+        }
+
+        override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
+            top?.currentIndex = index
+            return true
+        }
+
+        private fun discloseCurrent() {
+            disclose(top?.currentIndex ?: return)
+        }
+
+        /** Records that the element at [index] of the current frame carried a value. */
+        private fun disclose(index: Int) {
+            val frame = top ?: return
+            val plan = frame.plan ?: return
+            if (index < 0 || index >= plan.bitIndexes.size) return
+            val bit = plan.bitIndexes[index]
+            if (bit == NO_BIT) return
+            frame.record?.let { it.bits += bit }
+        }
+
+        /**
+         * Where a nested structure sits, relative to the audited model containing it. Mirrors the
+         * path rules the registry assigned bits under; see [auditFieldPaths].
+         */
+        private fun Frame?.childPathFor(child: SerialDescriptor): String {
+            if (this == null) return ""
+            return when (descriptor.kind) {
+                StructureKind.LIST -> "$basePath[]"
+                StructureKind.MAP -> "$basePath{}"
+                is PolymorphicKind -> "$basePath(${child.auditSerialName})"
+                else -> plan?.childPaths?.getOrNull(currentIndex) ?: basePath
+            }
+        }
+
+        // Field presence is judged on the value, not on whether the format in use would have written
+        // it: a default is a default whether or not a given encoder elides it. See section 5.5.
+        //
+        // AbstractEncoder routes every primitive element through encodeElement and then the bare
+        // encodeX, and the element forms are final — so the index is remembered above and consumed
+        // here. That also means a value whose serializer writes a primitive without opening a
+        // structure of its own, such as Uuid, is attributed to the element that holds it, which is
+        // what we want.
+        override fun encodeBoolean(value: Boolean) {
+            if (value) discloseCurrent()
+        }
+
+        override fun encodeByte(value: Byte) {
+            if (value != 0.toByte()) discloseCurrent()
+        }
+
+        override fun encodeShort(value: Short) {
+            if (value != 0.toShort()) discloseCurrent()
+        }
+
+        override fun encodeInt(value: Int) {
+            if (value != 0) discloseCurrent()
+        }
+
+        override fun encodeLong(value: Long) {
+            if (value != 0L) discloseCurrent()
+        }
+
+        override fun encodeFloat(value: Float) {
+            if (value != 0f) discloseCurrent()
+        }
+
+        override fun encodeDouble(value: Double) {
+            if (value != 0.0) discloseCurrent()
+        }
+
+        override fun encodeChar(value: Char) {
+            if (value.code != 0) discloseCurrent()
+        }
+
+        override fun encodeString(value: String) {
+            if (value.isNotEmpty()) discloseCurrent()
+        }
+
+        /** An enum has no natural zero, so holding any value of one is a disclosure. */
+        override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
+            discloseCurrent()
+        }
+
+        override fun <T> encodeSerializableElement(
+            descriptor: SerialDescriptor,
+            index: Int,
+            serializer: SerializationStrategy<T>,
+            value: T,
+        ) {
+            encodeElement(descriptor, index)
+            captureId(index, value)
+            if (value.carriesAValue()) disclose(index)
+            encodeSerializableValue(serializer, value)
+        }
+
+        override fun <T : Any> encodeNullableSerializableElement(
+            descriptor: SerialDescriptor,
+            index: Int,
+            serializer: SerializationStrategy<T>,
+            value: T?,
+        ) {
+            encodeElement(descriptor, index)
+            if (value == null) return
+            captureId(index, value)
+            if (value.carriesAValue()) disclose(index)
+            encodeSerializableValue(serializer, value)
+        }
+
+        /** An empty collection is a default, so it is not a disclosure — see section 5.5. */
+        private fun Any?.carriesAValue(): Boolean = when (this) {
+            null -> false
+            is Collection<*> -> isNotEmpty()
+            is Map<*, *> -> isNotEmpty()
+            else -> true
+        }
+
+        private fun captureId(index: Int, value: Any?) {
+            val frame = top ?: return
+            if (!frame.ownsRecord || index != frame.plan?.idElementIndex) return
+            frame.record?.recordId = value as? Uuid
+        }
+    }
+}

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DisclosureLogInterceptor.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DisclosureLogInterceptor.kt
@@ -1,0 +1,62 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.data.Request
+import com.lightningkite.lightningserver.definition.Runtime
+import com.lightningkite.lightningserver.definition.RuntimeDeferred
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.typedoutput.TypedOutputInterceptor
+import com.lightningkite.services.database.Table
+import kotlinx.serialization.KSerializer
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Writes one [DisclosureRecord] for every audited record that reaches a client.
+ *
+ * ## Fail-closed
+ *
+ * Nothing is caught here on purpose. An extraction that cannot resolve a model, a record with no
+ * `_id`, or a sink that will not accept the write all propagate out of
+ * [TypedOutputInterceptor.outputProduced], which aborts the send before the value is serialized. A
+ * disclosure that could not be recorded does not happen.
+ *
+ * The practical consequence is worth stating plainly: an outage of the audit database is an outage
+ * of every endpoint that returns an audited model.
+ */
+@OptIn(ExperimentalUuidApi::class)
+public class DisclosureLogInterceptor(
+    registry: RuntimeDeferred<AuditRegistry>,
+    private val table: Runtime<Table<DisclosureRecord>>,
+) : TypedOutputInterceptor {
+    override val name: String = "DisclosureLog"
+
+    /**
+     * Built once per process, since the registry it reads only changes during a deploy. Holding it
+     * here is also what makes the extractor's path cache worth having.
+     */
+    private val extractor = RuntimeDeferred.Cached(RuntimeDeferred { DisclosureExtractor(registry.await()) })
+
+    context(runtime: ServerRuntime)
+    override suspend fun <T> outputProduced(request: Request<*>, serializer: KSerializer<T>, value: T) {
+        val disclosures = extractor.await().extract(
+            serializer = serializer,
+            value = value,
+            serializersModule = runtime.externalSerialization.serializersModule,
+        )
+        if (disclosures.isEmpty()) return
+
+        val rows = disclosures.map {
+            DisclosureRecord(
+                // v7 so the row carries its own insert time; DisclosureRecord.at reads it back.
+                // Not generateRequestId(): that names execution ids, and this is a row id.
+                _id = Uuid.generateV7NonMonotonicAt(runtime.clock.now()),
+                requestId = runtime.initiator.requestRecordId,
+                modelId = it.modelId,
+                fields0 = it.bits.fields0,
+                fields1 = it.bits.fields1,
+                recordId = it.recordId,
+            )
+        }
+        table().insert(rows)
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DisclosureExtractorTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DisclosureExtractorTest.kt
@@ -1,0 +1,259 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.services.database.Database
+import com.lightningkite.services.database.Partial
+import com.lightningkite.services.database.PartialSerializer
+import com.lightningkite.services.database.partialOf
+import com.lightningkite.services.database.serializableProperties
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Disclosures are asserted by **field path**, not by bit number, and the paths themselves are pinned
+ * independently by [DescriptorWalkTest]. Asserting raw bits here would let the runtime walk and the
+ * registration walk agree on the same wrong answer — the exact failure mode that hid the bitwise
+ * condition bugs for so long.
+ */
+class DisclosureExtractorTest {
+
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val models = database.registerTable("AuditModelRegistration", AuditModelRegistration.serializer())
+        val fields = database.registerTable("AuditFieldRegistration", AuditFieldRegistration.serializer())
+    }
+
+    private fun onServer(block: suspend context(ServerRuntime) Fixture.() -> Unit) = runBlocking {
+        TestServer.test(settings = { database set Database.Settings() }) {
+            block(serverRuntime, Fixture())
+        }
+    }
+
+    private class Fixture {
+        lateinit var registry: AuditRegistry
+        lateinit var extractor: DisclosureExtractor
+
+        context(server: ServerRuntime)
+        suspend fun deploy(vararg serializers: KSerializer<*>) {
+            reconcileAuditRegistry(
+                TestServer.models(),
+                TestServer.fields(),
+                serializers.flatMap { it.descriptor.auditedModels().entries }.associate { it.key to it.value },
+            )
+            registry = loadAuditRegistry(TestServer.models(), TestServer.fields())
+            extractor = DisclosureExtractor(registry)
+        }
+
+        fun <T> extract(serializer: KSerializer<T>, value: T): List<Disclosure> =
+            extractor.extract(serializer, value)
+
+        /** The disclosed field paths of one disclosure, resolved back through the registry. */
+        fun paths(disclosure: Disclosure): Set<String> {
+            val byBit = registry.fields(disclosure.modelId).entries.associate { it.value to it.key }
+            return disclosure.bits.indices().map { byBit.getValue(it) }.toSet()
+        }
+
+        fun modelIdOf(serializer: KSerializer<*>): Int = registry.modelId(serializer.descriptor.serialName)
+    }
+
+    /** A `Patient` reduced to just the named fields, as `queryPartial` would return it. */
+    private fun patientPartial(fields: Set<String>): Partial<Patient> = partialOf(
+        Patient(_id = id, name = "Ada", ssn = "secret"),
+        Patient.serializer().serializableProperties!!.filter { it.name in fields },
+    )
+
+    private val id = Uuid.parse("00000000-0000-0000-0000-0000000000a1")
+    private val otherId = Uuid.parse("00000000-0000-0000-0000-0000000000b2")
+
+    @Test
+    fun `only fields that carried a value are recorded`() = onServer {
+        deploy(Patient.serializer())
+        val patient = Patient(_id = id, name = "Ada", ssn = "")
+
+        val disclosure = extract(Patient.serializer(), patient).single()
+
+        assertEquals(modelIdOf(Patient.serializer()), disclosure.modelId)
+        assertEquals(id, disclosure.recordId)
+        assertEquals(setOf("name"), paths(disclosure), "an empty ssn is a default, not a disclosure")
+    }
+
+    @Test
+    fun `nulls, zeroes, empty strings and empty collections are all defaults`() = onServer {
+        deploy(Reading.serializer())
+
+        val disclosure = extract(Reading.serializer(), Reading(_id = id)).single()
+
+        assertEquals(emptySet(), paths(disclosure), "a record with nothing tracked in its payload is still a record")
+    }
+
+    @Test
+    fun `an enum discloses whatever value it holds`() = onServer {
+        deploy(Reading.serializer())
+
+        val disclosure = extract(Reading.serializer(), Reading(_id = id, severity = Severity.Low)).single()
+
+        assertEquals(setOf("severity"), paths(disclosure), "the first enum entry is still a value")
+    }
+
+    @Test
+    fun `a false boolean and a zero int are not disclosures but their opposites are`() = onServer {
+        deploy(Reading.serializer())
+
+        val quiet = extract(Reading.serializer(), Reading(_id = id, count = 0, flagged = false)).single()
+        assertEquals(emptySet(), paths(quiet))
+
+        val loud = extract(Reading.serializer(), Reading(_id = id, count = 3, flagged = true)).single()
+        assertEquals(setOf("count", "flagged"), paths(loud))
+    }
+
+    @Test
+    fun `a nested structure records the container and each leaf that carried a value`() = onServer {
+        deploy(Patient.serializer())
+        val patient = Patient(_id = id, name = "Ada", ssn = "x", address = Address(street = "1 Main", city = ""))
+
+        val disclosure = extract(Patient.serializer(), patient).single()
+
+        assertEquals(setOf("name", "ssn", "address", "address.street"), paths(disclosure))
+    }
+
+    /** The distinction the container bit exists for. */
+    @Test
+    fun `a present but all-default structure is distinguishable from an absent one`() = onServer {
+        deploy(Patient.serializer())
+        val base = Patient(_id = id, name = "Ada", ssn = "x")
+
+        val absent = extract(Patient.serializer(), base).single()
+        val empty = extract(Patient.serializer(), base.copy(address = Address("", ""))).single()
+
+        assertTrue("address" !in paths(absent))
+        assertTrue("address" in paths(empty))
+    }
+
+    @Test
+    fun `list elements are recorded under the list path`() = onServer {
+        deploy(Patient.serializer())
+        val patient = Patient(_id = id, name = "Ada", ssn = "x", phones = listOf(Phone("555", "")))
+
+        val disclosure = extract(Patient.serializer(), patient).single()
+
+        assertEquals(
+            setOf("name", "ssn", "phones[].number"),
+            paths(disclosure),
+            "the list itself is not itemised, but the annotated field inside it is",
+        )
+    }
+
+    @Test
+    fun `an empty list is not a disclosure`() = onServer {
+        deploy(Patient.serializer())
+        val patient = Patient(_id = id, name = "Ada", ssn = "x", phones = listOf())
+
+        assertTrue("phones[].number" !in paths(extract(Patient.serializer(), patient).single()))
+    }
+
+    @Test
+    fun `map values are recorded under the map path`() = onServer {
+        deploy(Contact.serializer())
+        val contact = Contact(_id = id, numbers = mapOf("home" to Phone("555", "h")))
+
+        val disclosure = extract(Contact.serializer(), contact).single()
+
+        assertEquals(
+            setOf("numbers", "numbers{}.number"),
+            paths(disclosure),
+            "map values use a different path separator than list elements",
+        )
+    }
+
+    @Test
+    fun `a sealed field records the subclass it actually held`() = onServer {
+        deploy(Order.serializer())
+        val order = Order(_id = id, payment = Payment.Card(last4 = "4242"))
+
+        val disclosure = extract(Order.serializer(), order).single()
+
+        assertEquals(setOf("payment", "payment(Card).last4"), paths(disclosure))
+    }
+
+    @Test
+    fun `a nested audited model produces its own record rather than bits on its parent`() = onServer {
+        deploy(Patient.serializer())
+        val patient = Patient(_id = id, name = "Ada", ssn = "x", doctor = Doctor(otherId, "Dr Who"))
+
+        val disclosures = extract(Patient.serializer(), patient)
+
+        assertEquals(2, disclosures.size, "expected one record each for the patient and the doctor")
+        val doctor = disclosures.single { it.modelId == modelIdOf(Doctor.serializer()) }
+        assertEquals(otherId, doctor.recordId)
+        assertEquals(setOf("name"), paths(doctor))
+
+        val patientDisclosure = disclosures.single { it.modelId == modelIdOf(Patient.serializer()) }
+        assertTrue("doctor" in paths(patientDisclosure), "the parent still records that a doctor was disclosed")
+    }
+
+    @Test
+    fun `every element of a list of audited models gets its own record`() = onServer {
+        deploy(Patient.serializer())
+        val patients = (1..5).map { Patient(_id = Uuid.random(), name = "P$it", ssn = "s") }
+
+        val disclosures = extract(ListSerializer(Patient.serializer()), patients)
+
+        assertEquals(5, disclosures.size)
+        assertEquals(patients.map { it._id }.toSet(), disclosures.map { it.recordId }.toSet())
+    }
+
+    @Test
+    fun `a value with nothing audited in it produces nothing`() = onServer {
+        deploy(Patient.serializer())
+
+        assertEquals(emptyList(), extract(Address.serializer(), Address("1 Main", "Springfield")))
+    }
+
+    @Test
+    fun `a nullable audited model that is absent produces nothing`() = onServer {
+        deploy(Patient.serializer())
+
+        assertEquals(emptyList(), extract(Patient.serializer().nullable, null))
+    }
+
+    // --- Partials -------------------------------------------------------------------------------
+
+    @Test
+    fun `a partial records only the fields it actually carried`() = onServer {
+        deploy(Patient.serializer())
+        val partial = patientPartial(setOf("_id", "name"))
+
+        val disclosure = extract(PartialSerializer(Patient.serializer()), partial).single()
+
+        assertEquals(modelIdOf(Patient.serializer()), disclosure.modelId)
+        assertEquals(id, disclosure.recordId)
+        assertEquals(setOf("name"), paths(disclosure), "ssn was never sent, so it was not disclosed")
+    }
+
+    /**
+     * One row per record means a disclosure has to name a record. A partial without `_id` cannot, so
+     * it fails rather than recording an unattributable disclosure.
+     */
+    @Test
+    fun `a partial without an id fails closed`() = onServer {
+        deploy(Patient.serializer())
+        val partial = patientPartial(setOf("name", "ssn"))
+
+        val failure = assertFailsWith<IllegalStateException> {
+            extract(PartialSerializer(Patient.serializer()), partial)
+        }
+        assertTrue("_id" in failure.message.orEmpty(), "the message should say what was missing; was ${failure.message}")
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DisclosureLogEndToEndTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DisclosureLogEndToEndTest.kt
@@ -1,0 +1,228 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.auth.noAuth
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.*
+import com.lightningkite.lightningserver.definition.PreDeployTask
+import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.handle
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.typed.ApiHttpHandler
+import com.lightningkite.lightningserver.typed.MetaEndpoints
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.data.MediaType
+import com.lightningkite.services.data.TypedData
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.Database
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The whole disclosure log driven through a real server: install it, make a request, and read back
+ * what an auditor would read.
+ */
+class DisclosureLogEndToEndTest {
+
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val cache = setting("cache", Cache.Settings())
+        val audit = path.path("audit") include AuditCore(database)
+        val disclosureLog = path.path("audit-disclosure") include DisclosureLog(audit)
+
+        init {
+            registerBasicMediaTypeCoders()
+        }
+
+        val ada = Patient(
+            _id = Uuid.parse("00000000-0000-0000-0000-0000000000a1"),
+            name = "Ada",
+            ssn = "secret",
+        )
+
+        val patient = path.path("patient").get bind ApiHttpHandler(
+            summary = "Patient",
+            auth = noAuth,
+            implementation = { _: Unit -> ada },
+        )
+
+        val plain = path.path("plain").get bind ApiHttpHandler(
+            summary = "Plain",
+            auth = noAuth,
+            implementation = { _: Unit -> "nothing audited here" },
+        )
+
+        val meta = path.path("meta") include MetaEndpoints(
+            packageName = "com.lightningkite.lightningserver.audit",
+            database = database,
+            cache = cache,
+        )
+    }
+
+    /** A fixed, readable request id, so a record can be asserted against the request that wrote it. */
+    private fun testId(n: Int) = Uuid.parse("00000000-0000-4000-8000-" + n.toString().padStart(12, '0'))
+
+    private fun request(path: String, method: HttpMethod = HttpMethod.GET, body: String? = null) =
+        HttpRequest<PathSpec>(
+            path = RawHttpEndpoint(asString = path, method = method),
+            queryParameters = QueryParameters.EMPTY,
+            headers = HttpHeaders.EMPTY,
+            domain = "example.com",
+            protocol = "https",
+            sourceIp = "10.0.0.1",
+            body = body?.let { TypedData.text(it, MediaType.Application.Json) },
+        )
+
+    private fun onServer(block: suspend context(ServerRuntime) Reader.() -> Unit) = runBlocking {
+        TestServer.test(settings = { database set Database.Settings(); cache set Cache.Settings() }) {
+            runPreDeployTasks(serverRuntime)
+            block(serverRuntime, Reader())
+        }
+    }
+
+    /**
+     * Runs the server's pre-deploy tasks in dependency order, which is what assigns the audit bit
+     * indices. Done here rather than through the runner so the ordering the real deploy pipeline
+     * guarantees is reproduced explicitly.
+     */
+    private suspend fun runPreDeployTasks(runtime: ServerRuntime) {
+        val done = HashSet<PreDeployTask>()
+        suspend fun run(task: PreDeployTask) {
+            if (!done.add(task)) return
+            task.dependencies().forEach { run(it) }
+            with(runtime) { task.execute() }
+        }
+        runtime.server.preDeployTasks.values.forEach { run(it) }
+    }
+
+    private class Reader {
+        context(server: ServerRuntime)
+        suspend fun requests() = TestServer.audit.requests().find(Condition.Always).toList()
+
+        context(server: ServerRuntime)
+        suspend fun disclosures() = TestServer.disclosureLog.disclosures().find(Condition.Always).toList()
+
+        context(server: ServerRuntime)
+        suspend fun pathsOf(record: DisclosureRecord): Set<String> {
+            val registry = TestServer.audit.registry.await()
+            val byBit = registry.fields(record.modelId).entries.associate { it.value to it.key }
+            return record.fields.indices().map { byBit.getValue(it) }.toSet()
+        }
+    }
+
+    /**
+     * A disclosure row's instant comes from its own version-7 id, so it must reflect the engine's
+     * selected clock. Pinned end-to-end because the minting happens in the interceptor: a row minted
+     * with a v4 id would still serialize, still join, and still read back — it would just silently
+     * answer "epoch" when asked when the disclosure happened.
+     */
+    @Test
+    fun `a disclosure row carries the mint time of the clock that wrote it`() = runBlocking {
+        val fixed = Instant.fromEpochMilliseconds(1_700_000_123_456)
+        TestServer.test(
+            settings = { database set Database.Settings(); cache set Cache.Settings() },
+            clock = { object : Clock { override fun now(): Instant = fixed } },
+        ) {
+            runPreDeployTasks(serverRuntime)
+            with(serverRuntime) {
+                val response = handle(request("/patient"), testId(20))
+                assertEquals(HttpStatus.OK, response.status)
+                assertEquals(fixed, Reader().run { disclosures() }.single().at)
+            }
+        }
+        Unit
+    }
+
+    @Test
+    fun `a disclosed record is recorded against the request that disclosed it`() = onServer {
+        val response = serverRuntime.handle(request("/patient"), testId(1))
+        assertEquals(HttpStatus.OK, response.status)
+
+        val disclosure = disclosures().single()
+        assertEquals(testId(1), disclosure.requestId)
+        assertEquals(TestServer.ada._id, disclosure.recordId)
+        assertEquals(setOf("name", "ssn"), pathsOf(disclosure))
+
+        val record = requests().single { it._id == testId(1) }
+        assertEquals("10.0.0.1", record.sourceIp)
+        assertEquals("GET", record.method)
+        assertEquals("200", record.outcome)
+        assertNotNull(record.durationMs)
+        assertNull(record.parentRequestId)
+    }
+
+    @Test
+    fun `a request that discloses nothing still gets a request record and no disclosures`() = onServer {
+        serverRuntime.handle(request("/plain"), testId(2))
+
+        assertEquals(emptyList(), disclosures())
+        assertEquals("200", requests().single { it._id == testId(2) }.outcome)
+    }
+
+    /**
+     * The request record must exist before anything points at it, which is why it is written at the
+     * start rather than assembled at the end.
+     */
+    @Test
+    fun `every disclosure refers to a request record that exists`() = onServer {
+        serverRuntime.handle(request("/patient"), testId(3))
+
+        val known = requests().map { it._id }.toSet()
+        disclosures().forEach {
+            assertTrue(it.requestId in known, "disclosure ${it._id} refers to unknown request ${it.requestId}")
+        }
+    }
+
+    @Test
+    fun `each sub-request of a multiplexed request is recorded separately and parented`() = onServer {
+        serverRuntime.handle(
+            request(
+                "/meta/bulk",
+                HttpMethod.POST,
+                body = """{"a":{"path":"/patient","method":"GET"},"b":{"path":"/plain","method":"GET"}}""",
+            ),
+            testId(4),
+        )
+
+        val subs = requests().filter { it.parentRequestId == testId(4) }
+        assertEquals(2, subs.size, "expected one request record per sub-request; saw ${requests().map { it._id }}")
+        assertTrue(requests().any { it._id == testId(4) }, "the carrying request was not recorded")
+
+        val disclosure = disclosures().single()
+        assertTrue(
+            disclosure.requestId in subs.map { it._id },
+            "the disclosure was attributed to the outer request rather than the sub-request that made it",
+        )
+    }
+
+    /**
+     * A repeated trusted request id means a misconfigured proxy is about to merge two principals'
+     * activity under one identifier. That has to be loud.
+     */
+    @Test
+    fun `a duplicate request id fails the request and discloses nothing`() = onServer {
+        val first = serverRuntime.handle(request("/patient"), testId(5))
+        assertEquals(HttpStatus.OK, first.status)
+
+        val second = serverRuntime.handle(request("/patient"), testId(5))
+
+        assertEquals(
+            HttpStatus.InternalServerError,
+            second.status,
+            "a repeated request id must not quietly merge two requests' activity",
+        )
+        assertEquals(1, disclosures().size, "the rejected request disclosed a record anyway")
+    }
+}


### PR DESCRIPTION
**Stack: 11 of 16.** Based on `split/a1` — review that one first.
One row per audited record that reaches a client, recording which fields went
out and to whom, as a bitmask against the registry from the previous PR.
`DisclosureRecord` itself landed there; this is the layer that produces them.

This is the question nothing below the typed layer can answer. By the time a
value reaches the database layer it is a query, not a disclosure — the server
may have read a hundred rows and returned two, or read a whole record and
returned one field of it.

It attaches through `TypedOutputInterceptor`, added to core at the bottom of
this stack. That hook fires after the handler produces a value and before it
is serialized, which is what makes the layer fail *closed*: the interceptor
throwing means the response body was never built, so a disclosure that cannot
be recorded does not happen. An audit database outage is therefore an outage
for every endpoint returning an audited model. That is the intended trade and
it is the reason the layer is opt-in per deployment.

No endpoint can opt out, which is the property the whole design is for. The
circumvention being guarded against is an endpoint built without auditing,
not a deployment that chose not to audit.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd