### PR TITLE
Layer 3: the data access log — every query against an audited model

### DIFF
--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/DataAccessRecord.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/DataAccessRecord.kt
@@ -1,0 +1,95 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.data.GenerateDataClassPaths
+import com.lightningkite.services.data.Index
+import com.lightningkite.services.database.HasId
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/** The kind of database operation a [DataAccessRecord] describes. */
+@Serializable
+public enum class DataAccessOperation {
+    Find,
+    Count,
+    Aggregate,
+    GroupCount,
+    GroupAggregate,
+    Insert,
+    Update,
+    Replace,
+    Delete,
+}
+
+/**
+ * One query against an audited model — what the code asked for, whoever asked.
+ *
+ * This is the layer that closes the aggregation and oracle channels the disclosure log structurally
+ * cannot see. `groupCount(groupBy = ssn)` returns distinct field values and discloses no *record*, so
+ * it produces no [DisclosureRecord] at all; `find(ssn eq "X")` returning nothing leaks the same bit
+ * while disclosing nothing; a sort plus `skip` walks values without ever matching one. Recording the
+ * condition makes all three the same shape of evidence — a binary search appears as thousands of
+ * rows whose conditions walk a value.
+ *
+ * Sits at the database layer rather than the typed layer precisely so it also sees the privileged
+ * internal reads that never reach a user. See `plans/audit-logging.md` sections 6.1 and 6.2.
+ *
+ * ## The query is stored as text
+ * `Condition<T>` and `Modification<T>` are serializable, but only against the model's own serializer,
+ * and this one table holds rows for every audited model. A generic record type would mean a table per
+ * model. What that gives up is querying *inside* a recorded condition; an investigation reads these
+ * rows, it does not join on their contents.
+ *
+ * ## What it does not capture
+ * A recorded condition says a bulk read happened, not what came back. For a `groupCount` over a
+ * sensitive field the log says "someone enumerated this field" without the values, because by
+ * construction there are no record ids to name. A deployment that cannot accept that should deny the
+ * grouping through permissions rather than expect the framework to forbid it.
+ *
+ * @property requestId Joins to [RequestRecord], and matches the id a [DisclosureRecord] from the same
+ *   execution carries. For a WebSocket this names the socket, not the phase.
+ * @property executionId The execution that actually issued the query. Recorded alongside [requestId]
+ *   because that one deliberately blurs a socket's phases together; this is what places a query at a
+ *   specific message on a long-lived connection.
+ * @property modelId The audited model, from the same registry [DisclosureRecord] uses.
+ * @property condition The `Condition<T>` applied, serialized with the model's serializer.
+ * @property sort The ordering applied, where the operation takes one. A sort is an oracle too.
+ * @property modification The change applied, for write operations.
+ * @property groupBy The field path an aggregation grouped on — the thing that makes a group query an
+ *   enumeration of that field's values. Also the vector field of a similarity search.
+ * @property skip Offset applied. Recorded because *this is the walk*: an ordering plus a moving skip
+ *   enumerates a sensitive field one value at a time, and without the offset two probes a thousand
+ *   rows apart are byte-identical records.
+ * @property limit Page size applied. A limit of 1 alongside a moving [skip] is the signature of that
+ *   walk.
+ * @property fields Which fields a partial read asked for. `findPartial({ssn})` and
+ *   `findPartial({name})` are the same query but not the same disclosure.
+ * @property aggregate The aggregation applied, and for a similarity search the query parameters. A
+ *   `Max` over a sensitive numeric field is a value-revealing oracle that a bare "Aggregate" cannot
+ *   be told apart from a `Count`.
+ */
+@GenerateDataClassPaths
+@Serializable
+public data class DataAccessRecord(
+    override val _id: Uuid,
+    @Index val requestId: Uuid,
+    @Index val executionId: Uuid,
+    @Index val modelId: Int,
+    val operation: DataAccessOperation,
+    val condition: String,
+    val sort: String? = null,
+    val modification: String? = null,
+    val groupBy: String? = null,
+    val skip: Int? = null,
+    val limit: Int? = null,
+    val fields: String? = null,
+    val aggregate: String? = null,
+) : HasId<Uuid> {
+    /** When the query ran, derived from the version-7 [_id]. See [RequestRecord] for why it lives there. */
+    @OptIn(ExperimentalUuidApi::class)
+    public val at: Instant
+        get() = Instant.fromEpochMilliseconds(_id.epochMilliseconds)
+
+    public companion object
+}

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
@@ -30,3 +30,33 @@ public class DisclosureLog(private val core: AuditCore) : ServerBuilder() {
     }
 }
 
+/**
+ * Layer 3: one row per query against an audited model, including privileged internal reads.
+ *
+ * This is the expensive layer, and the only one that is opt-in per model — see [dataAccessLogged].
+ * That is deliberate rather than an inconsistency: it writes a row per *query* rather than per
+ * disclosure, so on a read-heavy model it is orders of magnitude more voluminous than everything else
+ * here combined. Enable it where the aggregation and oracle channels in `audit-logging.md` 6.1
+ * actually matter, not everywhere by reflex.
+ *
+ * ## Failure behaviour: fail-closed, with the widest blast radius here
+ * A query whose record cannot be written does not run. Because this sits at the database layer it
+ * covers privileged internal reads too — startup tasks, schedule ticks, one service reading another's
+ * model — so an audit outage stops more than request serving. See `audit-logging.md` 6.2 and the risk
+ * register.
+ *
+ * Unlike the other layers this installs no interceptor: it attaches per model through `log`.
+ *
+ * @property dataAccess One row per query against an audited model.
+ */
+public class DataAccessLog(private val core: AuditCore) : ServerBuilder() {
+    public val dataAccess: DatabaseTableRegistration<DataAccessRecord> =
+        core.database.registerTable("AuditDataAccess", DataAccessRecord.serializer())
+
+    internal val registry get() = core.registry
+
+    init {
+        core.claim("DataAccessLog")
+    }
+}
+

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DataAccessLog.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DataAccessLog.kt
@@ -1,0 +1,79 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.services.database.Table
+import com.lightningkite.services.database.insertOne
+
+/**
+ * Wraps a table so that every query against it is recorded — when, and only when, its model is
+ * audited.
+ *
+ * Pass it as a `ModelInfo`'s `log` parameter:
+ *
+ * ```kotlin
+ * val patients = database.explicitModelInfo(
+ *     // ...
+ *     log = { audit.dataAccessLogged(it) },
+ * )
+ * ```
+ *
+ * ## Why it is safe to pass everywhere
+ * A model without [Audited] is returned untouched, so the "is this audited" decision stays in the
+ * annotation alone rather than being split between the annotation and a list of decorated tables.
+ * Passing it on every model is the intended usage.
+ *
+ * ## An audited model with no registry entry fails
+ * The id is resolved per operation rather than once at wrap time, because `ModelInfo`'s `log` slot is
+ * not suspending while the registry loads asynchronously; the operations themselves are suspending.
+ * Resolution uses [AuditRegistry.modelId], which **throws** when the model has no entry — the same
+ * fail-closed rule the disclosure log uses.
+ *
+ * That matters because the registry is populated by scanning **endpoints**, not tables (see
+ * [AuditCore]'s bit assignment). An `@Audited` model that no endpoint's serializer reaches has no id,
+ * and its reads will fail rather than go unrecorded. For a model that is only ever read internally
+ * this is a real limitation: it must be reachable from some endpoint's serializer to be
+ * data-access-logged at all. Recorded in `plans/audit-logging.md` 6.2.
+ *
+ * ## Where it sits
+ * `ModelInfo` applies `log` below permissions and in **both** `table(auth)` and `table()`, so this
+ * observes privileged internal reads — startup tasks, schedule ticks, one service reading another's
+ * model — as well as user-facing ones. That is the whole reason this layer exists rather than
+ * relying on the typed layer's disclosure log; see `plans/audit-logging.md` 2.1 and 6.1.
+ *
+ * ## Failure
+ * Fail-closed: a query whose record cannot be written does not run. The blast radius is larger than
+ * the disclosure log's, because it covers privileged reads too — see 6.2.
+ */
+context(runtime: ServerRuntime)
+public fun <T : Any> DataAccessLog.dataAccessLogged(table: Table<T>): Table<T> {
+    val descriptor = table.serializer.descriptor
+    // Reachability, not a single annotation. `isAudited` inspects one descriptor, so gating on it
+    // would return a sealed parent's table — or any wrapper's — untouched even though its children
+    // are audited, and every read of them would go unrecorded in silence. `auditedModels()` walks.
+    val reachable = descriptor.auditedModels()
+    if (reachable.isEmpty()) return table
+    // The row names one model, so a table that merely *contains* audited data cannot be attributed.
+    // Fail loudly rather than pick one: inconsistent coverage hides the gap instead of failing on it,
+    // which is the same rule the registry applies to an unregistered model.
+    if (!descriptor.isAudited) throw IllegalStateException(
+        "Table \"" + descriptor.serialName + "\" is not itself @Audited but can contain audited " +
+            "models (" + reachable.keys.sorted().joinToString(", ") + "). A data access record names " +
+            "one model, so this shape cannot be attributed and is refused rather than logged " +
+            "inconsistently."
+    )
+    val serialName = descriptor.auditSerialName
+    val initiator = runtime.initiator
+    return DataAccessLogTable(
+        wraps = table,
+        modelId = { registry.await().modelId(serialName) },
+        // The anchor, not this execution's own id. A query run inside a task has no request row of
+        // its own, so `requestRecordId` would store an id that joins to nothing; `attributedTo`
+        // names the row of whoever is responsible. Identical for http and websocket executions,
+        // which are their own anchor.
+        requestId = initiator.attributedTo,
+        executionId = initiator.executionId,
+        json = runtime.internalSerialization.json,
+        nowMillis = { runtime.clock.now().toEpochMilliseconds() },
+        write = { with(runtime) { dataAccess().insertOne(it) } },
+    )
+}

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DataAccessLogTable.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/DataAccessLogTable.kt
@@ -1,0 +1,268 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.services.database.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Records every query issued against an audited model, then performs it.
+ *
+ * Recording happens **before** the operation, and nothing here catches: a read whose query cannot be
+ * recorded does not happen. See `plans/audit-logging.md` 6.2 for why that trade is taken and what it
+ * costs.
+ *
+ * Wrapping the [Table] rather than instrumenting the endpoints is the whole point — this sees the
+ * privileged internal reads that never reach a user, which the typed layer never observes.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal class DataAccessLogTable<T : Any>(
+    override val wraps: Table<T>,
+    /** Throws when the model is audited but has no registry entry; see [DataAccessLogTable]. */
+    private val modelId: suspend () -> Int,
+    private val requestId: Uuid,
+    private val executionId: Uuid,
+    private val json: Json,
+    private val nowMillis: () -> Long,
+    private val write: suspend (DataAccessRecord) -> Unit,
+) : Table<T> by wraps {
+
+    private fun conditionText(condition: Condition<T>): String =
+        json.encodeToString(Condition.serializer(wraps.serializer), condition)
+
+    private fun sortText(orderBy: List<SortPart<T>>): String? =
+        if (orderBy.isEmpty()) null
+        else json.encodeToString(ListSerializer(SortPart.serializer(wraps.serializer)), orderBy)
+
+    private fun modificationText(modification: Modification<T>): String =
+        json.encodeToString(Modification.serializer(wraps.serializer), modification)
+
+    private suspend fun record(
+        operation: DataAccessOperation,
+        condition: Condition<T>,
+        sort: String? = null,
+        modification: String? = null,
+        groupBy: String? = null,
+        skip: Int? = null,
+        limit: Int? = null,
+        fields: String? = null,
+        aggregate: String? = null,
+    ) {
+        val modelId = modelId()
+        write(
+            DataAccessRecord(
+                _id = Uuid.generateV7NonMonotonicAt(kotlin.time.Instant.fromEpochMilliseconds(nowMillis())),
+                requestId = requestId,
+                executionId = executionId,
+                modelId = modelId,
+                operation = operation,
+                condition = conditionText(condition),
+                sort = sort,
+                modification = modification,
+                groupBy = groupBy,
+                skip = skip,
+                limit = limit,
+                fields = fields,
+                aggregate = aggregate,
+            )
+        )
+    }
+
+    override suspend fun find(
+        condition: Condition<T>,
+        orderBy: List<SortPart<T>>,
+        skip: Int,
+        limit: Int,
+        maxQueryMs: Long,
+    ): Flow<T> {
+        record(DataAccessOperation.Find, condition, sort = sortText(orderBy), skip = skip, limit = limit)
+        return wraps.find(condition, orderBy, skip, limit, maxQueryMs)
+    }
+
+    /**
+     * Overridden even though the interface default routes through [find]: a backend that implements
+     * this directly would otherwise be delegated straight past every override here, and read audited
+     * fields with no record of it.
+     */
+    override suspend fun findPartial(
+        fields: Set<DataClassPathPartial<T>>,
+        condition: Condition<T>,
+        orderBy: List<SortPart<T>>,
+        skip: Int,
+        limit: Int,
+        maxQueryMs: Long,
+    ): Flow<Partial<T>> {
+        record(
+            DataAccessOperation.Find, condition, sort = sortText(orderBy), skip = skip, limit = limit,
+            fields = fields.joinToString(",") { it.toString() },
+        )
+        return wraps.findPartial(fields, condition, orderBy, skip, limit, maxQueryMs)
+    }
+
+    override suspend fun findSimilar(
+        vectorField: DataClassPath<T, Embedding>,
+        params: DenseVectorSearchParams,
+        condition: Condition<T>,
+        maxQueryMs: Long,
+    ): Flow<ScoredResult<T>> {
+        // params carries the query vector, which *is* the probe in a similarity search.
+        record(
+            DataAccessOperation.Find, condition, groupBy = vectorField.toString(),
+            aggregate = params.toString(),
+        )
+        return wraps.findSimilar(vectorField, params, condition, maxQueryMs)
+    }
+
+    override suspend fun findSimilarSparse(
+        vectorField: DataClassPath<T, SparseEmbedding>,
+        params: SparseVectorSearchParams,
+        condition: Condition<T>,
+        maxQueryMs: Long,
+    ): Flow<ScoredResult<T>> {
+        record(
+            DataAccessOperation.Find, condition, groupBy = vectorField.toString(),
+            aggregate = params.toString(),
+        )
+        return wraps.findSimilarSparse(vectorField, params, condition, maxQueryMs)
+    }
+
+    override suspend fun upsertOne(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        model: T,
+    ): EntryChange<T> {
+        record(DataAccessOperation.Update, condition, modification = modificationText(modification))
+        return wraps.upsertOne(condition, modification, model)
+    }
+
+    override suspend fun upsertOneIgnoringResult(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        model: T,
+    ): Boolean {
+        record(DataAccessOperation.Update, condition, modification = modificationText(modification))
+        return wraps.upsertOneIgnoringResult(condition, modification, model)
+    }
+
+    override suspend fun count(condition: Condition<T>): Int {
+        record(DataAccessOperation.Count, condition)
+        return wraps.count(condition)
+    }
+
+    override suspend fun <Key> groupCount(
+        condition: Condition<T>,
+        groupBy: DataClassPath<T, Key>,
+    ): Map<Key, Int> {
+        record(DataAccessOperation.GroupCount, condition, groupBy = groupBy.toString())
+        return wraps.groupCount(condition, groupBy)
+    }
+
+    override suspend fun <N : Number?> aggregate(
+        aggregate: Aggregate,
+        condition: Condition<T>,
+        property: DataClassPath<T, N>,
+    ): Double? {
+        record(
+            DataAccessOperation.Aggregate, condition, groupBy = property.toString(),
+            aggregate = aggregate.toString(),
+        )
+        return wraps.aggregate(aggregate, condition, property)
+    }
+
+    override suspend fun <N : Number?, Key> groupAggregate(
+        aggregate: Aggregate,
+        condition: Condition<T>,
+        groupBy: DataClassPath<T, Key>,
+        property: DataClassPath<T, N>,
+    ): Map<Key, Double?> {
+        record(
+            DataAccessOperation.GroupAggregate, condition, groupBy = groupBy.toString(),
+            aggregate = aggregate.toString() + " over " + property.toString(),
+        )
+        return wraps.groupAggregate(aggregate, condition, groupBy, property)
+    }
+
+    override suspend fun insert(models: Iterable<T>): List<T> {
+        val list = models.toList()
+        // Condition.Never because an insert matches nothing, and the count goes in `limit` rather
+        // than in `modification`: that column is serialized JSON everywhere else and mixing free
+        // text into it makes the whole column untrustworthy to a query.
+        record(DataAccessOperation.Insert, Condition.Never, limit = list.size)
+        return wraps.insert(list)
+    }
+
+    override suspend fun replaceOne(
+        condition: Condition<T>,
+        model: T,
+        orderBy: List<SortPart<T>>,
+    ): EntryChange<T> {
+        record(DataAccessOperation.Replace, condition, sort = sortText(orderBy))
+        return wraps.replaceOne(condition, model, orderBy)
+    }
+
+    override suspend fun replaceOneIgnoringResult(
+        condition: Condition<T>,
+        model: T,
+        orderBy: List<SortPart<T>>,
+    ): Boolean {
+        record(DataAccessOperation.Replace, condition, sort = sortText(orderBy))
+        return wraps.replaceOneIgnoringResult(condition, model, orderBy)
+    }
+
+    override suspend fun updateOne(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        orderBy: List<SortPart<T>>,
+    ): EntryChange<T> {
+        record(DataAccessOperation.Update, condition, sortText(orderBy), modificationText(modification))
+        return wraps.updateOne(condition, modification, orderBy)
+    }
+
+    override suspend fun updateOneIgnoringResult(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        orderBy: List<SortPart<T>>,
+    ): Boolean {
+        record(DataAccessOperation.Update, condition, sortText(orderBy), modificationText(modification))
+        return wraps.updateOneIgnoringResult(condition, modification, orderBy)
+    }
+
+    override suspend fun updateMany(
+        condition: Condition<T>,
+        modification: Modification<T>,
+    ): CollectionChanges<T> {
+        record(DataAccessOperation.Update, condition, modification = modificationText(modification))
+        return wraps.updateMany(condition, modification)
+    }
+
+    override suspend fun updateManyIgnoringResult(
+        condition: Condition<T>,
+        modification: Modification<T>,
+    ): Int {
+        record(DataAccessOperation.Update, condition, modification = modificationText(modification))
+        return wraps.updateManyIgnoringResult(condition, modification)
+    }
+
+    override suspend fun deleteOne(condition: Condition<T>, orderBy: List<SortPart<T>>): T? {
+        record(DataAccessOperation.Delete, condition, sort = sortText(orderBy))
+        return wraps.deleteOne(condition, orderBy)
+    }
+
+    override suspend fun deleteOneIgnoringOld(condition: Condition<T>, orderBy: List<SortPart<T>>): Boolean {
+        record(DataAccessOperation.Delete, condition, sort = sortText(orderBy))
+        return wraps.deleteOneIgnoringOld(condition, orderBy)
+    }
+
+    override suspend fun deleteMany(condition: Condition<T>): List<T> {
+        record(DataAccessOperation.Delete, condition)
+        return wraps.deleteMany(condition)
+    }
+
+    override suspend fun deleteManyIgnoringOld(condition: Condition<T>): Int {
+        record(DataAccessOperation.Delete, condition)
+        return wraps.deleteManyIgnoringOld(condition)
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DataAccessLogTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/DataAccessLogTest.kt
@@ -1,0 +1,288 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.auth.noAuth
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.http.get
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.typed.ApiHttpHandler
+import com.lightningkite.lightningserver.definition.PreDeployTask
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.typed.explicitModelInfo
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.services.database.ModelPermissions
+import kotlinx.serialization.builtins.serializer
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.database.*
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.uuid.Uuid
+
+/**
+ * The data access log exists to close what the disclosure log structurally cannot see: reads that
+ * leak information without disclosing a record. Each test here is one of those channels.
+ */
+class DataAccessLogTest {
+
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val cache = setting("cache", Cache.Settings())
+        val audit = path.path("audit") include AuditCore(database)
+        val dataAccessLog = path.path("audit-data-access") include DataAccessLog(audit)
+
+        init {
+            registerBasicMediaTypeCoders()
+        }
+
+        val patients = database.registerTable("Patient", Patient.serializer())
+
+        /** Not audited, so it must generate no rows at all. */
+        val plain = database.registerTable("Plain", PlainThing.serializer())
+
+        /** Not audited itself, but contains an audited model — the shape that used to slip through. */
+        val wrappers = database.registerTable("Wrapper", PatientWrapper.serializer())
+
+        /** A full ModelInfo, so the two raw-table accessors can be told apart. */
+        val patientInfo = database.explicitModelInfo(
+            auth = noAuth,
+            serializer = Patient.serializer(),
+            idSerializer = Uuid.serializer(),
+            tableName = "PatientInfo",
+            log = { dataAccessLog.dataAccessLogged(it) },
+            permissions = { ModelPermissions() },
+        )
+
+        /**
+         * The audit registry assigns ids by scanning endpoint serializers, never tables, so an
+         * audited model needs an endpoint that can return it before it has an id at all. Present
+         * only for that — no test calls it. See the limitation noted on [dataAccessLogged].
+         */
+        val sample = Patient(_id = Uuid.parse("00000000-0000-0000-0000-0000000000b1"), name = "", ssn = "")
+
+        val patientEndpoint = path.path("patient").get bind ApiHttpHandler(
+            summary = "Patient",
+            auth = noAuth,
+            implementation = { _: Unit -> sample },
+        )
+    }
+
+    private fun onServer(block: suspend context(ServerRuntime) (ServerRuntime) -> Unit) = runBlocking {
+        TestServer.test(settings = { database set Database.Settings(); cache set Cache.Settings() }) {
+            val done = HashSet<PreDeployTask>()
+            suspend fun run(task: PreDeployTask) {
+                if (!done.add(task)) return
+                task.dependencies().forEach { run(it) }
+                with(serverRuntime) { task.execute() }
+            }
+            serverRuntime.server.preDeployTasks.values.forEach { run(it) }
+            block(serverRuntime, serverRuntime)
+        }
+    }
+
+    context(server: ServerRuntime)
+    private suspend fun logged() = TestServer.dataAccessLog.dataAccess().find(Condition.Always).toList()
+
+    context(server: ServerRuntime)
+    private fun auditedTable() = TestServer.dataAccessLog.dataAccessLogged(TestServer.patients())
+
+    @Test
+    fun `a group count over a sensitive field is recorded, though it discloses no record`() = onServer {
+        val table = auditedTable()
+        table.groupCount(Condition.Always, Patient.path.ssn)
+
+        val row = logged().single()
+        assertEquals(DataAccessOperation.GroupCount, row.operation)
+        assertEquals("ssn", row.groupBy)
+    }
+
+    /**
+     * `find(ssn eq "X")` returning nothing discloses nothing under the field-presence rule, and tells
+     * an attacker the same bit a count would. The condition is the evidence.
+     */
+    @Test
+    fun `an existence probe that returns nothing is still recorded, with its condition`() = onServer {
+        val table = auditedTable()
+        assertEquals(0, table.find(condition<Patient> { it.ssn.eq("guess") }).count())
+
+        val row = logged().single()
+        assertEquals(DataAccessOperation.Find, row.operation)
+        assertTrue("guess" in row.condition, "the probed value is not recoverable from the record")
+    }
+
+    /** A sort plus skip walks values without ever matching one, so the ordering has to be recorded. */
+    @Test
+    fun `a sort is recorded`() = onServer {
+        val table = auditedTable()
+        table.find(Condition.Always, orderBy = listOf(SortPart(Patient.path.ssn))).toList()
+
+        val row = logged().single()
+        assertTrue(row.sort?.contains("ssn") == true, "the ordering was not recorded: ${row.sort}")
+    }
+
+    @Test
+    fun `a count is recorded`() = onServer {
+        val table = auditedTable()
+        table.count(condition<Patient> { it.ssn.eq("probe") })
+
+        assertEquals(DataAccessOperation.Count, logged().single().operation)
+    }
+
+    /** Writes go through the same choke point; the modification is what says intent. */
+    @Test
+    fun `an update records its modification`() = onServer {
+        val table = auditedTable()
+        val id = Uuid.random()
+        table.insert(listOf(Patient(_id = id, name = "Ada", ssn = "s")))
+        table.updateOneById(id, modification<Patient> { it.ssn assign "changed" })
+
+        val update = logged().single { it.operation == DataAccessOperation.Update }
+        assertTrue(
+            update.modification?.contains("changed") == true,
+            "the modification was not recoverable from the record: ${update.modification}",
+        )
+    }
+
+    /**
+     * The central guarantee, and until now untested: a query whose record cannot be written must not
+     * run. Everything else here checks that rows appear; this checks that the read does not happen
+     * when they cannot.
+     */
+    @Test
+    fun `a query whose record cannot be written does not run`() = onServer { runtime ->
+        var reads = 0
+        val counting = object : com.lightningkite.services.database.Table<Patient> by TestServer.patients() {
+            override suspend fun count(condition: com.lightningkite.services.database.Condition<Patient>): Int {
+                reads++
+                return 0
+            }
+        }
+        val table = DataAccessLogTable(
+            wraps = counting,
+            modelId = { 1 },
+            requestId = Uuid.random(),
+            executionId = Uuid.random(),
+            json = runtime.internalSerialization.json,
+            nowMillis = { 1L },
+            write = { throw RuntimeException("audit sink down") },
+        )
+
+        try {
+            table.count(Condition.Always)
+            fail("the read happened even though its record could not be written")
+        } catch (_: RuntimeException) {
+        }
+        assertEquals(0, reads, "the underlying table was read despite the audit write failing")
+    }
+
+    /**
+     * An ordering plus a moving offset walks values one at a time. Without skip and limit on the
+     * record, the first probe and the four-thousandth are byte-identical, and the enumeration this
+     * layer exists to expose stays invisible.
+     */
+    @Test
+    fun `two probes at different offsets are distinguishable`() = onServer {
+        val table = auditedTable()
+        val sort = listOf(SortPart(Patient.path.ssn))
+        table.find(Condition.Always, orderBy = sort, skip = 0, limit = 1).toList()
+        table.find(Condition.Always, orderBy = sort, skip = 4_000, limit = 1).toList()
+
+        val offsets = logged().sortedBy { it.skip }.map { it.skip }
+        assertEquals(listOf(0, 4_000), offsets, "the walk's offsets were not recorded")
+    }
+
+    /**
+     * A table whose declared type is not itself audited but whose children are must be refused, not
+     * quietly passed through: a sealed parent's descriptor carries no annotation, so gating on that
+     * alone would leave every read of its audited children unrecorded and silent.
+     */
+    @Test
+    fun `a table that merely contains audited models is refused`() = onServer {
+        try {
+            TestServer.dataAccessLog.dataAccessLogged(TestServer.wrappers())
+            fail("a table containing audited models was silently left unlogged")
+        } catch (e: IllegalStateException) {
+            assertTrue("Patient" in (e.message ?: ""), "the contained model was not named: ${e.message}")
+        }
+    }
+
+    /** The decorator is meant to be passed on every model; an unaudited one must cost nothing. */
+    @Test
+    fun `an unaudited model generates no rows`() = onServer {
+        val table = TestServer.dataAccessLog.dataAccessLogged(TestServer.plain())
+        table.insert(listOf(PlainThing(Uuid.random(), "x")))
+        table.find(Condition.Always).toList()
+        table.count(Condition.Always)
+
+        assertEquals(emptyList(), logged())
+    }
+
+    /**
+     * The path production actually takes, and the one nothing exercised.
+     *
+     * `table()` applies `log` itself and is built on the *undecorated* table for exactly this reason:
+     * routing `collectionWithSignals()` through `baseTable()` would put the decorator on twice and
+     * record every query in duplicate. That invariant was asserted only in a code comment — mutation
+     * testing made `collectionWithSignals()` use `baseTable()` and every test in `audit`, `typed` and
+     * `sessions` stayed green, because nothing called `table()` on an audited model at all. The two
+     * accessors that *were* covered, `baseTable()` and `dangerouslyDirectTable()`, are the escape
+     * hatches rather than the normal route.
+     *
+     * A duplicated audit row is not a cosmetic problem: it double-counts disclosure, so "how many
+     * times was this record read" — the question the log exists to answer — comes back wrong.
+     */
+    @Test
+    fun `table records each query exactly once`() = onServer {
+        TestServer.patientInfo.table().count(Condition.Always)
+
+        assertEquals(
+            1,
+            logged().size,
+            "table() must record one row per query; more than one means the log decorator is applied twice",
+        )
+        assertEquals(DataAccessOperation.Count, logged().single().operation)
+    }
+
+    /**
+     * `baseTable()` means "without permissions", not "without a record". It was the real bypass — one
+     * production call site was updating a model through it with nothing logged — so it now goes
+     * through the same decorator as `table()`.
+     */
+    @Test
+    fun `baseTable is audited`() = onServer {
+        TestServer.patientInfo.baseTable().count(Condition.Always)
+
+        assertEquals(DataAccessOperation.Count, logged().single().operation)
+    }
+
+    /**
+     * The genuine bypass still exists, because migrations and similar work legitimately need it. What
+     * changed is that it is named, and reaching it requires opting in, so every bypass in a codebase
+     * is greppable.
+     */
+    @OptIn(com.lightningkite.lightningserver.typed.UnauditedDatabaseAccess::class)
+    @Test
+    fun `dangerouslyDirectTable is not audited`() = onServer {
+        TestServer.patientInfo.dangerouslyDirectTable().count(Condition.Always)
+
+        assertEquals(emptyList(), logged())
+    }
+
+    /** Both ids are carried: one to join, one to place the query at a precise execution. */
+    @Test
+    fun `each row carries the joining request id and the precise execution id`() = onServer { runtime ->
+        val table = auditedTable()
+        table.count(Condition.Always)
+
+        val row = logged().single()
+        assertEquals(runtime.initiator.executionId, row.executionId)
+        assertEquals(runtime.initiator.requestRecordId, row.requestId)
+    }
+}


### PR DESCRIPTION
**Stack: 12 of 16.** Based on `split/a2` — review that one first.
One row per query, including the privileged internal reads no request-shaped
hook can see: startup tasks, schedule ticks, one service reading another's
model. It records the condition and sort actually applied, which is what
closes the aggregation and oracle channels — a caller who cannot read a field
directly can still learn it a bit at a time by asking questions about it.

Two ways this differs from the layers around it, both deliberate:

- **It is opt-in per model**, via `dataAccessLogged`. It writes a row per
  *query* rather than per disclosure, so on a read-heavy model it is orders
  of magnitude more voluminous than everything else here combined. That is a
  cost to take on where the aggregation channel actually matters, not
  everywhere by reflex.
- **It installs no interceptor.** It attaches per model through `ModelInfo`'s
  `log` slot, using the `baseTable()`/`dangerouslyDirectTable()` separation
  added at the bottom of this stack.

Fail-closed, with the widest blast radius of any layer here: a query whose
record cannot be written does not run, and because this sits at the database
layer that stops privileged internal work too, not just request serving.

An audited model with no registry entry throws rather than logging nothing.
Resolution happens per operation rather than once at wrap time because the
`log` slot is not suspending while the registry loads asynchronously.

The record's `requestId` stores the initiator's `attributedTo` rather than the
execution's own id: a query run inside a task has no request row of its own, so
its own id would join to nothing. Identical for http and websocket executions,
which are their own anchor.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd