### PR TITLE
Layer 4: the authentication event log

### DIFF
--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/AuthEventRecord.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/AuthEventRecord.kt
@@ -1,0 +1,88 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.data.GenerateDataClassPaths
+import com.lightningkite.services.data.Index
+import com.lightningkite.services.database.HasId
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * What happened, for an authentication event.
+ *
+ * Deliberately coarse: each value is a distinction an auditor would act on differently. The
+ * `sessions` module recorded none of these — it had mutable *state* on a session row, which cannot
+ * answer "when did this account start failing logins", because state is overwritten and a failure
+ * counter is deleted on the next success. See `plans/audit-logging.md` 7.1.
+ */
+@Serializable
+public enum class AuthEventType {
+    /** A session was created — the event a `Session` row's existence only implies. */
+    SessionCreated,
+
+    /** A refresh token was exchanged for access. */
+    SessionUsed,
+
+    /** A session was ended, by its owner or by an administrator. */
+    SessionTerminated,
+
+    /** An authentication attempt was rejected. [AuthEventRecord.failureReason] says why. */
+    AuthenticationFailed,
+
+    /** A proof (password, TOTP, WebAuthN, backup code, emailed PIN) was accepted. */
+    ProofAccepted,
+
+    /** A proof was rejected. */
+    ProofRejected,
+}
+
+/**
+ * One authentication event: the history that a session row's mutable state cannot provide.
+ *
+ * The distinction that makes this a separate layer rather than a column somewhere: a `Session` row
+ * records that a session *exists*, not that a login *happened*. Everything the survey in
+ * `plans/audit-logging.md` 7.1 found was last-write-wins state on a row, an ephemeral cache counter
+ * deleted on the next success, or a debug `println`. None of those can be counted, ordered, or
+ * alerted on.
+ *
+ * @property requestId Joins to [RequestRecord], so an auth event and the disclosures made under the
+ *   resulting session share one identifier.
+ * @property principal Who the event is about — the subject id, as a string, since principals differ
+ *   in key type across a deployment.
+ * @property actor The principal that *caused* the event, when it differs from [principal] — an
+ *   administrator terminating someone else's session, or a masquerade. Null when they are the same.
+ * @property sourceIp Recorded only when actually observed. A placeholder here would read as a real
+ *   origin, which is the mistake this system already made once (7.1, finding 3).
+ * @property failureReason Why an attempt was rejected, for the failure event types. Populated from
+ *   the `AuthFailureReason` or `ProofFailureReason` enum in the sessions module.
+ * @property method How the attempt was made, for events that came from a particular mechanism — a
+ *   proof method's `via` ("password", "totp", "email"). Null for the refresh-token path, which has
+ *   only one mechanism. Without it "which account is being attacked" is answerable but "with what"
+ *   is not, and those two call for different responses.
+ * @property methodProperty The property [method] was applied to, where it has one — the `email` of
+ *   an emailed PIN. Null for methods that identify the subject directly, such as a password.
+ */
+@GenerateDataClassPaths
+@Serializable
+public data class AuthEventRecord(
+    override val _id: Uuid,
+    @Index val requestId: Uuid,
+    @Index val type: AuthEventType,
+    @Index val principal: String? = null,
+    val actor: String? = null,
+    val sessionId: String? = null,
+    val sourceIp: String? = null,
+    val userAgent: String? = null,
+    val failureReason: String? = null,
+    val method: String? = null,
+    val methodProperty: String? = null,
+) : HasId<Uuid> {
+    /** When the event happened, derived from the version-7 [_id]. See [RequestRecord]. */
+    @OptIn(ExperimentalUuidApi::class)
+    public val at: Instant
+        get() = Instant.fromEpochMilliseconds(_id.epochMilliseconds)
+
+    public companion object
+}
+

--- a/audit/build.gradle.kts
+++ b/audit/build.gradle.kts
@@ -21,6 +21,11 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit)
+
+    // Test-only. The auth event log's whole point is that something else raises the events, so
+    // proving the seam is actually reached needs the module that raises them. `sessions` does not
+    // depend on `audit`, so this stays one-directional.
+    testImplementation(project(":sessions"))
 }
 
 kotlin {

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
@@ -60,3 +60,30 @@ public class DataAccessLog(private val core: AuditCore) : ServerBuilder() {
     }
 }
 
+/**
+ * Layer 4: authentication events — the history a mutable session row cannot provide.
+ *
+ * A `Session` row records that a session *exists*, not that a login *happened*. Everything the survey
+ * in `audit-logging.md` 7.1 found was last-write-wins state, an ephemeral counter deleted on the next
+ * success, or a debug `println`.
+ *
+ * ## Failure behaviour: fail-open, deliberately and uniquely
+ * Unlike the layers above, this one logs and swallows a write failure. Those gate *disclosure*, so the
+ * guarded thing must not happen unrecorded. An authentication event has already happened by the time
+ * it is reported, and is usually reported from a path that is itself rejecting something — throwing
+ * would replace a clean "your login failed" with an unrelated server error and lose the original
+ * reason. The cost, stated plainly: an attacker who can make the audit database unavailable can make
+ * authentication events go unrecorded while authentication keeps working. See 7.3.1.
+ *
+ * @property authEvents One row per authentication event.
+ */
+public class AuthEventLog(private val core: AuditCore) : ServerBuilder() {
+    public val authEvents: DatabaseTableRegistration<AuthEventRecord> =
+        core.database.registerTable("AuditAuthEvent", AuthEventRecord.serializer())
+
+    init {
+        core.claim("AuthEventLog")
+        install(AuthEventLogReporter(authEvents))
+    }
+}
+

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuthEventLogReporter.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuthEventLogReporter.kt
@@ -1,0 +1,74 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.definition.Runtime
+import io.github.oshai.kotlinlogging.KotlinLogging
+import com.lightningkite.lightningserver.runtime.AuthEventReporter
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.services.database.Table
+import com.lightningkite.services.database.insertOne
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Writes authentication events to the audit database and folds them into the tamper-evidence chain.
+ *
+ * ## Why this one does not fail closed
+ * The disclosure and data access logs gate *disclosure*: the thing they guard must not happen unless
+ * it was recorded, so they throw. An authentication event is different in kind — it has already
+ * happened by the time it is reported, and is usually reported from a path that is itself rejecting
+ * something. Throwing here would replace a clean "your login failed" with an unrelated server error
+ * and lose the original reason. So a write failure is logged loudly and swallowed.
+ *
+ * That is a real weakening: an attacker who can make the audit database unavailable can make
+ * authentication events go unrecorded while authentication still works. It is recorded in
+ * `plans/audit-logging.md` 7.3 as a deliberate asymmetry rather than an oversight.
+ */
+private val authEventLogger = KotlinLogging.logger("com.lightningkite.lightningserver.audit.AuthEventLog")
+
+@OptIn(ExperimentalUuidApi::class)
+public class AuthEventLogReporter(
+    private val table: Runtime<Table<AuthEventRecord>>,
+) : AuthEventReporter {
+    override val name: String = "AuthEventLog"
+
+    context(runtime: ServerRuntime)
+    override suspend fun report(
+        type: String,
+        principal: String?,
+        actor: String?,
+        sessionId: String?,
+        sourceIp: String?,
+        userAgent: String?,
+        detail: String?,
+        method: String?,
+        methodProperty: String?,
+    ) {
+        val parsed = AuthEventType.entries.firstOrNull { it.name == type }
+        if (parsed == null) {
+            authEventLogger.error { "Unknown auth event type \"$type\"; not recorded." }
+            return
+        }
+        val record = AuthEventRecord(
+            _id = Uuid.generateV7NonMonotonicAt(runtime.clock.now()),
+            requestId = runtime.initiator.requestRecordId,
+            type = parsed,
+            principal = principal,
+            actor = actor,
+            sessionId = sessionId,
+            sourceIp = sourceIp,
+            userAgent = userAgent,
+            failureReason = detail,
+            method = method,
+            methodProperty = methodProperty,
+        )
+        try {
+            with(runtime) { table().insertOne(record) }
+        } catch (e: Exception) {
+            // Cancellation is the caller being torn down, not a sink failure. Swallowing it here
+            // would report this coroutine as having completed normally and break structured
+            // concurrency on every cancelled request.
+            if (e is kotlin.coroutines.cancellation.CancellationException) throw e
+            authEventLogger.error(e) { "Failed to record auth event $parsed; authentication continued unrecorded." }
+        }
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/AuthEventLogTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/AuthEventLogTest.kt
@@ -1,0 +1,81 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.Database
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The auth event log is reached through a reporter installed on the server, because an authentication
+ * failure touches nothing the other layers observe: the login endpoints are `noAuth` and throw before
+ * any authentication resolves, so the access log cannot see them, and nothing is written to a table.
+ */
+class AuthEventLogTest {
+
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val cache = setting("cache", Cache.Settings())
+        val audit = path.path("audit") include AuditCore(database)
+        val authEventLog = path.path("audit-auth") include AuthEventLog(audit)
+    }
+
+    private fun onServer(block: suspend context(ServerRuntime) (ServerRuntime) -> Unit) = runBlocking {
+        TestServer.test(settings = { database set Database.Settings(); cache set Cache.Settings() }) {
+            block(serverRuntime, serverRuntime)
+        }
+    }
+
+    context(server: ServerRuntime)
+    private suspend fun events() = TestServer.authEventLog.authEvents().find(Condition.Always).toList()
+
+    @Test
+    fun `a reported failure becomes a queryable record`() = onServer { runtime ->
+        runtime.server.authEventReporters.single().report(
+            type = "AuthenticationFailed",
+            principal = "user-1",
+            detail = "SecretMismatch",
+        )
+
+        val event = events().single()
+        assertEquals(AuthEventType.AuthenticationFailed, event.type)
+        assertEquals("user-1", event.principal)
+        assertEquals("SecretMismatch", event.failureReason)
+        assertEquals(runtime.initiator.requestRecordId, event.requestId)
+    }
+
+    /**
+     * A reporter must not throw: it is called from paths that are already rejecting something, and a
+     * second failure there would replace a clean rejection with an unrelated error and lose the
+     * original reason. An unknown type is logged and dropped rather than raised.
+     */
+    @Test
+    fun `an unrecognised event type is dropped, not thrown`() = onServer { runtime ->
+        runtime.server.authEventReporters.single().report(type = "NotAnEventType")
+
+        assertEquals(emptyList(), events())
+    }
+
+    /** Events join to the same request record as the disclosures made under the resulting session. */
+    @Test
+    fun `an actor is recorded separately from the subject`() = onServer { runtime ->
+        runtime.server.authEventReporters.single().report(
+            type = "SessionTerminated",
+            principal = "victim",
+            actor = "administrator",
+        )
+
+        val event = events().single()
+        assertEquals("victim", event.principal)
+        assertEquals("administrator", event.actor)
+    }
+
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/AuthEventLogWiringTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/AuthEventLogWiringTest.kt
@@ -1,0 +1,260 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.auth.PrincipalType
+import com.lightningkite.lightningserver.definition.Runtime
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.*
+import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.handle
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.sessions.RefreshToken
+import com.lightningkite.lightningserver.sessions.SessionManager
+import com.lightningkite.lightningserver.sessions.token.PrivateTinyTokenFormat
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.data.MediaType
+import com.lightningkite.services.data.TypedData
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.Database
+import com.lightningkite.services.database.HasId
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * The auth event log's *wiring*, driven through a real rejected authentication.
+ *
+ * [AuthEventLogTest] calls the reporter directly, which proves the writer works and nothing at all
+ * about whether anything ever calls it — the seam was shipped once with the call site passing its
+ * free text into `sessionId`, and no test noticed. These go in through the refresh-token endpoint,
+ * which is the flagship case for the seam existing: it is `noAuth` and rejects before any
+ * authentication resolves, so no other audit layer can see the failure.
+ */
+class AuthEventLogWiringTest {
+
+    @Serializable
+    data class WiringUser(override val _id: Uuid) : HasId<Uuid> {
+        companion object : PrincipalType<WiringUser, Uuid> {
+            override val idSerializer: KSerializer<Uuid> = Uuid.serializer()
+            override val subjectSerializer: KSerializer<WiringUser> = WiringUser.serializer()
+
+            context(server: ServerRuntime)
+            override suspend fun fetch(id: Uuid): WiringUser = WiringUser(id)
+        }
+    }
+
+    class WiringSessionManager(database: Runtime<Database>) : SessionManager<WiringUser, Uuid>(
+        principal = WiringUser,
+        database = database,
+        tokenFormat = Runtime { PrivateTinyTokenFormat() },
+    ) {
+        context(server: ServerRuntime)
+        override suspend fun sessionExpiration(subject: WiringUser): Instant? = null
+
+        context(server: ServerRuntime)
+        override suspend fun permitAuthentication(subject: WiringUser): Boolean = true
+
+        context(server: ServerRuntime)
+        override suspend fun sessionStaleAfter(subject: WiringUser): Duration? = null
+    }
+
+    /**
+     * The core and the auth event log only — no disclosure or data access log — because that is also
+     * the combination a deployment that only wants a login trail would include.
+     */
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val cache = setting("cache", Cache.Settings())
+
+        val audit = path.path("audit") include AuditCore(database)
+        val authEventLog = path.path("audit-auth") include AuthEventLog(audit)
+
+        val sessions = path.path("auth") include WiringSessionManager(database)
+
+        init {
+            registerBasicMediaTypeCoders()
+        }
+    }
+
+    private fun testId(n: Int) = Uuid.parse("00000000-0000-4000-8000-" + n.toString().padStart(12, '0'))
+
+    /** A POST to the refresh-token endpoint carrying [token] as its JSON string body. */
+    private fun tokenExchange(token: String, userAgent: String? = null) = HttpRequest<PathSpec>(
+        path = RawHttpEndpoint(asString = "/auth/token/simple", method = HttpMethod.POST),
+        queryParameters = QueryParameters.EMPTY,
+        headers = HttpHeaders {
+            add(HttpHeader.ContentType, MediaType.Application.Json.toString())
+            userAgent?.let { add(HttpHeader.UserAgent, it) }
+        },
+        domain = "example.com",
+        protocol = "https",
+        sourceIp = "203.0.113.7",
+        body = TypedData.text("\"$token\"", MediaType.Application.Json),
+    )
+
+    private fun onServer(block: suspend context(ServerRuntime) () -> Unit) = runBlocking {
+        TestServer.test(settings = { database set Database.Settings(); cache set Cache.Settings() }) {
+            block(serverRuntime)
+        }
+    }
+
+    context(server: ServerRuntime)
+    private suspend fun events() = TestServer.authEventLog.authEvents().find(Condition.Always).toList()
+
+    /**
+     * A refresh token naming a real session but carrying the wrong secret. The most interesting
+     * rejection to record, because it is the one that means someone is guessing.
+     */
+    context(server: ServerRuntime)
+    private suspend fun tokenWithWrongSecret(subjectId: Uuid = Uuid.random()): Pair<Uuid, String> {
+        val (session, _) = TestServer.sessions.newSession(subjectId)
+        return session._id to RefreshToken("WiringUser", session._id, "not-the-secret").string
+    }
+
+    @Test
+    fun `a rejected refresh token reaches the reporter and lands in the table`() = onServer {
+        val (sessionId, token) = tokenWithWrongSecret()
+
+        val response = serverRuntime.handle(tokenExchange(token, userAgent = "probe/1.0"), testId(1))
+        assertEquals(HttpStatus.Unauthorized, response.status)
+
+        val event = events().single()
+        assertEquals(AuthEventType.AuthenticationFailed, event.type)
+        assertEquals("SecretMismatch", event.failureReason)
+        assertEquals(sessionId.toString(), event.sessionId)
+    }
+
+    /**
+     * The account the attempt was against. `AuthEventRecord` indexes this column precisely so that
+     * "when did this account start failing logins" is answerable, which is the question the layer
+     * exists for — and nothing checked that the call site fills it in. Mutation testing confirmed
+     * the gap: passing null for `principal` in `SessionManager.authFailed` left every test in
+     * `audit`, `sessions` and `typed` green. `AuthEventLogTest` asserts the field, but it calls the
+     * reporter directly, so it covers the writer and not the caller — the same split this file's
+     * header describes for `sessionId`.
+     */
+    @Test
+    fun `the event names the account the attempt was against`() = onServer {
+        val subjectId = Uuid.parse("00000000-0000-4000-8000-00000000beef")
+        val (_, token) = tokenWithWrongSecret(subjectId)
+
+        serverRuntime.handle(tokenExchange(token, userAgent = "probe/1.0"), testId(7))
+
+        assertEquals(
+            subjectId.toString(),
+            events().single().principal,
+            "without the principal, the log cannot answer which account was being attacked",
+        )
+    }
+
+    /** Where the attempt came from, as observed on the request that made it. */
+    @Test
+    fun `the observed source ip and user agent are recorded`() = onServer {
+        val (_, token) = tokenWithWrongSecret()
+
+        serverRuntime.handle(tokenExchange(token, userAgent = "probe/1.0"), testId(2))
+
+        val event = events().single()
+        assertEquals("203.0.113.7", event.sourceIp)
+        assertEquals("probe/1.0", event.userAgent)
+    }
+
+    /**
+     * Absent is absent. A blank user agent in this column would read as a genuine observation to
+     * whoever queries the log, which is the mistake the session row's `userAgents` set already made
+     * once.
+     */
+    @Test
+    fun `an unobserved user agent is null rather than blank`() = onServer {
+        val (_, token) = tokenWithWrongSecret()
+
+        serverRuntime.handle(tokenExchange(token, userAgent = null), testId(3))
+
+        val event = events().single()
+        assertNull(event.userAgent, "an unsent user agent must not be recorded as an observed one")
+        assertEquals("203.0.113.7", event.sourceIp)
+    }
+
+    /** A well-formed token naming a session that never existed. Costs an attacker nothing to make. */
+    private fun forgedToken() = RefreshToken("WiringUser", Uuid.random(), "anything").string
+
+    /**
+     * A refresh token is not signed — [RefreshToken.valid] is a prefix check and the session id is
+     * read back out of the attacker's own string — so anyone can produce a `NoSuchSession` rejection
+     * on demand. Recording it would mean an unauthenticated caller writes one audit row per request,
+     * into the same database the fail-closed disclosure and data access logs depend on.
+     *
+     * The rejection itself must not change: the request still fails, it just is not evidence.
+     */
+    @Test
+    fun `a forged token naming no real session is rejected without recording an event`() = onServer {
+        val response = serverRuntime.handle(tokenExchange(forgedToken(), userAgent = "probe/1.0"), testId(5))
+
+        assertEquals(HttpStatus.Unauthorized, response.status)
+        assertTrue(
+            events().isEmpty(),
+            "a rejection anyone can forge was recorded as an authentication event, which lets an " +
+                "unauthenticated caller grow the audit table one row at a time",
+        )
+    }
+
+    /**
+     * The amplification property itself, rather than one instance of it. This is the assertion that
+     * would have failed before `reachableWithoutCredentials` existed: the guard used to be a
+     * two-value list inside `authFailed`, and `NoSuchSession` was added to the enum afterwards
+     * without being added to the list.
+     */
+    @Test
+    fun `spraying forged tokens cannot grow the audit table`() = onServer {
+        repeat(25) { serverRuntime.handle(tokenExchange(forgedToken()), testId(100 + it)) }
+
+        assertEquals(0, events().size, "forged tokens wrote audit rows")
+    }
+
+    /**
+     * The other half of the trade: the attempt is not invisible, it is just recorded as a request
+     * rather than as an authentication event. Without this the mitigation above would be dropping
+     * the evidence rather than relocating it.
+     */
+    @Test
+    fun `a forged attempt is still visible in the request log`() = onServer {
+        serverRuntime.handle(tokenExchange(forgedToken()), testId(6))
+
+        val requests = TestServer.audit.requests().find(Condition.Always).toList()
+        assertTrue(
+            requests.any { it._id == testId(6) },
+            "a forged attempt left no trace at all — it must still appear as a request",
+        )
+    }
+
+    /**
+     * The event has to join the request record for the attempt, or an auditor cannot put the failure
+     * next to anything else that happened on that request.
+     */
+    @Test
+    fun `the event joins the request record of the attempt`() = onServer {
+        val (_, token) = tokenWithWrongSecret()
+
+        serverRuntime.handle(tokenExchange(token, userAgent = "probe/1.0"), testId(4))
+
+        assertEquals(testId(4), events().single().requestId)
+        val requests = TestServer.audit.requests().find(Condition.Always).toList()
+        assertTrue(
+            requests.any { it._id == testId(4) },
+            "the auth event points at a request record that was never written",
+        )
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/ProofAuthEventWiringTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/ProofAuthEventWiringTest.kt
@@ -1,0 +1,494 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.auth.PrincipalType
+import com.lightningkite.lightningserver.auth.idString
+import com.lightningkite.lightningserver.auth.register
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.*
+import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.handle
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.sessions.*
+import com.lightningkite.lightningserver.sessions.proofs.*
+import com.lightningkite.lightningserver.sessions.proofs.extensions.code
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.data.MediaType
+import com.lightningkite.services.data.TypedData
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.Database
+import com.lightningkite.services.database.HasId
+import com.lightningkite.services.database.insertOne
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+
+/**
+ * The proof endpoints' auth-event wiring, driven through real HTTP requests.
+ *
+ * Same reasoning as [AuthEventLogWiringTest]: [AuthEventLogTest] proves the writer works and nothing
+ * about whether anything calls it. These go in through `prove`, which is where credential *guessing*
+ * happens — `SessionManager.authFailed` only ever saw refresh-token rejections, which are mostly
+ * expired sessions.
+ *
+ * ## What this file deliberately does not assume
+ * Proof *issuance* and proof *acceptance* are different events. `Signer.makeProof` is reached both by
+ * a `prove` handler that has just checked a secret and by `PinBasedProofEndpoints.issueProof`, which
+ * mints a proof to be mailed to somebody (a magic link) with nothing presented at all. Only the first
+ * is an acceptance; `a mailed magic link is not recorded as an accepted proof` pins that down.
+ */
+class ProofAuthEventWiringTest {
+
+    @Serializable
+    data class ProofUser(
+        override val _id: Uuid = Uuid.random(),
+        val email: String = "",
+    ) : HasId<Uuid> {
+        companion object : PrincipalType<ProofUser, Uuid> {
+            override val idSerializer: KSerializer<Uuid> = Uuid.serializer()
+            override val subjectSerializer: KSerializer<ProofUser> = serializer()
+
+            val users: MutableMap<Uuid, ProofUser> = mutableMapOf()
+
+            context(server: ServerRuntime)
+            override suspend fun fetch(id: Uuid): ProofUser = users[id] ?: ProofUser(id)
+
+            override fun normalizePropertyValue(property: String, value: String): String =
+                if (property == "email") value.lowercase().trim() else value
+
+            context(server: ServerRuntime)
+            override suspend fun fetchByProperty(property: String, value: String): ProofUser? = when (property) {
+                "email" -> users.values.find { it.email == value }
+                "ProofUser/_id" -> users.values.find { it._id.toString() == value }
+                else -> super.fetchByProperty(property, value)
+            }
+        }
+    }
+
+    /** A PIN method with delivery replaced by a capture, so the code is available to the test. */
+    class CapturingPinEndpoints(pin: PinHandler) : PinBasedProofEndpoints(
+        name = "testpin",
+        property = "email",
+        proofExpiration = 1.hours,
+        pin = pin,
+        exampleTarget = "test@test.com",
+    ) {
+        val sent: MutableList<Pair<String, String>> = mutableListOf()
+
+        context(_: ServerRuntime)
+        override suspend fun send(to: String, pin: String) {
+            sent += to to pin
+        }
+
+        /** Reaches the magic-link mint, which is `protected` on the base class. */
+        context(_: ServerRuntime)
+        suspend fun mintMagicLink(destination: String): Proof = issueProof(destination)
+    }
+
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val cache = setting("cache", Cache.Settings())
+
+        val audit = path.path("audit") include AuditCore(database)
+        val authEventLog = path.path("audit-auth") include AuthEventLog(audit)
+
+        val password = path.path("password") include PasswordProofEndpoints(database, cache)
+        val totp = path.path("totp") include TimeBasedOTPProofEndpoints(database, cache)
+        val backupCode = path.path("backup") include BackupCodeEndpoints(database, cache)
+        val knownDevice = path.path("device") include KnownDeviceProofEndpoints(database, cache)
+        val pin = path.path("pin") include CapturingPinEndpoints(PinHandler(cache, "testpin"))
+        val webAuthN = path.path("webauthn") include WebAuthNProofEndpoints(
+            database = database,
+            cache = cache,
+            rpId = { "example.com" },
+            registrationForUser = { _, _ ->
+                WebAuthN.Registration.RegistrationOptions(
+                    user = WebAuthN.PublicKeyCredentialUserEntity("Test", "id", "test")
+                )
+            },
+        )
+
+        init {
+            register(ProofUser)
+            registerBasicMediaTypeCoders()
+        }
+    }
+
+    private val json = Json { encodeDefaults = true }
+
+    private fun testId(n: Int) = Uuid.parse("00000000-0000-4000-8000-" + n.toString().padStart(12, '0'))
+
+    private fun post(
+        path: String,
+        body: String,
+        userAgent: String? = "probe/1.0",
+        sourceIp: String = "203.0.113.7",
+    ) = HttpRequest<PathSpec>(
+        path = RawHttpEndpoint(asString = path, method = HttpMethod.POST),
+        queryParameters = QueryParameters.EMPTY,
+        headers = HttpHeaders {
+            add(HttpHeader.ContentType, MediaType.Application.Json.toString())
+            userAgent?.let { add(HttpHeader.UserAgent, it) }
+        },
+        domain = "example.com",
+        protocol = "https",
+        sourceIp = sourceIp,
+        body = TypedData.text(body, MediaType.Application.Json),
+    )
+
+    private fun identify(property: String, value: String, secret: String) = json.encodeToString(
+        IdentificationAndPassword.serializer(),
+        IdentificationAndPassword(type = "ProofUser", property = property, value = value, password = secret),
+    )
+
+    private fun onServer(block: suspend context(ServerRuntime) () -> Unit) = runBlocking {
+        ProofUser.users.clear()
+        TestServer.test(settings = { database set Database.Settings(); cache set Cache.Settings() }) {
+            block(serverRuntime)
+        }
+    }
+
+    context(server: ServerRuntime)
+    private suspend fun events() = TestServer.authEventLog.authEvents().find(Condition.Always).toList()
+
+    private fun user(email: String = "victim@example.com"): ProofUser =
+        ProofUser(Uuid.random(), email).also { ProofUser.users[it._id] = it }
+
+    // ---- password ----------------------------------------------------------------------------
+
+    /**
+     * The flagship case. A wrong password against a real account is the event the whole layer exists
+     * for, and before this it was recorded nowhere at all: `prove` is `noAuth` and throws, so no
+     * other audit layer sees it either.
+     */
+    @Test
+    fun `a rejected password names the account and the method`() = onServer {
+        val victim = user()
+        TestServer.password.establish(ProofUser, victim._id, EstablishPassword("correct-horse"))
+
+        val response = serverRuntime.handle(
+            post("/password/prove", identify("email", victim.email, "wrong-password")),
+            testId(1),
+        )
+        assertEquals(HttpStatus.BadRequest, response.status)
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals(victim._id.toString(), event.principal, "the log must say which account was attacked")
+        assertEquals("SecretMismatch", event.failureReason)
+        assertEquals("password", event.method)
+    }
+
+    /** Where the attempt came from, as observed on the request that carried it. */
+    @Test
+    fun `the observed source ip and user agent are recorded`() = onServer {
+        val victim = user()
+        TestServer.password.establish(ProofUser, victim._id, EstablishPassword("correct-horse"))
+
+        serverRuntime.handle(post("/password/prove", identify("email", victim.email, "nope")), testId(2))
+
+        val event = events().single()
+        assertEquals("203.0.113.7", event.sourceIp)
+        assertEquals("probe/1.0", event.userAgent)
+    }
+
+    /** Absent is absent: a blank user agent would read as a genuine observation. */
+    @Test
+    fun `an unobserved user agent is null rather than blank`() = onServer {
+        val victim = user()
+        TestServer.password.establish(ProofUser, victim._id, EstablishPassword("correct-horse"))
+
+        serverRuntime.handle(
+            post("/password/prove", identify("email", victim.email, "nope"), userAgent = null),
+            testId(3),
+        )
+
+        val event = events().single()
+        assertNull(event.userAgent, "an unsent user agent must not be recorded as an observed one")
+        assertEquals("203.0.113.7", event.sourceIp)
+    }
+
+    /**
+     * A guess at an account that does not exist. Recorded — a run of these against different
+     * addresses is what enumeration looks like — but with no principal, because none resolved and
+     * inventing one would make the row assert something that did not happen.
+     */
+    @Test
+    fun `a failure against no account is still recorded, with no principal`() = onServer {
+        val response = serverRuntime.handle(
+            post("/password/prove", identify("email", "nobody@example.com", "guess")),
+            testId(4),
+        )
+        assertEquals(HttpStatus.BadRequest, response.status)
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals("NoSuchSubject", event.failureReason)
+        assertNull(event.principal, "no account resolved, so there is no principal to name")
+        assertEquals("password", event.method)
+    }
+
+    /** The other half: an accepted credential is an event too, and the one a rejection is counted against. */
+    @Test
+    fun `an accepted password is recorded`() = onServer {
+        val victim = user()
+        TestServer.password.establish(ProofUser, victim._id, EstablishPassword("correct-horse"))
+
+        val response = serverRuntime.handle(
+            post("/password/prove", identify("email", victim.email, "correct-horse")),
+            testId(5),
+        )
+        assertEquals(HttpStatus.OK, response.status)
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofAccepted, event.type)
+        assertEquals(victim._id.toString(), event.principal)
+        assertEquals("password", event.method)
+        assertNull(event.failureReason)
+    }
+
+    /**
+     * Once the limiter starts answering, the guesses stop reaching the credential check — and without
+     * this, stop leaving any trace, so "is this still going on?" becomes unanswerable at exactly the
+     * point it matters.
+     */
+    @Test
+    fun `attempts that continue past the rate limit are recorded`() = onServer {
+        val victim = user()
+        TestServer.password.establish(ProofUser, victim._id, EstablishPassword("correct-horse"))
+
+        repeat(8) {
+            serverRuntime.handle(post("/password/prove", identify("email", victim.email, "nope")), testId(10 + it))
+        }
+
+        assertTrue(
+            events().any { it.failureReason == "RateLimited" },
+            "a blocked attempt left no record, so a continuing attack looks like it stopped",
+        )
+    }
+
+    // ---- TOTP --------------------------------------------------------------------------------
+
+    context(server: ServerRuntime)
+    private suspend fun totpFor(victim: ProofUser): TotpSecret = TotpSecret(
+        subjectId = ProofUser.idString(victim._id),
+        subjectType = ProofUser.name,
+        secretBase32 = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ",
+        label = "test",
+        issuer = "TestApp",
+        period = 30.seconds,
+        digits = 6,
+        algorithm = TotpHashAlgorithm.SHA1,
+        establishedAt = Clock.System.now(),
+        lastUsedAt = Clock.System.now(),
+    ).also { TestServer.totp.modelInfo.table().insertOne(it) }
+
+    @Test
+    fun `a rejected TOTP code names the account and the method`() = onServer {
+        val victim = user()
+        totpFor(victim)
+
+        serverRuntime.handle(
+            post("/totp/prove", identify("ProofUser/_id", victim._id.toString(), "000000")),
+            testId(20),
+        )
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals(victim._id.toString(), event.principal)
+        assertEquals("SecretMismatch", event.failureReason)
+        assertEquals("totp", event.method)
+    }
+
+    /** A replayed code is a different event from a wrong one: it means the code leaked, not that it was guessed. */
+    @Test
+    fun `a replayed TOTP code is recorded as a reuse`() = onServer {
+        val victim = user()
+        val secret = totpFor(victim)
+        val body = identify("ProofUser/_id", victim._id.toString(), secret.code)
+
+        serverRuntime.handle(post("/totp/prove", body), testId(21))
+        serverRuntime.handle(post("/totp/prove", body), testId(22))
+
+        val all = events()
+        assertEquals(1, all.count { it.type == AuthEventType.ProofAccepted })
+        val rejected = all.single { it.type == AuthEventType.ProofRejected }
+        assertEquals("SecretAlreadyUsed", rejected.failureReason)
+        assertEquals(victim._id.toString(), rejected.principal)
+    }
+
+    // ---- backup codes ------------------------------------------------------------------------
+
+    @Test
+    fun `a rejected backup code names the account and the method`() = onServer {
+        val victim = user()
+        TestServer.backupCode.modelInfo.table().insertOne(
+            BackupCodeSecret(
+                code = "abcdefghij",
+                subjectId = ProofUser.idString(victim._id),
+                subjectType = ProofUser.name,
+                createdAt = Clock.System.now(),
+            )
+        )
+
+        serverRuntime.handle(
+            post("/backup/prove", identify("email", victim.email, "zzzzzzzzzz")),
+            testId(30),
+        )
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals(victim._id.toString(), event.principal)
+        assertEquals("SecretMismatch", event.failureReason)
+        assertEquals("backupcode", event.method)
+    }
+
+    // ---- known device ------------------------------------------------------------------------
+
+    @Test
+    fun `a rejected known-device secret names the account and the method`() = onServer {
+        val victim = user()
+        val established = TestServer.knownDevice.establish(ProofUser, victim._id, "test device")
+        val deviceId = established.secret.substringBefore('/')
+
+        serverRuntime.handle(
+            post("/device/prove", "\"$deviceId/not-the-secret\""),
+            testId(40),
+        )
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals(victim._id.toString(), event.principal)
+        assertEquals("SecretMismatch", event.failureReason)
+        assertEquals("known-device", event.method)
+    }
+
+    // ---- emailed / texted PIN ----------------------------------------------------------------
+
+    /** Runs the real `start` endpoint and returns the key it issued alongside the captured PIN. */
+    context(server: ServerRuntime)
+    private suspend fun startPin(email: String): Pair<String, String> {
+        val response = serverRuntime.handle(post("/pin/start", "\"$email\""), testId(50))
+        val key = json.decodeFromString(String.serializer(), response.body!!.text())
+        return key to TestServer.pin.sent.last().second
+    }
+
+    private fun finish(key: String, code: String) =
+        json.encodeToString(FinishProof.serializer(), FinishProof(key = key, password = code))
+
+    /**
+     * A PIN proves ownership of an address, not of an account — these endpoints never resolve a
+     * subject, that happens later at login — so the address is what the event is about and the only
+     * identity a failure has.
+     */
+    @Test
+    fun `a rejected PIN names the address it was against`() = onServer {
+        TestServer.pin.sent.clear()
+        val (key, _) = startPin("victim@example.com")
+
+        serverRuntime.handle(post("/pin/prove", finish(key, "ZZZZZZ")), testId(51))
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals("victim@example.com", event.principal)
+        assertEquals("SecretMismatch", event.failureReason)
+        assertEquals("testpin", event.method)
+        assertEquals("email", event.methodProperty)
+    }
+
+    /** An unknown or expired key names nothing: there is no pending attempt behind it to attribute. */
+    @Test
+    fun `a PIN attempt against an unknown key is recorded with no principal`() = onServer {
+        serverRuntime.handle(post("/pin/prove", finish(Uuid.random().toString(), "ZZZZZZ")), testId(52))
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals("SecretExpired", event.failureReason)
+        assertNull(event.principal)
+        assertEquals("testpin", event.method)
+    }
+
+    @Test
+    fun `an accepted PIN is recorded`() = onServer {
+        TestServer.pin.sent.clear()
+        val (key, code) = startPin("victim@example.com")
+
+        val response = serverRuntime.handle(post("/pin/prove", finish(key, code)), testId(53))
+        assertEquals(HttpStatus.OK, response.status)
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofAccepted, event.type)
+        assertEquals("victim@example.com", event.principal)
+        assertEquals("testpin", event.method)
+    }
+
+    /**
+     * The issuance/acceptance split, asserted rather than assumed. `issueProof` mints a proof to be
+     * mailed to an address — a magic link — with no credential presented by anyone. Recording that as
+     * `ProofAccepted` would put a login in the log that never happened.
+     */
+    @Test
+    fun `a mailed magic link is not recorded as an accepted proof`() = onServer {
+        TestServer.pin.mintMagicLink("victim@example.com")
+
+        assertTrue(
+            events().isEmpty(),
+            "minting a proof to mail to someone was recorded as a presented credential being accepted",
+        )
+    }
+
+    // ---- WebAuthN ----------------------------------------------------------------------------
+
+    /**
+     * The challenge is single-use and time-limited, so an unknown id is one that expired, was already
+     * spent, or was never issued. No subject is known at that point — the credential has not been
+     * looked at yet — so the row names none.
+     */
+    @Test
+    fun `a WebAuthN attempt with no live challenge is recorded`() = onServer {
+        val clientData = Base64.encode(
+            """{"challenge":"YWJj","origin":"https://example.com","crossOrigin":false,"type":"webauthn.get"}"""
+                .encodeToByteArray()
+        )
+        val body = json.encodeToString(
+            WebAuthN.Authentication.ProveRequest.serializer(),
+            WebAuthN.Authentication.ProveRequest(
+                challengeId = Uuid.random().toString(),
+                credentials = WebAuthN.Authentication.AssertedPublicKeyCredential(
+                    id = "aWQ",
+                    clientExtensionResults = null,
+                    response = WebAuthN.Authentication.AuthenticatorAssertionResponse(
+                        authenticatorData = "YQ",
+                        clientDataJSON = clientData,
+                        signature = "Yg",
+                        userHandle = null,
+                    ),
+                ),
+            ),
+        )
+
+        serverRuntime.handle(post("/webauthn/prove", body), testId(60))
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofRejected, event.type)
+        assertEquals("SecretExpired", event.failureReason)
+        assertNull(event.principal)
+        assertEquals("WebAuthN", event.method)
+    }
+}


### PR DESCRIPTION
**Stack: 13 of 16.** Based on `split/a3` — review that one first.
A `Session` row records that a session *exists*, not that a login *happened*.
The survey behind this found nothing usable: last-write-wins state on session
and secret rows, a counter deleted on the next success, and debug prints.
Failed logins, token issuance, successful masquerade and PIN proofs left no
trace at all.

The events are raised by `sessions` through the `AuthEventReporter` seam
added earlier in this stack; this PR is the consumer that writes them down.
`sessions` does not depend on `audit`, so the direction holds — the test
dependency here is the reverse of the runtime one, on purpose, because the
point of the seam is that something else fires it.

**Fail-open, uniquely among these layers.** The layers above gate disclosure,
so the guarded thing must not happen unrecorded. An authentication event has
already happened by the time it is reported, usually from a path that is
itself rejecting something — throwing there would replace a clean "your login
failed" with an unrelated server error and lose the original reason. Stated
plainly: an attacker who can make the audit database unavailable can make
auth events go unrecorded while authentication keeps working.

`AuthEventLogWiringTest` and `ProofAuthEventWiringTest` drive real rejections
through real endpoints rather than calling the reporter. That split matters:
the reporter was once shipped with the call site passing its free text into
`sessionId`, and every direct-call test stayed green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd