### PR TITLE
Layer 5: the mutation log — what changed, who changed it, and what caused it

### DIFF
--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/MutationRecord.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/MutationRecord.kt
@@ -1,0 +1,136 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.data.GenerateDataClassPaths
+import com.lightningkite.services.data.Index
+import com.lightningkite.services.database.HasId
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/** The kind of change a [MutationRecord] describes. */
+@Serializable
+public enum class MutationOperation {
+    Insert,
+    Update,
+    Replace,
+    Upsert,
+    Delete,
+}
+
+/**
+ * How much a bulk mutation is worth recording — the one trade in this layer that a deployment gets
+ * to make.
+ *
+ * The `…IgnoringResult` / `…IgnoringOld` methods exist so a backend can skip reading rows it is about
+ * to overwrite. That is exactly the information this log is for, so the default gives the saving up.
+ */
+@Serializable
+public enum class BulkMutationDetail {
+    /**
+     * Record every changed row, whichever method the caller reached for.
+     *
+     * The `Ignoring*` calls are upgraded to their effect-returning equivalents, so an
+     * `updateManyIgnoringResult` over a large table materialises every matched row and writes a
+     * [MutationRecord] per change. That cost is accepted deliberately: a log that can be circumvented
+     * by choosing a different method on the same interface is not an audit log, it is a convention.
+     *
+     * Callers see no difference — an upgraded call returns exactly what the method it replaced would
+     * have returned.
+     */
+    RecordEveryRow,
+
+    /**
+     * Let the `Ignoring*` variants keep their cheap path, and record one summary row for the call.
+     *
+     * The escape hatch for deployments whose bulk writes are too large to pay [RecordEveryRow] for.
+     * What it gives up is the whole point of the layer for those calls: a summary row says *how many*
+     * rows changed, never *which* ones or *from what*. Prefer narrowing which models are mutation
+     * logged over turning this on globally.
+     */
+    SummaryOnly,
+}
+
+/**
+ * One change to one audited record — what it was, what it became, and which execution did it.
+ *
+ * The question this answers is "who changed this record, and to what", which no other layer can. A
+ * [DataAccessRecord] captures the `Modification` that was *submitted*; that is intent, not effect. It
+ * says nothing about which rows a condition actually matched, and a modification like
+ * `count assign count + 1` does not name a resulting value at all. This layer records after the fact,
+ * per affected row, with both sides of the change.
+ *
+ * ## A separate table from the data access log, deliberately
+ * Looking for tampering and looking for query abuse are unrelated investigations with unrelated
+ * volumes, and each should be installable without paying for the other. Sharing a table would also
+ * mean one schema serving two record shapes, most columns null in either direction.
+ *
+ * ## Both sides are stored as text
+ * As with [DataAccessRecord], one table holds rows for every audited model, and a model-typed column
+ * would mean a table per model. What that gives up is querying *inside* a recorded value; an
+ * investigation reads these rows, it does not join on their contents.
+ *
+ * @property requestId The request record for the execution that made the change, where it has one.
+ *   Set for `Http` and `WebSocket` initiators and null for everything else, because
+ *   `RequestRecordInterceptor` is an http/websocket interceptor and writes no row for a task, a
+ *   schedule tick, startup, pre-deploy, or a directly built runtime. Storing the execution id there
+ *   anyway would produce an id that joins to nothing, which is worse than an honest null.
+ * @property attributedTo The request record that names **who is responsible**, and the column to
+ *   start an investigation from. Never null, and it resolves for indirect work where [requestId]
+ *   cannot: a change made inside a task carries the anchor of whatever launched it.
+ *
+ *   Deliberately not the same question as [rootExecutionId]. The framework creates inner executions
+ *   that carry their own credentials — a `/meta/bulk` sub-request and a multiplexed sub-socket both
+ *   take per-sub query parameters, and `SessionManager.read` falls back to the `Authorization` and
+ *   `jwt` query parameters — so an anonymous carrier can dispatch an authenticated inner execution.
+ *   The head of the causal chain is then the carrier, which names nobody, while the person is named
+ *   on the inner execution's row. Both shapes are pinned by tests in this module.
+ * @property executionId The execution that actually made the change. For a socket this is the phase,
+ *   where [requestId] deliberately names the whole socket.
+ * @property causedBy The execution that caused this one, or null if it started here.
+ * @property rootExecutionId The head of the causal chain — how a mutation made three tasks deep
+ *   chains back to whatever started it, in one indexed lookup rather than a recursive walk.
+ *
+ *   This is a *causal* key, not an attribution key: it answers "what set this off", and the answer
+ *   can be an execution that authenticated nobody. Use [attributedTo] to reach the person.
+ * @property initiatorKind The initiator's `@SerialName` discriminator — "http", "ws", "task",
+ *   "schedule", "startup", "predeploy", "direct". Indexed and denormalised out of [initiator] so that
+ *   "every mutation not made by a request" is a query rather than a scan of JSON.
+ * @property initiator The whole `Initiator`, serialized. Carries the endpoint, socket phase or task
+ *   location that [initiatorKind] alone cannot.
+ * @property modelId The audited model, from the same registry [DisclosureRecord] uses.
+ * @property recordId The changed row's `_id`, as text — the models this can wrap are not all keyed by
+ *   `Uuid`. Null only on a summary row, where by construction no single row is named.
+ * @property old The previous value, serialized. Null for an insert, and for the inserting branch of
+ *   an upsert.
+ * @property new The resulting value, serialized. Null for a delete. Note that for an update this is
+ *   the database layer's *prediction* — see `Table.updateOne` — computed by applying the modification
+ *   to the row that was read, not a re-read of the row.
+ * @property affectedCount How many rows the call changed. Set only on a summary row; a per-row row
+ *   describes exactly one change and does not need it.
+ */
+@GenerateDataClassPaths
+@Serializable
+public data class MutationRecord(
+    override val _id: Uuid,
+    @Index val requestId: Uuid? = null,
+    @Index val attributedTo: Uuid,
+    @Index val executionId: Uuid,
+    val causedBy: Uuid? = null,
+    @Index val rootExecutionId: Uuid,
+    @Index val initiatorKind: String,
+    val initiator: String,
+    @Index val modelId: Int,
+    @Index val recordId: String? = null,
+    val operation: MutationOperation,
+    val old: String? = null,
+    val new: String? = null,
+    val affectedCount: Int? = null,
+) : HasId<Uuid> {
+    /** When the change happened, derived from the version-7 [_id]. See [RequestRecord] for why it lives there. */
+    @OptIn(ExperimentalUuidApi::class)
+    public val at: Instant
+        get() = Instant.fromEpochMilliseconds(_id.epochMilliseconds)
+
+    public companion object
+}

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/AuditLayers.kt
@@ -87,3 +87,41 @@ public class AuthEventLog(private val core: AuditCore) : ServerBuilder() {
     }
 }
 
+/**
+ * Layer 5: one row per audited record that changed, and what it changed from.
+ *
+ * The question this answers is "who changed this record, and to what" — tampering rather than
+ * snooping. Nothing else here can: a [DataAccessRecord] carries the `Modification` that was
+ * *submitted*, which is intent, not effect. It does not say which rows a condition matched, and a
+ * modification such as `count assign count + 1` names no resulting value at all.
+ *
+ * A separate layer with its own table rather than more columns on the data access log, because
+ * looking for tampering and looking for query abuse are unrelated investigations with unrelated
+ * volumes; a deployment should be able to install either without paying for the other. Opt-in per
+ * model, like the data access log — see [mutationLogged].
+ *
+ * ## Failure behaviour: fail-open, and necessarily so
+ * The layers that gate disclosure record first and throw. That option does not exist here: the effect
+ * *is* the record, so there is nothing to write until the change is made, and once it is made,
+ * throwing reports failure for something that happened — inviting a retry that applies it twice. A
+ * failed audit write is therefore logged loudly and the mutation stands. Where "no unrecorded write"
+ * matters more than "no double write", install [DataAccessLog] alongside: it fails closed and records
+ * the attempt before it runs.
+ *
+ * @param bulkDetail Whether the `Ignoring*` methods are upgraded so every changed row is recorded.
+ *   Defaults to recording everything; see [BulkMutationDetail] for what the alternative gives up.
+ * @property mutations One row per change to an audited record.
+ */
+public class MutationLog(
+    private val core: AuditCore,
+    internal val bulkDetail: BulkMutationDetail = BulkMutationDetail.RecordEveryRow,
+) : ServerBuilder() {
+    public val mutations: DatabaseTableRegistration<MutationRecord> =
+        core.database.registerTable("AuditMutation", MutationRecord.serializer())
+
+    internal val registry get() = core.registry
+
+    init {
+        core.claim("MutationLog")
+    }
+}

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/MutationLog.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/MutationLog.kt
@@ -1,0 +1,105 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.services.database.Table
+import com.lightningkite.services.database.insertOne
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Wraps a table so that every change it makes is recorded — when, and only when, its model is
+ * audited.
+ *
+ * Pass it as a `ModelInfo`'s `log` parameter, alongside [DataAccessLog.dataAccessLogged] if both
+ * layers are installed:
+ *
+ * ```kotlin
+ * val patients = database.explicitModelInfo(
+ *     // ...
+ *     log = { audit.mutationLogged(it) },
+ * )
+ * ```
+ *
+ * ## Why it is safe to pass everywhere
+ * A model without [Audited] is returned untouched, so the "is this audited" decision stays in the
+ * annotation alone rather than being split between the annotation and a list of decorated tables.
+ * Passing it on every model is the intended usage.
+ *
+ * ## An audited model with no registry entry fails
+ * As with [DataAccessLog.dataAccessLogged], the id is resolved per operation through
+ * [AuditRegistry.modelId], which **throws** when the model has no entry — and the registry is
+ * populated by scanning *endpoints*, not tables. An `@Audited` model no endpoint's serializer reaches
+ * therefore has no id. Here that throw is caught by the fail-open guard rather than failing the call,
+ * so the symptom is a loud log line and an unrecorded mutation rather than a rejected write. Make the
+ * model reachable from an endpoint's serializer to log it at all.
+ *
+ * ## Where it sits
+ * `ModelInfo` applies `log` below permissions and in **both** `table(auth)` and `table()`, so this
+ * observes privileged internal writes — startup tasks, schedule ticks, one service writing another's
+ * model — as well as user-facing ones.
+ *
+ * ## Failure
+ * Fail-open: the change is already committed by the time there is anything to record, so a failed
+ * audit write is logged loudly and the mutation stands. See [MutationLog].
+ */
+@OptIn(ExperimentalSerializationApi::class)
+context(runtime: ServerRuntime)
+public fun <T : Any> MutationLog.mutationLogged(table: Table<T>): Table<T> {
+    val descriptor = table.serializer.descriptor
+    // Reachability, not a single annotation. `isAudited` inspects one descriptor, so gating on it
+    // would return a sealed parent's table — or any wrapper's — untouched even though its children
+    // are audited, and every change to them would go unrecorded in silence. `auditedModels()` walks.
+    val reachable = descriptor.auditedModels()
+    if (reachable.isEmpty()) return table
+    // The row names one model, so a table that merely *contains* audited data cannot be attributed.
+    // Fail loudly rather than pick one: inconsistent coverage hides the gap instead of failing on it,
+    // which is the same rule the registry applies to an unregistered model.
+    if (!descriptor.isAudited) throw IllegalStateException(
+        "Table \"" + descriptor.serialName + "\" is not itself @Audited but can contain audited " +
+            "models (" + reachable.keys.sorted().joinToString(", ") + "). A mutation record names " +
+            "one model, so this shape cannot be attributed and is refused rather than logged " +
+            "inconsistently."
+    )
+    val serialName = descriptor.auditSerialName
+    val initiator = runtime.initiator
+    val json = runtime.internalSerialization.json
+    return MutationLogTable(
+        wraps = table,
+        modelId = { registry.await().modelId(serialName) },
+        // Only where a request record actually exists. RequestRecordInterceptor is an http/websocket
+        // interceptor, so a task or schedule tick has no row to point at, and storing its execution
+        // id here would produce an id that joins to nothing.
+        requestId = when (initiator) {
+            is Initiator.Http, is Initiator.WebSocket -> initiator.requestRecordId
+            else -> null
+        },
+        // The row that names who is responsible. Unlike `requestId` this is never null: a change
+        // made inside a task carries the anchor of whatever launched it, which is the only way an
+        // indirect change stays traceable to a person.
+        attributedTo = initiator.attributedTo,
+        executionId = initiator.executionId,
+        causedBy = initiator.causedBy,
+        rootExecutionId = initiator.rootExecutionId,
+        initiatorKind = initiator.kind(json),
+        initiator = json.encodeToString(Initiator.serializer(), initiator),
+        json = json,
+        nowMillis = { runtime.clock.now().toEpochMilliseconds() },
+        write = { with(runtime) { mutations().insertOne(it) } },
+        bulkDetail = bulkDetail,
+    )
+}
+
+/**
+ * The `@SerialName` discriminator of this initiator's concrete type — "http", "task", and so on.
+ *
+ * Read back out of the encoded form rather than matched against the subtypes in a `when`, so that the
+ * value in the record is by construction the same string the serialized [Initiator] carries. A `when`
+ * would be a second copy of the discriminators, free to drift from the annotations.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+private fun Initiator.kind(json: Json): String =
+    json.encodeToJsonElement(Initiator.serializer(), this)
+        .jsonObject.getValue(json.configuration.classDiscriminator).jsonPrimitive.content

--- a/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/MutationLogTable.kt
+++ b/audit/src/main/kotlin/com/lightningkite/lightningserver/audit/MutationLogTable.kt
@@ -1,0 +1,303 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.services.database.*
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+private val mutationLogger = KotlinLogging.logger("com.lightningkite.lightningserver.audit.MutationLog")
+
+/**
+ * Performs a mutation, then records what it actually changed.
+ *
+ * Only the mutating members are overridden; reads are delegated straight through, because a read is
+ * the data access log's subject and recording it here would duplicate that layer in a table with the
+ * wrong shape for it.
+ *
+ * ## After, not before
+ * The disclosure and data access logs record first and throw, because the thing they guard must not
+ * happen unless it was recorded. That is not available here: the effect *is* the record, so there is
+ * nothing to write until the change has been made — and once it has, throwing would report failure
+ * for something that happened, inviting a retry that applies it twice. So this fails open: a write
+ * that cannot be recorded is logged loudly and the mutation stands. The cost, stated plainly: an
+ * attacker who can make the audit database unavailable can mutate unrecorded. Pair this layer with
+ * the data access log, which fails closed and records the attempt, where that matters.
+ *
+ * ## The `Ignoring*` upgrade
+ * Under [BulkMutationDetail.RecordEveryRow] each `…IgnoringResult` / `…IgnoringOld` call is performed
+ * through its effect-returning equivalent so the changed rows are visible to record. The value handed
+ * back is then derived to match what the skipped method's contract promises, so no caller can tell
+ * the difference. Those derivations are the delicate part of this class and are noted individually.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal class MutationLogTable<T : Any>(
+    override val wraps: Table<T>,
+    /** Throws when the model is audited but has no registry entry; see [mutationLogged]. */
+    private val modelId: suspend () -> Int,
+    private val requestId: Uuid?,
+    private val attributedTo: Uuid,
+    private val executionId: Uuid,
+    private val causedBy: Uuid?,
+    private val rootExecutionId: Uuid,
+    private val initiatorKind: String,
+    private val initiator: String,
+    private val json: Json,
+    private val nowMillis: () -> Long,
+    private val write: suspend (MutationRecord) -> Unit,
+    private val bulkDetail: BulkMutationDetail,
+) : Table<T> by wraps {
+
+    /**
+     * The model as JSON, kept as a tree so that the row's id and its text come from one encode.
+     */
+    private fun encode(model: T): JsonObject =
+        json.encodeToJsonElement(wraps.serializer, model).jsonObject
+
+    /**
+     * The `_id` as text, because the models this wraps are not all keyed by `Uuid` — a `String`-keyed
+     * model is a legal audited model. A non-primitive key renders as its JSON, which is still a
+     * faithful identifier even if it is an awkward one to type into a query.
+     */
+    private fun idOf(model: JsonObject): String = model["_id"].let {
+        if (it == null) throw IllegalStateException(
+            "Mutation of \"" + wraps.serializer.descriptor.auditSerialName + "\" cannot be recorded: " +
+                "the model has no _id, so no record could say which row changed."
+        )
+        if (it is JsonPrimitive) it.content else it.toString()
+    }
+
+    private fun row(
+        modelId: Int,
+        operation: MutationOperation,
+        recordId: String?,
+        old: JsonObject?,
+        new: JsonObject?,
+        affectedCount: Int? = null,
+    ) = MutationRecord(
+        _id = Uuid.generateV7NonMonotonicAt(kotlin.time.Instant.fromEpochMilliseconds(nowMillis())),
+        requestId = requestId,
+        attributedTo = attributedTo,
+        executionId = executionId,
+        causedBy = causedBy,
+        rootExecutionId = rootExecutionId,
+        initiatorKind = initiatorKind,
+        initiator = initiator,
+        modelId = modelId,
+        recordId = recordId,
+        operation = operation,
+        old = old?.toString(),
+        new = new?.toString(),
+        affectedCount = affectedCount,
+    )
+
+    /**
+     * Writes the rows for one call, swallowing any failure.
+     *
+     * The whole call's rows share one guard rather than one each: a sink that fails on the third row
+     * of ten will fail on the rest, and ten copies of the same error in the log obscures rather than
+     * informs.
+     */
+    private suspend fun audit(block: suspend (modelId: Int) -> Unit) {
+        try {
+            block(modelId())
+        } catch (e: Exception) {
+            // Cancellation is the caller being torn down, not a sink failure. Swallowing it would
+            // report this coroutine as having completed normally and break structured concurrency.
+            if (e is CancellationException) throw e
+            mutationLogger.error(e) {
+                "Failed to record a mutation of \"" + wraps.serializer.descriptor.auditSerialName +
+                    "\"; the change was already made and stands, unrecorded."
+            }
+        }
+    }
+
+    /**
+     * Records one row per change.
+     *
+     * A change with neither side is not a change — that is how the database layer reports "nothing
+     * matched" — and produces no row. Recording the *attempt* that matched nothing is the data access
+     * log's job; this table holds changes.
+     */
+    private suspend fun recordChanges(operation: MutationOperation, changes: List<EntryChange<T>>) {
+        if (changes.none { it.old != null || it.new != null }) return
+        audit { modelId ->
+            for (change in changes) {
+                val old = change.old?.let(::encode)
+                val new = change.new?.let(::encode)
+                val identity = new ?: old ?: continue
+                write(row(modelId, operation, idOf(identity), old, new))
+            }
+        }
+    }
+
+    /** The stand-in for [recordChanges] when a bulk call kept its cheap path. */
+    private suspend fun recordSummary(operation: MutationOperation, affectedCount: Int) {
+        if (affectedCount == 0) return
+        audit { modelId ->
+            write(row(modelId, operation, recordId = null, old = null, new = null, affectedCount = affectedCount))
+        }
+    }
+
+    override suspend fun insert(models: Iterable<T>): List<T> {
+        val inserted = wraps.insert(models)
+        recordChanges(MutationOperation.Insert, inserted.map { EntryChange(old = null, new = it) })
+        return inserted
+    }
+
+    override suspend fun replaceOne(
+        condition: Condition<T>,
+        model: T,
+        orderBy: List<SortPart<T>>,
+    ): EntryChange<T> {
+        val change = wraps.replaceOne(condition, model, orderBy)
+        recordChanges(MutationOperation.Replace, listOf(change))
+        return change
+    }
+
+    /** Contract: "if a change was made", which [replaceOne] reports as a non-null `new`. */
+    override suspend fun replaceOneIgnoringResult(
+        condition: Condition<T>,
+        model: T,
+        orderBy: List<SortPart<T>>,
+    ): Boolean {
+        if (bulkDetail == BulkMutationDetail.SummaryOnly) {
+            val changed = wraps.replaceOneIgnoringResult(condition, model, orderBy)
+            recordSummary(MutationOperation.Replace, if (changed) 1 else 0)
+            return changed
+        }
+        val change = wraps.replaceOne(condition, model, orderBy)
+        recordChanges(MutationOperation.Replace, listOf(change))
+        return change.new != null
+    }
+
+    override suspend fun upsertOne(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        model: T,
+    ): EntryChange<T> {
+        val change = wraps.upsertOne(condition, modification, model)
+        recordChanges(MutationOperation.Upsert, listOf(change))
+        return change
+    }
+
+    /**
+     * Contract: "if there was an existing element that matched the condition" — deliberately *not*
+     * "if a change was made". [upsertOne] reports that as a non-null `old`; an insert returns
+     * `EntryChange(null, model)` and so returns false here, which is the documented behaviour.
+     */
+    override suspend fun upsertOneIgnoringResult(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        model: T,
+    ): Boolean {
+        if (bulkDetail == BulkMutationDetail.SummaryOnly) {
+            val existed = wraps.upsertOneIgnoringResult(condition, modification, model)
+            // An upsert leaves a row behind either way, so the count is one; the return value says
+            // which branch it took, not whether anything happened. The exception is a degenerate
+            // call — a `Condition.Never`, or a modification that simplifies to nothing — which some
+            // backends short-circuit without writing. Those over-report by one here, because a
+            // summary row is all the information this mode kept. RecordEveryRow has no such gap.
+            recordSummary(MutationOperation.Upsert, 1)
+            return existed
+        }
+        val change = wraps.upsertOne(condition, modification, model)
+        recordChanges(MutationOperation.Upsert, listOf(change))
+        return change.old != null
+    }
+
+    override suspend fun updateOne(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        orderBy: List<SortPart<T>>,
+    ): EntryChange<T> {
+        val change = wraps.updateOne(condition, modification, orderBy)
+        recordChanges(MutationOperation.Update, listOf(change))
+        return change
+    }
+
+    /** Contract: "if a change was made", which [updateOne] reports as a non-null `new`. */
+    override suspend fun updateOneIgnoringResult(
+        condition: Condition<T>,
+        modification: Modification<T>,
+        orderBy: List<SortPart<T>>,
+    ): Boolean {
+        if (bulkDetail == BulkMutationDetail.SummaryOnly) {
+            val changed = wraps.updateOneIgnoringResult(condition, modification, orderBy)
+            recordSummary(MutationOperation.Update, if (changed) 1 else 0)
+            return changed
+        }
+        val change = wraps.updateOne(condition, modification, orderBy)
+        recordChanges(MutationOperation.Update, listOf(change))
+        return change.new != null
+    }
+
+    override suspend fun updateMany(
+        condition: Condition<T>,
+        modification: Modification<T>,
+    ): CollectionChanges<T> {
+        val changes = wraps.updateMany(condition, modification)
+        recordChanges(MutationOperation.Update, changes.changes)
+        return changes
+    }
+
+    /**
+     * Contract: "the number of entries affected", which [updateMany] reports as its change count.
+     *
+     * This is the upgrade that costs the most — every matched row is read and written back — and the
+     * one [BulkMutationDetail.SummaryOnly] exists for.
+     */
+    override suspend fun updateManyIgnoringResult(
+        condition: Condition<T>,
+        modification: Modification<T>,
+    ): Int {
+        if (bulkDetail == BulkMutationDetail.SummaryOnly) {
+            val affected = wraps.updateManyIgnoringResult(condition, modification)
+            recordSummary(MutationOperation.Update, affected)
+            return affected
+        }
+        val changes = wraps.updateMany(condition, modification)
+        recordChanges(MutationOperation.Update, changes.changes)
+        return changes.changes.size
+    }
+
+    override suspend fun deleteOne(condition: Condition<T>, orderBy: List<SortPart<T>>): T? {
+        val deleted = wraps.deleteOne(condition, orderBy)
+        recordChanges(MutationOperation.Delete, listOf(EntryChange(old = deleted, new = null)))
+        return deleted
+    }
+
+    /** Contract: "whether any items were deleted", which [deleteOne] reports by returning the row. */
+    override suspend fun deleteOneIgnoringOld(condition: Condition<T>, orderBy: List<SortPart<T>>): Boolean {
+        if (bulkDetail == BulkMutationDetail.SummaryOnly) {
+            val deleted = wraps.deleteOneIgnoringOld(condition, orderBy)
+            recordSummary(MutationOperation.Delete, if (deleted) 1 else 0)
+            return deleted
+        }
+        val deleted = wraps.deleteOne(condition, orderBy)
+        recordChanges(MutationOperation.Delete, listOf(EntryChange(old = deleted, new = null)))
+        return deleted != null
+    }
+
+    override suspend fun deleteMany(condition: Condition<T>): List<T> {
+        val deleted = wraps.deleteMany(condition)
+        recordChanges(MutationOperation.Delete, deleted.map { EntryChange(old = it, new = null) })
+        return deleted
+    }
+
+    /** Contract: "the number of deleted items", which [deleteMany] reports as the rows it returns. */
+    override suspend fun deleteManyIgnoringOld(condition: Condition<T>): Int {
+        if (bulkDetail == BulkMutationDetail.SummaryOnly) {
+            val affected = wraps.deleteManyIgnoringOld(condition)
+            recordSummary(MutationOperation.Delete, affected)
+            return affected
+        }
+        val deleted = wraps.deleteMany(condition)
+        recordChanges(MutationOperation.Delete, deleted.map { EntryChange(old = it, new = null) })
+        return deleted.size
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/BulkSubRequestMutationAttributionTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/BulkSubRequestMutationAttributionTest.kt
@@ -1,0 +1,425 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.auth.Authentication
+import com.lightningkite.lightningserver.auth.PrincipalType
+import com.lightningkite.lightningserver.auth.authReaders
+import com.lightningkite.lightningserver.auth.noAuth
+import com.lightningkite.lightningserver.auth.register
+import com.lightningkite.lightningserver.auth.testAuth
+import com.lightningkite.lightningserver.data.Request
+import com.lightningkite.lightningserver.definition.Task
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.HttpHeader
+import com.lightningkite.lightningserver.http.HttpHeaders
+import com.lightningkite.lightningserver.http.HttpRequest
+import com.lightningkite.lightningserver.http.HttpStatus
+import com.lightningkite.lightningserver.http.QueryParameters
+import com.lightningkite.lightningserver.http.post
+import com.lightningkite.lightningserver.http.get
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.pathing.PathSpec0
+import com.lightningkite.lightningserver.pathing.RawHttpEndpoint
+import com.lightningkite.lightningserver.pathing.path
+import com.lightningkite.lightningserver.runtime.EngineBase
+import com.lightningkite.lightningserver.runtime.ExecutionCause
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.executeWithMetrics
+import com.lightningkite.lightningserver.runtime.handle
+import com.lightningkite.lightningserver.runtime.invoke
+import com.lightningkite.lightningserver.runtime.location
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.typed.ApiHttpHandler
+import com.lightningkite.lightningserver.typed.MetaEndpoints
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.data.MediaType
+import com.lightningkite.services.data.TypedData
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.Database
+import com.lightningkite.services.database.HasId
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The same attribution question as [WebSocketMutationAttributionTest], with no socket involved.
+ *
+ * A `/meta/bulk` sub-request is structurally what a multiplexed sub-socket is: `HttpRequest.subRequest`
+ * gives it its own query parameters while sharing the carrier's `cache`, and `Initiator.Http.subRequest`
+ * gives it its own `executionId` while inheriting the carrier's `rootExecutionId`. So if a sub-request
+ * can authenticate where the carrier did not, everything the socket tests found follows here too —
+ * which is why the fix is not about sockets: `rootExecutionId` names the outermost execution, and the
+ * outermost execution is not necessarily the one that authenticated anybody. `attributedTo` is the
+ * column that answers "who", and these tests assert it alongside the root so the two stay distinct.
+ */
+@OptIn(InternalLightningServerApi::class)
+class BulkSubRequestMutationAttributionTest {
+
+    private val user = Uuid.parse("00000000-0000-4000-8000-0000000000d1")
+
+    private fun probe(block: suspend context(ServerRuntime) (BulkProbeEngine) -> Unit) = runBlocking {
+        val engine = BulkProbeEngine()
+        engine.ready()
+        engine.preDeploy()
+        block(engine, engine)
+    }
+
+    context(server: ServerRuntime)
+    private suspend fun requests() = BulkTestServer.audit.requests().find(Condition.Always).toList()
+
+    context(server: ServerRuntime)
+    private suspend fun mutations() = BulkTestServer.mutationLog.mutations().find(Condition.Always).toList()
+
+    private fun List<RequestRecord>.rowFor(id: Uuid?): RequestRecord? = firstOrNull { it._id == id }
+
+    /**
+     * A bulk request carrying one sub-request, with no credential of its own.
+     *
+     * The credential rides in the sub-request's *own* query string, which is what the client controls
+     * per sub-request: `MetaEndpoints` splits `path` on `?` and hands the result to
+     * `HttpRequest.subRequest` as that sub-request's query parameters.
+     */
+    private fun bulkOf(subPath: String, subBody: String) = HttpRequest<PathSpec>(
+        path = RawHttpEndpoint(asString = "/meta/bulk", method = HttpMethod.POST),
+        queryParameters = QueryParameters.EMPTY,
+        headers = HttpHeaders { add(HttpHeader.ContentType, MediaType.Application.Json.toString()) },
+        domain = "example.com",
+        protocol = "https",
+        sourceIp = "10.0.0.2",
+        body = TypedData.text(
+            """{"only":{"path":"$subPath","method":"POST","body":${escape(subBody)}}}""",
+            MediaType.Application.Json,
+        ),
+    )
+
+    private fun escape(raw: String) = "\"" + raw.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+    private fun credential() = "${HttpHeader.Authorization}=$user"
+
+    // ===================== can a sub-request authenticate at all? =====================
+
+    /**
+     * `subRequest` hands the sub-request the carrier's same `SerializableCache`, so an anonymous
+     * carrier resolving `Authentication.CacheKey` first could memoize a null the sub-request inherits.
+     * It does not, for the same reason it does not for sub-sockets:
+     * `SerializableCache.get(CalculatingKey, input)` is `retrieve(key)?.value ?: calculate(input)`, so
+     * a cached null falls through to a fresh resolution against the sub-request's own query
+     * parameters.
+     */
+    @Test
+    fun `a bulk sub-request authenticates on its own query parameters even when the carrier did not`() =
+        probe { engine ->
+            val response = engine.handle(bulkOf("/mutate?${credential()}", Uuid.random().toString()), engine.newId())
+            assertEquals(HttpStatus.OK, response.status)
+
+            val requests = requests()
+            val carrier = requests.single { it.endpoint == "/meta/bulk" }
+            assertNull(carrier.principal, "the carrying bulk request was supposed to be anonymous")
+
+            val sub = requests.single { it.endpoint == "/mutate" }
+            assertTrue(
+                sub.principal?.contains(user.toString()) == true,
+                "the sub-request did not authenticate on its own query parameters: ${sub.principal}",
+            )
+        }
+
+    // ===================== a direct mutation from a sub-request =====================
+
+    /**
+     * The two columns pulling apart, on one row, with no socket involved.
+     *
+     * `attributedTo` names the sub-request, which authenticated; `rootExecutionId` names the bulk
+     * carrier, which did not. Pinned together so neither can later be collapsed into the other on the
+     * grounds that they usually agree.
+     */
+    @Test
+    fun `a direct mutation from an authenticated sub-request attributes to the person while its root stays anonymous`() =
+        probe { engine ->
+            val id = Uuid.random()
+            engine.handle(bulkOf("/mutate?${credential()}", id.toString()), engine.newId())
+
+            val requests = requests()
+            val mutation = mutations().single()
+            assertEquals(id.toString(), mutation.recordId)
+
+            val byAttribution = requests.rowFor(mutation.attributedTo)
+            assertNotNull(byAttribution, "attributedTo ${mutation.attributedTo} names no request row")
+            assertEquals("/mutate", byAttribution.endpoint, "attributedTo should name the sub-request's own row")
+            assertTrue(
+                byAttribution.principal?.contains(user.toString()) == true,
+                "the sub-request's own row does not name the person: ${byAttribution.principal}",
+            )
+
+            val byRoot = requests.rowFor(mutation.rootExecutionId)
+            assertNotNull(byRoot, "rootExecutionId ${mutation.rootExecutionId} names no request row")
+            assertEquals("/meta/bulk", byRoot.endpoint, "the root should be the carrying bulk request")
+            assertNull(
+                byRoot.principal,
+                "the root is the causal head, which here is the anonymous carrier; it must not be " +
+                    "what an auditor reads to name the person",
+            )
+            assertTrue(
+                byAttribution._id != byRoot._id,
+                "the whole reason for two columns is that they can differ, and here they must",
+            )
+        }
+
+    /**
+     * The asymmetry with a sub-socket, and the one that matters for a fix: HTTP has no third
+     * identifier. `Initiator.requestRecordId` is `(this as? Initiator.WebSocket)?.socketId ?: executionId`,
+     * so a sub-request's row is keyed by its own `executionId` — the id the mutation already carries
+     * in `executionId` as well as in `requestId`.
+     */
+    @Test
+    fun `a bulk sub-request's row is keyed by its own executionId`() = probe { engine ->
+        engine.handle(bulkOf("/mutate?${credential()}", Uuid.random().toString()), engine.newId())
+
+        val mutation = mutations().single()
+        assertEquals(
+            mutation.executionId,
+            mutation.requestId,
+            "an HTTP execution's request row is keyed by the execution itself, unlike a socket's",
+        )
+        assertEquals(
+            mutation.executionId,
+            mutation.attributedTo,
+            "an execution that has a request row of its own anchors to that row",
+        )
+        assertNotNull(requests().rowFor(mutation.executionId))
+    }
+
+    // ===================== the gap, with no socket involved =====================
+
+    /**
+     * The socket file's hardest case, reached through plain HTTP — which is what makes this a
+     * framework-wide property rather than a websocket quirk.
+     *
+     * A task has no request row of its own, so `requestId` is null and there is exactly one column
+     * left to trace it by. That column must not be `rootExecutionId`: the root is the head of the
+     * *causal* chain, which here is the bulk carrier — an execution that authenticated nobody,
+     * because the credential arrived on the sub-request's own query parameters. Anchoring to the
+     * causal head would answer "anonymous" for a change a known person made.
+     *
+     * `attributedTo` anchors to the innermost execution that had a request row, and a task inherits
+     * its launcher's anchor through the serialized `ExecutionCause`, so it survives the queue.
+     */
+    @Test
+    fun `a task launched from an authenticated bulk sub-request attributes to the person who made it`() =
+        probe { engine ->
+            val id = Uuid.random()
+            engine.handle(bulkOf("/mutate-task?${credential()}", id.toString()), engine.newId())
+            engine.drainTasks()
+
+            val mutation = mutations().single()
+            assertEquals(id.toString(), mutation.recordId)
+            assertEquals("task", mutation.initiatorKind, "the task ran inline rather than as its own execution")
+            assertNull(mutation.requestId, "a task has no request row, so attributedTo is the only handle")
+
+            val requests = requests()
+            val byAttribution = requests.rowFor(mutation.attributedTo)
+            assertNotNull(byAttribution, "attributedTo ${mutation.attributedTo} names no request row")
+            assertEquals("/mutate-task", byAttribution.endpoint, "the task inherited the sub-request's anchor")
+            assertTrue(
+                byAttribution.principal?.contains(user.toString()) == true,
+                "a change a person made through a bulk sub-request must name that person: " +
+                    "${byAttribution.principal}",
+            )
+
+            // And the column that used to be the only handle still answers the causal question,
+            // still lands on the carrier, and is still anonymous.
+            val byRoot = requests.rowFor(mutation.rootExecutionId)
+            assertNotNull(byRoot)
+            assertEquals("/meta/bulk", byRoot.endpoint)
+            assertNull(byRoot.principal)
+        }
+
+    /** The control: with the credential on the carrier, the very same task traces back fine. */
+    @Test
+    fun `a task launched from a bulk sub-request traces back when the carrier itself is authenticated`() =
+        probe { engine ->
+            val id = Uuid.random()
+            val request = bulkOf("/mutate-task", id.toString()).let {
+                HttpRequest<PathSpec>(
+                    path = it.path,
+                    queryParameters = it.queryParameters,
+                    headers = HttpHeaders {
+                        add(HttpHeader.ContentType, MediaType.Application.Json.toString())
+                        add(HttpHeader.Authorization, user.toString())
+                    },
+                    domain = it.domain,
+                    protocol = it.protocol,
+                    sourceIp = it.sourceIp,
+                    body = it.body,
+                )
+            }
+            engine.handle(request, engine.newId())
+            engine.drainTasks()
+
+            val mutation = mutations().single()
+            val requests = requests()
+            val byRoot = requests.rowFor(mutation.rootExecutionId)
+            assertNotNull(byRoot)
+            assertTrue(
+                byRoot.principal?.contains(user.toString()) == true,
+                "an authenticated carrier should make the whole tree attributable: ${byRoot.principal}",
+            )
+            // With the credential on the carrier the two questions have the same answer, which is
+            // why a single column looked sufficient until an inner execution held the credential.
+            val byAttribution = requests.rowFor(mutation.attributedTo)
+            assertNotNull(byAttribution)
+            assertTrue(byAttribution.principal?.contains(user.toString()) == true)
+        }
+}
+
+// ===================== the server under test =====================
+
+@Serializable
+private data class BulkUser(override val _id: Uuid) : HasId<Uuid> {
+    companion object : PrincipalType<BulkUser, Uuid> {
+        override val idSerializer: KSerializer<Uuid> = Uuid.serializer()
+        override val subjectSerializer: KSerializer<BulkUser> = serializer()
+
+        context(server: ServerRuntime)
+        override suspend fun fetch(id: Uuid): BulkUser = BulkUser(id)
+    }
+}
+
+/** Header or query parameter, as `SessionManager.read` does. */
+private object BulkTokenReader : Authentication.Reader<BulkUser> {
+    override val priority: Double = 1.0
+
+    context(server: ServerRuntime)
+    override suspend fun read(request: Request<*>): Authentication<BulkUser>? {
+        val raw = request.headers[HttpHeader.Authorization]?.root
+            ?: request.queryParameters.find { it.first.equals(HttpHeader.Authorization, ignoreCase = true) }?.second
+            ?: return null
+        return BulkUser.testAuth(BulkUser(Uuid.parse(raw)))
+    }
+}
+
+private object BulkTestServer : ServerBuilder() {
+    val database = setting("database", Database.Settings())
+    val cache = setting("cache", Cache.Settings())
+
+    val audit = path.path("audit") include AuditCore(database)
+    val mutationLog = path.path("audit-mutation") include MutationLog(audit)
+
+    init {
+        registerBasicMediaTypeCoders()
+        register(BulkUser)
+        authReaders.register(BulkTokenReader)
+    }
+
+    val patients = database.registerTable("Patient", Patient.serializer())
+
+    /** Present only so the registry, which scans endpoint serializers, assigns Patient an id. */
+    val sample = Patient(_id = Uuid.parse("00000000-0000-0000-0000-0000000000d2"), name = "", ssn = "")
+
+    val patientEndpoint = path.path("patient").get bind ApiHttpHandler(
+        summary = "Patient",
+        auth = noAuth,
+        implementation = { _: Unit -> sample },
+    )
+
+    val mutateTask: Task<Uuid> = path.path("mutate-task-impl") bind Task(Uuid.serializer()) { id ->
+        mutationLog.mutationLogged(patients()).insert(listOf(Patient(_id = id, name = "FromTask", ssn = "t")))
+    }
+
+    /** POST so the record id travels in the body, leaving the query string to the credential. */
+    val mutate = path.path("mutate").post bind ApiHttpHandler(
+        summary = "Mutate",
+        auth = noAuth,
+        implementation = { id: Uuid ->
+            mutationLog.mutationLogged(patients()).insert(listOf(Patient(_id = id, name = "FromRequest", ssn = "s")))
+            "ok"
+        },
+    )
+
+    val mutateViaTask = path.path("mutate-task").post bind ApiHttpHandler(
+        summary = "Mutate Via Task",
+        auth = noAuth,
+        implementation = { id: Uuid ->
+            mutateTask(id)
+            "ok"
+        },
+    )
+
+    val meta = path.path("meta") include MetaEndpoints(
+        packageName = "com.lightningkite.lightningserver.audit",
+        database = database,
+        cache = cache,
+    )
+}
+
+// ===================== the engine =====================
+
+/**
+ * The HTTP twin of `WebSocketMutationAttributionTest`'s probe engine: everything is the framework's
+ * own `handle`, except that tasks go over a queue that keeps only the serialized payload, so a task
+ * really becomes an execution of its own instead of running inline in its launcher.
+ */
+@OptIn(InternalLightningServerApi::class)
+private class BulkProbeEngine : EngineBase(BulkTestServer.build()), ServerRuntime {
+    override val serverId: String = "bulk-probe"
+    override val serverVersion: String = "test"
+    override val initiator: Initiator = Initiator.Direct(Uuid.random())
+
+    override suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(
+        event: WebSocketSubscriptionMessage<PATH, T>,
+    ): Unit = Unit
+
+    fun ready() {
+        with(settings) {
+            BulkTestServer.database set Database.Settings()
+            BulkTestServer.cache set Cache.Settings()
+        }
+        settings.readyUsingDefaults()
+    }
+
+    suspend fun preDeploy(): Unit = runPreDeployTasks()
+
+    /** The id an engine would mint for an incoming request. */
+    fun newId(): Uuid = com.lightningkite.lightningserver.http.generateRequestId()
+
+    @Serializable
+    private data class Queued(val location: String, val cause: ExecutionCause?, val input: String)
+
+    private val queue = ArrayDeque<Queued>()
+
+    override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?) {
+        queue.addLast(
+            Queued(
+                location = location.toString(),
+                cause = cause,
+                input = internalSerialization.json.encodeToString(serializer, input),
+            )
+        )
+    }
+
+    suspend fun drainTasks() {
+        while (queue.isNotEmpty()) {
+            val queued = queue.removeFirst()
+            val location = PathSpec0.fromString(queued.location)
+            @Suppress("UNCHECKED_CAST")
+            val task = server.tasks.getValue(location) as Task<Any?>
+            task.executeWithMetrics(
+                location,
+                internalSerialization.json.decodeFromString(task.serializer, queued.input),
+                queued.cause,
+            )
+        }
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/MutationLogTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/MutationLogTest.kt
@@ -1,0 +1,645 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.HttpMethod
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.auth.noAuth
+import com.lightningkite.lightningserver.definition.PreDeployTask
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.PathSegments
+import com.lightningkite.lightningserver.http.get
+import com.lightningkite.lightningserver.pathing.*
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.runtime.serverRuntime
+import com.lightningkite.lightningserver.runtime.test.test
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.typed.ApiHttpHandler
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.database.*
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.uuid.Uuid
+
+/**
+ * The mutation log answers "who changed this record, and to what" — the question the data access
+ * log's recorded `Modification` describes only as intent.
+ *
+ * Two things here are load-bearing beyond "a row appears". The `Ignoring*` methods must record just
+ * as completely as their effect-returning twins, or the log is circumventable by picking a different
+ * method on the same interface; and the value those upgraded calls hand back must be indistinguishable
+ * from what the method they replaced would have returned, or wrapping a table silently changes what
+ * every caller sees.
+ */
+@OptIn(InternalLightningServerApi::class)
+class MutationLogTest {
+
+    object TestServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val cache = setting("cache", Cache.Settings())
+
+        val audit = path.path("audit") include AuditCore(database)
+        val mutationLog = path.path("audit-mutation") include MutationLog(audit)
+
+        init {
+            registerBasicMediaTypeCoders()
+        }
+
+        val patients = database.registerTable("Patient", Patient.serializer())
+
+        /** An undecorated twin, so a decorated call's return value has something to be equal to. */
+        val patientsUndecorated = database.registerTable("PatientUndecorated", Patient.serializer())
+
+        /** Not audited, so it must generate no rows at all. */
+        val plain = database.registerTable("Plain", PlainThing.serializer())
+
+        /** Not audited itself, but contains an audited model — the shape that must be refused. */
+        val wrappers = database.registerTable("Wrapper", PatientWrapper.serializer())
+
+        /**
+         * The registry assigns ids by scanning endpoint serializers, never tables, so an audited
+         * model needs an endpoint that can return it before it has an id at all. Present only for
+         * that — no test calls it.
+         */
+        val sample = Patient(_id = Uuid.parse("00000000-0000-0000-0000-0000000000b1"), name = "", ssn = "")
+
+        val patientEndpoint = path.path("patient").get bind ApiHttpHandler(
+            summary = "Patient",
+            auth = noAuth,
+            implementation = { _: Unit -> sample },
+        )
+    }
+
+    /** The same server, with the escape hatch turned on. */
+    object SummaryServer : ServerBuilder() {
+        val database = setting("database", Database.Settings())
+        val cache = setting("cache", Cache.Settings())
+
+        val audit = path.path("audit") include AuditCore(database)
+        val mutationLog = path.path("audit-mutation") include
+            MutationLog(audit, BulkMutationDetail.SummaryOnly)
+
+        init {
+            registerBasicMediaTypeCoders()
+        }
+
+        val patients = database.registerTable("Patient", Patient.serializer())
+
+        val sample = Patient(_id = Uuid.parse("00000000-0000-0000-0000-0000000000b2"), name = "", ssn = "")
+
+        val patientEndpoint = path.path("patient").get bind ApiHttpHandler(
+            summary = "Patient",
+            auth = noAuth,
+            implementation = { _: Unit -> sample },
+        )
+    }
+
+    private suspend fun runPreDeployTasks(runtime: ServerRuntime) {
+        val done = HashSet<PreDeployTask>()
+        suspend fun run(task: PreDeployTask) {
+            if (!done.add(task)) return
+            task.dependencies().forEach { run(it) }
+            with(runtime) { task.execute() }
+        }
+        runtime.server.preDeployTasks.values.forEach { run(it) }
+    }
+
+    /**
+     * @param initiator What the execution should be attributed to. Defaults to the test runner's own
+     *   `Initiator.Direct`, which is the case with no request record behind it.
+     */
+    private fun onServer(
+        initiator: Initiator? = null,
+        block: suspend context(ServerRuntime) (ServerRuntime) -> Unit,
+    ) = runBlocking {
+        TestServer.test(settings = { database set Database.Settings(); cache set Cache.Settings() }) {
+            runPreDeployTasks(serverRuntime)
+            val runtime = if (initiator == null) serverRuntime else serverRuntime.forExecution(initiator)
+            block(runtime, runtime)
+        }
+    }
+
+    private fun onSummaryServer(block: suspend context(ServerRuntime) (ServerRuntime) -> Unit) = runBlocking {
+        SummaryServer.test(settings = { database set Database.Settings(); cache set Cache.Settings() }) {
+            runPreDeployTasks(serverRuntime)
+            block(serverRuntime, serverRuntime)
+        }
+    }
+
+    context(server: ServerRuntime)
+    private suspend fun logged() = TestServer.mutationLog.mutations().find(Condition.Always).toList()
+
+    context(server: ServerRuntime)
+    private fun auditedTable() = TestServer.mutationLog.mutationLogged(TestServer.patients())
+
+    private fun patient(name: String, ssn: String = "s", id: Uuid = Uuid.random()) =
+        Patient(_id = id, name = name, ssn = ssn)
+
+    // ===================== one row per changed record, with both sides =====================
+
+    @Test
+    fun `insert records a row per inserted record`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada")
+        val grace = patient("Grace")
+        table.insert(listOf(ada, grace))
+
+        val rows = logged()
+        assertEquals(2, rows.size, "one row per inserted record")
+        assertEquals(setOf(ada._id.toString(), grace._id.toString()), rows.map { it.recordId }.toSet())
+        assertTrue(rows.all { it.operation == MutationOperation.Insert })
+        assertTrue(rows.all { it.old == null }, "an insert has no previous value")
+        assertTrue(rows.any { it.new?.contains("Ada") == true }, "the inserted value was not recorded")
+    }
+
+    /**
+     * The heart of the layer: the data access log records `ssn assign "changed"` as *intent*, and
+     * cannot say what the row held before. Both sides live here.
+     */
+    @Test
+    fun `updateOne records the value before and after`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada", ssn = "before")
+        table.insert(listOf(ada))
+        table.updateOneById(ada._id, modification<Patient> { it.ssn assign "after" })
+
+        val row = logged().single { it.operation == MutationOperation.Update }
+        assertEquals(ada._id.toString(), row.recordId)
+        assertTrue(row.old?.contains("before") == true, "the previous value was not recorded: ${row.old}")
+        assertTrue(row.new?.contains("after") == true, "the resulting value was not recorded: ${row.new}")
+    }
+
+    @Test
+    fun `replaceOne records the value before and after`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada", ssn = "before")
+        table.insert(listOf(ada))
+        table.replaceOne(condition { it._id eq ada._id }, ada.copy(ssn = "after"))
+
+        val row = logged().single { it.operation == MutationOperation.Replace }
+        assertEquals(ada._id.toString(), row.recordId)
+        assertTrue(row.old?.contains("before") == true, "the previous value was not recorded: ${row.old}")
+        assertTrue(row.new?.contains("after") == true, "the resulting value was not recorded: ${row.new}")
+    }
+
+    @Test
+    fun `upsertOne records the inserting branch with no previous value`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada")
+        table.upsertOne(condition { it._id eq ada._id }, modification { it.ssn assign "x" }, ada)
+
+        val row = logged().single()
+        assertEquals(MutationOperation.Upsert, row.operation)
+        assertEquals(ada._id.toString(), row.recordId)
+        assertNull(row.old, "nothing was there before, so there is no previous value to record")
+        assertTrue(row.new?.contains("Ada") == true)
+    }
+
+    @Test
+    fun `deleteOne records what was removed`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada")
+        table.insert(listOf(ada))
+        table.deleteOne(condition { it._id eq ada._id })
+
+        val row = logged().single { it.operation == MutationOperation.Delete }
+        assertEquals(ada._id.toString(), row.recordId)
+        assertTrue(row.old?.contains("Ada") == true, "the deleted value was not recorded: ${row.old}")
+        assertNull(row.new, "a delete leaves no resulting value")
+    }
+
+    @Test
+    fun `updateMany and deleteMany record a row per affected record`() = onServer {
+        val table = auditedTable()
+        val people = List(3) { patient("P$it") }
+        table.insert(people)
+        table.updateMany(Condition.Always, modification { it.ssn assign "bulk" })
+        table.deleteMany(Condition.Always)
+
+        val rows = logged()
+        assertEquals(3, rows.count { it.operation == MutationOperation.Update })
+        assertEquals(3, rows.count { it.operation == MutationOperation.Delete })
+        assertEquals(
+            people.map { it._id.toString() }.toSet(),
+            rows.filter { it.operation == MutationOperation.Delete }.map { it.recordId }.toSet(),
+        )
+    }
+
+    /**
+     * A call that matched nothing changed nothing. Recording the *attempt* is the data access log's
+     * job — it fails closed and writes the condition before the call runs — so a row here would be a
+     * change that never happened, which is the one thing an audit table must not contain.
+     */
+    @Test
+    fun `a mutation that matches nothing writes no rows`() = onServer {
+        val table = auditedTable()
+        table.updateMany(condition { it.name eq "nobody" }, modification { it.ssn assign "x" })
+        table.deleteOne(condition { it.name eq "nobody" })
+
+        assertEquals(emptyList(), logged())
+    }
+
+    // ===================== the Ignoring* variants record in full by default =====================
+
+    @Test
+    fun `replaceOneIgnoringResult records full detail by default`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada", ssn = "before")
+        table.insert(listOf(ada))
+        table.replaceOneIgnoringResult(condition { it._id eq ada._id }, ada.copy(ssn = "after"))
+
+        val row = logged().single { it.operation == MutationOperation.Replace }
+        assertEquals(ada._id.toString(), row.recordId)
+        assertTrue(row.old?.contains("before") == true, "the previous value was skipped: ${row.old}")
+        assertTrue(row.new?.contains("after") == true, "the resulting value was skipped: ${row.new}")
+        assertNull(row.affectedCount, "a per-row record needs no count")
+    }
+
+    @Test
+    fun `upsertOneIgnoringResult records full detail by default`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada", ssn = "before")
+        table.insert(listOf(ada))
+        table.upsertOneIgnoringResult(
+            condition { it._id eq ada._id },
+            modification { it.ssn assign "after" },
+            ada,
+        )
+
+        val row = logged().single { it.operation == MutationOperation.Upsert }
+        assertEquals(ada._id.toString(), row.recordId)
+        assertTrue(row.old?.contains("before") == true, "the previous value was skipped: ${row.old}")
+        assertTrue(row.new?.contains("after") == true, "the resulting value was skipped: ${row.new}")
+    }
+
+    @Test
+    fun `updateOneIgnoringResult records full detail by default`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada", ssn = "before")
+        table.insert(listOf(ada))
+        table.updateOneIgnoringResult(condition { it._id eq ada._id }, modification { it.ssn assign "after" })
+
+        val row = logged().single { it.operation == MutationOperation.Update }
+        assertEquals(ada._id.toString(), row.recordId)
+        assertTrue(row.old?.contains("before") == true, "the previous value was skipped: ${row.old}")
+        assertTrue(row.new?.contains("after") == true, "the resulting value was skipped: ${row.new}")
+    }
+
+    /** The most expensive upgrade, and the one that most obviously must not be skippable. */
+    @Test
+    fun `updateManyIgnoringResult records full detail by default`() = onServer {
+        val table = auditedTable()
+        val people = List(3) { patient("P$it", ssn = "before") }
+        table.insert(people)
+        table.updateManyIgnoringResult(Condition.Always, modification { it.ssn assign "after" })
+
+        val rows = logged().filter { it.operation == MutationOperation.Update }
+        assertEquals(3, rows.size, "the bulk call produced a summary rather than a row per change")
+        assertEquals(people.map { it._id.toString() }.toSet(), rows.map { it.recordId }.toSet())
+        assertTrue(rows.all { it.old?.contains("before") == true })
+        assertTrue(rows.all { it.new?.contains("after") == true })
+        assertTrue(rows.all { it.affectedCount == null })
+    }
+
+    @Test
+    fun `deleteOneIgnoringOld records what was removed by default`() = onServer {
+        val table = auditedTable()
+        val ada = patient("Ada")
+        table.insert(listOf(ada))
+        table.deleteOneIgnoringOld(condition { it._id eq ada._id })
+
+        val row = logged().single { it.operation == MutationOperation.Delete }
+        assertEquals(ada._id.toString(), row.recordId)
+        assertTrue(row.old?.contains("Ada") == true, "the deleted value was skipped: ${row.old}")
+    }
+
+    @Test
+    fun `deleteManyIgnoringOld records what was removed by default`() = onServer {
+        val table = auditedTable()
+        val people = List(3) { patient("P$it") }
+        table.insert(people)
+        table.deleteManyIgnoringOld(Condition.Always)
+
+        val rows = logged().filter { it.operation == MutationOperation.Delete }
+        assertEquals(3, rows.size, "the bulk call produced a summary rather than a row per change")
+        assertEquals(people.map { it._id.toString() }.toSet(), rows.map { it.recordId }.toSet())
+        assertTrue(rows.all { it.old != null }, "the deleted values were skipped")
+    }
+
+    // ===================== return-value equivalence, one test per method =====================
+
+    /**
+     * Each upgraded call must return exactly what the method it replaced would have. These run the
+     * same call against a decorated table and an undecorated twin holding the same rows, so the
+     * expected value is the real implementation's rather than a restatement of its documentation.
+     */
+    private fun equivalence(
+        seed: List<Patient>,
+        call: suspend (Table<Patient>) -> Any?,
+    ) = onServer {
+        val decorated = auditedTable()
+        val undecorated = TestServer.patientsUndecorated()
+        decorated.insert(seed)
+        undecorated.insert(seed)
+
+        assertEquals(call(undecorated), call(decorated), "the decorator changed what the caller sees")
+    }
+
+    private val ada = patient("Ada", ssn = "before", id = Uuid.parse("00000000-0000-4000-8000-00000000aaa1"))
+
+    @Test
+    fun `replaceOneIgnoringResult returns what the undecorated table returns when it matches`() =
+        equivalence(listOf(ada)) {
+            it.replaceOneIgnoringResult(condition { p -> p._id eq ada._id }, ada.copy(ssn = "after"))
+        }
+
+    @Test
+    fun `replaceOneIgnoringResult returns what the undecorated table returns when it misses`() =
+        equivalence(listOf(ada)) {
+            it.replaceOneIgnoringResult(condition { p -> p.name eq "nobody" }, ada.copy(ssn = "after"))
+        }
+
+    /**
+     * The trap: this one reports whether an element *already existed*, not whether anything changed,
+     * so the obvious `new != null` derivation would invert the answer on the inserting branch.
+     */
+    @Test
+    fun `upsertOneIgnoringResult returns what the undecorated table returns when it inserts`() =
+        equivalence(listOf()) {
+            it.upsertOneIgnoringResult(
+                condition { p -> p._id eq ada._id },
+                modification { p -> p.ssn assign "after" },
+                ada,
+            )
+        }
+
+    @Test
+    fun `upsertOneIgnoringResult returns what the undecorated table returns when it updates`() =
+        equivalence(listOf(ada)) {
+            it.upsertOneIgnoringResult(
+                condition { p -> p._id eq ada._id },
+                modification { p -> p.ssn assign "after" },
+                ada,
+            )
+        }
+
+    @Test
+    fun `updateOneIgnoringResult returns what the undecorated table returns when it matches`() =
+        equivalence(listOf(ada)) {
+            it.updateOneIgnoringResult(condition { p -> p._id eq ada._id }, modification { p -> p.ssn assign "after" })
+        }
+
+    @Test
+    fun `updateOneIgnoringResult returns what the undecorated table returns when it misses`() =
+        equivalence(listOf(ada)) {
+            it.updateOneIgnoringResult(condition { p -> p.name eq "nobody" }, modification { p -> p.ssn assign "after" })
+        }
+
+    @Test
+    fun `updateManyIgnoringResult returns the number of affected rows`() =
+        equivalence(List(3) { patient("P$it") }) {
+            it.updateManyIgnoringResult(Condition.Always, modification { p -> p.ssn assign "after" })
+        }
+
+    @Test
+    fun `updateManyIgnoringResult returns zero when nothing matches`() =
+        equivalence(List(3) { patient("P$it") }) {
+            it.updateManyIgnoringResult(condition { p -> p.name eq "nobody" }, modification { p -> p.ssn assign "after" })
+        }
+
+    @Test
+    fun `deleteOneIgnoringOld returns what the undecorated table returns when it matches`() =
+        equivalence(listOf(ada)) { it.deleteOneIgnoringOld(condition { p -> p._id eq ada._id }) }
+
+    @Test
+    fun `deleteOneIgnoringOld returns what the undecorated table returns when it misses`() =
+        equivalence(listOf(ada)) { it.deleteOneIgnoringOld(condition { p -> p.name eq "nobody" }) }
+
+    @Test
+    fun `deleteManyIgnoringOld returns the number of deleted rows`() =
+        equivalence(List(3) { patient("P$it") }) { it.deleteManyIgnoringOld(Condition.Always) }
+
+    @Test
+    fun `deleteManyIgnoringOld returns zero when nothing matches`() =
+        equivalence(List(3) { patient("P$it") }) { it.deleteManyIgnoringOld(condition { p -> p.name eq "nobody" }) }
+
+    // ===================== the escape hatch =====================
+
+    /**
+     * Counts the effect-returning calls, which is how "did the cheap path stay cheap" is observable
+     * from outside: the upgrade is precisely a call to [Table.updateMany] instead.
+     */
+    private class CountingTable<T : Any>(override val wraps: Table<T>) : Table<T> by wraps {
+        var updateManyCalls: Int = 0
+        var deleteManyCalls: Int = 0
+
+        override suspend fun updateMany(
+            condition: Condition<T>,
+            modification: Modification<T>,
+        ): CollectionChanges<T> {
+            updateManyCalls++
+            return wraps.updateMany(condition, modification)
+        }
+
+        override suspend fun deleteMany(condition: Condition<T>): List<T> {
+            deleteManyCalls++
+            return wraps.deleteMany(condition)
+        }
+    }
+
+    @Test
+    fun `SummaryOnly writes one summary row and does not materialise the changed rows`() = onSummaryServer {
+        val counting = CountingTable(SummaryServer.patients())
+        val table = SummaryServer.mutationLog.mutationLogged(counting)
+        table.insert(List(3) { patient("P$it") })
+        val affected = table.updateManyIgnoringResult(Condition.Always, modification { it.ssn assign "after" })
+
+        assertEquals(3, affected)
+        assertEquals(0, counting.updateManyCalls, "SummaryOnly took the expensive path anyway")
+
+        val rows = SummaryServer.mutationLog.mutations().find(Condition.Always).toList()
+        val summary = rows.single { it.operation == MutationOperation.Update }
+        assertEquals(3, summary.affectedCount)
+        assertNull(summary.recordId, "a summary row names no single record")
+        assertNull(summary.old)
+        assertNull(summary.new)
+    }
+
+    @Test
+    fun `SummaryOnly summarises deletes too`() = onSummaryServer {
+        val counting = CountingTable(SummaryServer.patients())
+        val table = SummaryServer.mutationLog.mutationLogged(counting)
+        table.insert(List(2) { patient("P$it") })
+        assertEquals(2, table.deleteManyIgnoringOld(Condition.Always))
+        assertEquals(0, counting.deleteManyCalls, "SummaryOnly took the expensive path anyway")
+
+        val summary = SummaryServer.mutationLog.mutations().find(Condition.Always).toList()
+            .single { it.operation == MutationOperation.Delete }
+        assertEquals(2, summary.affectedCount)
+        assertNull(summary.recordId)
+    }
+
+    /** SummaryOnly is about the `Ignoring*` variants only; a call that already has the rows keeps them. */
+    @Test
+    fun `SummaryOnly still records effect-returning calls in full`() = onSummaryServer {
+        val table = SummaryServer.mutationLog.mutationLogged(SummaryServer.patients())
+        val people = List(2) { patient("P$it") }
+        table.insert(people)
+        table.updateMany(Condition.Always, modification { it.ssn assign "after" })
+
+        val rows = SummaryServer.mutationLog.mutations().find(Condition.Always).toList()
+            .filter { it.operation == MutationOperation.Update }
+        assertEquals(2, rows.size)
+        assertTrue(rows.all { it.recordId != null && it.affectedCount == null })
+    }
+
+    // ===================== attribution =====================
+
+    /** A task has no request record to point at, so an id there would join to nothing. */
+    @Test
+    fun `a schedule tick records no request id`() {
+        val scheduleId = Uuid.parse("00000000-0000-4000-8000-000000000501")
+        val schedule = Initiator.Schedule(
+            executionId = scheduleId,
+            attributedTo = scheduleId,
+            location = PathSegments(listOf("schedule", "nightly")),
+        )
+        onServer(schedule) {
+            auditedTable().insert(listOf(patient("Ada")))
+
+            val row = logged().single()
+            assertNull(row.requestId, "a schedule tick has no RequestRecord, so this would dangle")
+            assertEquals(schedule.executionId, row.executionId)
+            assertEquals("schedule", row.initiatorKind)
+            assertTrue("schedule" in row.initiator && "nightly" in row.initiator, row.initiator)
+        }
+    }
+
+    @Test
+    fun `an http request records the id its request record is keyed by`() {
+        val http = Initiator.Http(
+            executionId = Uuid.parse("00000000-0000-4000-8000-000000000601"),
+            endpoint = RawHttpEndpoint<PathSpec>(asString = "/patient", method = HttpMethod.GET),
+        )
+        onServer(http) {
+            auditedTable().insert(listOf(patient("Ada")))
+
+            val row = logged().single()
+            assertEquals(http.executionId, row.requestId)
+            assertEquals(http.executionId, row.executionId)
+            assertEquals("http", row.initiatorKind)
+            assertTrue("patient" in row.initiator, row.initiator)
+        }
+    }
+
+    /**
+     * The query the layer exists for: "everything that changed because of request X", in one indexed
+     * lookup rather than a walk of parent pointers.
+     */
+    @Test
+    fun `an indirect mutation chains back to the root execution`() {
+        val root = Uuid.parse("00000000-0000-4000-8000-000000000701")
+        val nested = Initiator.Task(
+            executionId = Uuid.parse("00000000-0000-4000-8000-000000000702"),
+            causedBy = root,
+            rootExecutionId = root,
+            attributedTo = root,
+            location = PathSegments(listOf("task", "cleanup")),
+        )
+        onServer(nested) {
+            auditedTable().insert(listOf(patient("Ada")))
+
+            val row = logged().single()
+            assertEquals(root, row.rootExecutionId)
+            assertEquals(root, row.causedBy)
+            assertEquals(nested.executionId, row.executionId)
+            assertEquals("task", row.initiatorKind)
+        }
+    }
+
+    // ===================== gating =====================
+
+    /** The decorator is meant to be passed on every model; an unaudited one must cost nothing. */
+    @Test
+    fun `an unaudited model generates no rows`() = onServer {
+        val table = TestServer.mutationLog.mutationLogged(TestServer.plain())
+        table.insert(listOf(PlainThing(Uuid.random(), "x")))
+        table.deleteMany(Condition.Always)
+
+        assertEquals(emptyList(), logged())
+    }
+
+    /**
+     * A table whose declared type is not itself audited but whose children are must be refused. A row
+     * names one model, so this shape cannot be attributed — and quietly passing it through would
+     * leave every change to the audited model inside unrecorded and silent.
+     */
+    @Test
+    fun `a table that merely contains audited models is refused`() = onServer {
+        try {
+            TestServer.mutationLog.mutationLogged(TestServer.wrappers())
+            fail("a table containing audited models was silently left unlogged")
+        } catch (e: IllegalStateException) {
+            assertTrue("Patient" in (e.message ?: ""), "the contained model was not named: ${e.message}")
+        }
+    }
+
+    // ===================== failure behaviour =====================
+
+    /**
+     * The asymmetry with the layers above, and the one that has to be verified rather than asserted
+     * in a comment: the change has already committed by the time there is anything to record, so
+     * throwing would report failure for something that happened and invite a double-applying retry.
+     */
+    @Test
+    fun `a mutation whose record cannot be written still happens`() = onServer { runtime ->
+        val underlying = TestServer.patients()
+        val table = MutationLogTable(
+            wraps = underlying,
+            modelId = { 1 },
+            requestId = null,
+            executionId = Uuid.random(),
+            causedBy = null,
+            rootExecutionId = Uuid.random(),
+            attributedTo = Uuid.random(),
+            initiatorKind = "direct",
+            initiator = "{}",
+            json = runtime.internalSerialization.json,
+            nowMillis = { 1L },
+            write = { throw RuntimeException("audit sink down") },
+            bulkDetail = BulkMutationDetail.RecordEveryRow,
+        )
+
+        val ada = patient("Ada")
+        table.insert(listOf(ada))
+        assertEquals(
+            listOf(ada),
+            underlying.find(Condition.Always).toList(),
+            "the insert was rolled back or refused because its record could not be written",
+        )
+
+        // And the upgraded path still hands back the right answer with the sink broken.
+        assertTrue(table.deleteOneIgnoringOld(condition { it._id eq ada._id }))
+        assertEquals(emptyList(), underlying.find(Condition.Always).toList())
+    }
+
+    // ===================== the row is readable =====================
+
+    /** A row is only useful if the model id resolves back through the registry the core owns. */
+    @Test
+    fun `the recorded model id resolves through the registry`() = onServer {
+        auditedTable().insert(listOf(patient("Ada")))
+
+        val row = logged().single()
+        // Keyed by the full serial name, which is what the walk records — not the class's short name.
+        val serialName = Patient.serializer().descriptor.serialName
+        assertEquals(TestServer.audit.registry.await().modelId(serialName), row.modelId)
+    }
+}

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/WebSocketMutationAttributionTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/WebSocketMutationAttributionTest.kt
@@ -1,0 +1,646 @@
+package com.lightningkite.lightningserver.audit
+
+import com.lightningkite.lightningserver.InternalLightningServerApi
+import com.lightningkite.lightningserver.MultiplexMessage
+import com.lightningkite.lightningserver.auth.Authentication
+import com.lightningkite.lightningserver.auth.PrincipalType
+import com.lightningkite.lightningserver.auth.authReaders
+import com.lightningkite.lightningserver.auth.noAuth
+import com.lightningkite.lightningserver.auth.register
+import com.lightningkite.lightningserver.auth.testAuth
+import com.lightningkite.lightningserver.data.Request
+import com.lightningkite.lightningserver.definition.Task
+import com.lightningkite.lightningserver.definition.builder.ServerBuilder
+import com.lightningkite.lightningserver.http.HttpHeader
+import com.lightningkite.lightningserver.http.HttpHeaders
+import com.lightningkite.lightningserver.http.generateRequestId
+import com.lightningkite.lightningserver.http.get
+import com.lightningkite.lightningserver.pathing.PathSpec
+import com.lightningkite.lightningserver.pathing.PathSpec0
+import com.lightningkite.lightningserver.pathing.RawWebSocketPath
+import com.lightningkite.lightningserver.pathing.path
+import com.lightningkite.lightningserver.runtime.EngineBase
+import com.lightningkite.lightningserver.runtime.ExecutionCause
+import com.lightningkite.lightningserver.runtime.Initiator
+import com.lightningkite.lightningserver.runtime.ServerRuntime
+import com.lightningkite.lightningserver.runtime.executeWithMetrics
+import com.lightningkite.lightningserver.runtime.forExecution
+import com.lightningkite.lightningserver.runtime.invoke
+import com.lightningkite.lightningserver.runtime.location
+import com.lightningkite.lightningserver.runtime.phase
+import com.lightningkite.lightningserver.serialization.registerBasicMediaTypeCoders
+import com.lightningkite.lightningserver.settings.set
+import com.lightningkite.lightningserver.typed.ApiHttpHandler
+import com.lightningkite.lightningserver.typed.registerTable
+import com.lightningkite.lightningserver.websockets.MultiplexWebSocketHandler
+import com.lightningkite.lightningserver.websockets.WebSocketClose
+import com.lightningkite.lightningserver.websockets.WebSocketConnectRequest
+import com.lightningkite.lightningserver.websockets.WebSocketConnection
+import com.lightningkite.lightningserver.websockets.WebSocketFrame
+import com.lightningkite.lightningserver.websockets.WebSocketHandler
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionMessage
+import com.lightningkite.lightningserver.websockets.WebSocketSubscriptionRequest
+import com.lightningkite.services.cache.Cache
+import com.lightningkite.services.database.Condition
+import com.lightningkite.services.database.Database
+import com.lightningkite.services.database.HasId
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Can a change made under a WebSocket be traced back to a person?
+ *
+ * A [MutationRecord] names a `rootExecutionId`; turning that into a person means looking it up in
+ * [RequestRecord] and reading `principal`. For HTTP that join is trivially sound — the row is keyed by
+ * the request's own execution id. For a socket it is not obvious: [RequestRecordInterceptor] keys the
+ * row by the *socket* id rather than by the phase execution that wrote the change, and a virtual
+ * socket multiplexed inside a physical one gets a fresh socket id while inheriting the physical
+ * connection's root.
+ *
+ * These tests answer that by driving real sockets through the real interceptor chain and then
+ * performing exactly the join an auditor would: `requests().find { it._id == mutation.attributedTo }`.
+ *
+ * `attributedTo` rather than `rootExecutionId` throughout, and the difference is the point. The root
+ * is a *causal* key — it answers "what set this off" — and the head of a causal chain is not
+ * necessarily the execution that carried the credentials. A multiplexed socket is exactly where the
+ * two come apart, so the tests below assert both, and assert that they disagree where they should.
+ */
+@OptIn(InternalLightningServerApi::class)
+class WebSocketMutationAttributionTest {
+
+    private val user = Uuid.parse("00000000-0000-4000-8000-0000000000c1")
+
+    private fun probe(block: suspend context(ServerRuntime) (ProbeEngine) -> Unit) = runBlocking {
+        val engine = ProbeEngine()
+        engine.ready()
+        engine.preDeploy()
+        block(engine, engine)
+    }
+
+    context(server: ServerRuntime)
+    private suspend fun requests() = TestServer.audit.requests().find(Condition.Always).toList()
+
+    context(server: ServerRuntime)
+    private suspend fun mutations() = TestServer.mutationLog.mutations().find(Condition.Always).toList()
+
+    private fun authHeaders() = HttpHeaders { add(HttpHeader.Authorization, user.toString()) }
+
+    /** The same credential as [authHeaders], carried the way a browser has to carry it on a socket. */
+    private fun tokenQuery() = mapOf(HttpHeader.Authorization to listOf(user.toString()))
+
+    /** The join an auditor performs, as one call, so every test below asks the same question. */
+    private fun List<RequestRecord>.rowFor(id: Uuid?): RequestRecord? = firstOrNull { it._id == id }
+
+    // ===================== 1. a plain socket, mutating directly =====================
+
+    @Test
+    fun `a mutation made by a socket message joins back to the person through both ids`() = probe { engine ->
+        val socket = engine.openSocket(TestServer.socket, authHeaders())
+        val id = Uuid.random()
+        socket.send("direct:$id")
+
+        val mutation = mutations().single()
+        assertEquals(id.toString(), mutation.recordId)
+
+        val requests = requests()
+        val byRequestId = requests.rowFor(mutation.requestId)
+        assertNotNull(byRequestId, "requestId ${mutation.requestId} names no request row; rows are ${requests.map { it._id }}")
+        val byRoot = requests.rowFor(mutation.rootExecutionId)
+        assertNotNull(byRoot, "rootExecutionId ${mutation.rootExecutionId} names no request row; rows are ${requests.map { it._id }}")
+
+        assertEquals(socket.initiator.socketId, mutation.requestId, "the row is keyed by the socket, not the phase")
+
+        val byAttribution = requests.rowFor(mutation.attributedTo)
+        assertNotNull(byAttribution, "attributedTo ${mutation.attributedTo} names no request row")
+        assertTrue(
+            byAttribution.principal?.contains(user.toString()) == true,
+            "the request the change attributes to does not name the authenticated user: ${byAttribution.principal}",
+        )
+        // For a plain socket the three ids coincide, which is why one column looked like enough.
+        assertEquals(byAttribution._id, byRoot._id)
+    }
+
+    // ===================== 2. a plain socket, mutating from a task =====================
+
+    @Test
+    fun `a mutation made by a task launched from a socket message joins back to the person`() = probe { engine ->
+        val socket = engine.openSocket(TestServer.socket, authHeaders())
+        val id = Uuid.random()
+        socket.send("task:$id")
+        engine.drainTasks()
+
+        val mutation = mutations().single()
+        assertEquals("task", mutation.initiatorKind, "the task ran inline rather than as its own execution")
+        assertNull(mutation.requestId, "a task has no request row of its own to point at")
+
+        val requests = requests()
+        val byAttribution = requests.rowFor(mutation.attributedTo)
+        assertNotNull(byAttribution, "attributedTo ${mutation.attributedTo} names no request row; rows are ${requests.map { it._id }}")
+        assertEquals(
+            socket.initiator.socketId,
+            byAttribution._id,
+            "the task should attribute to the socket it descends from",
+        )
+        assertTrue(
+            byAttribution.principal?.contains(user.toString()) == true,
+            "the request the change attributes to does not name the authenticated user: ${byAttribution.principal}",
+        )
+        // The anchor survived the queue: it is carried in the serialized ExecutionCause, not derived.
+        assertEquals(byAttribution._id, requests.rowFor(mutation.rootExecutionId)?._id)
+    }
+
+    // ===================== 3. a virtual socket multiplexed inside a physical one =====================
+
+    @Test
+    fun `a mutation made by a virtual sub-socket message joins back to the person`() = probe { engine ->
+        val physical = engine.openSocket(TestServer.multiplex, authHeaders())
+        val id = Uuid.random()
+        engine.startChannel(physical, "c1")
+        engine.sendOnChannel(physical, "c1", "direct:$id")
+
+        val mutation = mutations().single()
+        assertEquals(id.toString(), mutation.recordId)
+
+        val requests = requests()
+        val byRequestId = requests.rowFor(mutation.requestId)
+        assertNotNull(byRequestId, "requestId ${mutation.requestId} names no request row; rows are ${requests.map { it._id to it.endpoint }}")
+        val byRoot = requests.rowFor(mutation.rootExecutionId)
+        assertNotNull(byRoot, "rootExecutionId ${mutation.rootExecutionId} names no request row; rows are ${requests.map { it._id to it.endpoint }}")
+
+        assertEquals(
+            physical.initiator.socketId,
+            byRoot._id,
+            "the root of a virtual socket's work should be the physical connection carrying it",
+        )
+
+        val byAttribution = requests.rowFor(mutation.attributedTo)
+        assertNotNull(byAttribution, "attributedTo ${mutation.attributedTo} names no request row")
+        assertEquals("/socket", byAttribution.endpoint, "a sub-socket attributes to its own row, not the carrier's")
+        assertTrue(
+            byAttribution.principal?.contains(user.toString()) == true,
+            "the request the change attributes to does not name the authenticated user: ${byAttribution.principal}",
+        )
+    }
+
+    @Test
+    fun `a mutation made by a task launched from a virtual sub-socket message joins back to the person`() =
+        probe { engine ->
+            val physical = engine.openSocket(TestServer.multiplex, authHeaders())
+            val id = Uuid.random()
+            engine.startChannel(physical, "c1")
+            engine.sendOnChannel(physical, "c1", "task:$id")
+            engine.drainTasks()
+
+            val mutation = mutations().single()
+            assertEquals("task", mutation.initiatorKind)
+            assertNull(mutation.requestId)
+
+            val requests = requests()
+            val byAttribution = requests.rowFor(mutation.attributedTo)
+            assertNotNull(
+                byAttribution,
+                "attributedTo ${mutation.attributedTo} names no request row; rows are ${requests.map { it._id to it.endpoint }}",
+            )
+            assertEquals(
+                "/socket",
+                byAttribution.endpoint,
+                "the anchor a task inherits is the sub-socket's, not the carrier the root names",
+            )
+            assertTrue(
+                byAttribution.principal?.contains(user.toString()) == true,
+                "the request the change attributes to does not name the authenticated user: ${byAttribution.principal}",
+            )
+        }
+
+    // ===== 4. a virtual sub-socket authenticated where the carrier is not =====
+
+    /**
+     * `WebSocketConnectRequest.subConnection` hands the sub-connection the carrier's *same*
+     * [com.lightningkite.lightningserver.data.SerializableCache] instance, so an unauthenticated
+     * carrier resolving `Authentication.CacheKey` first could plausibly memoize a null that the
+     * sub-socket then inherits. It does not: `SerializableCache.get(CalculatingKey, input)` is
+     * `retrieve(key)?.value ?: calculate(input)`, so a cached null falls through to a fresh
+     * calculation against the sub-socket's own request. Pinned because the failure mode it rules out
+     * would be silent and would look exactly like "the user did not authenticate".
+     */
+    @Test
+    fun `a virtual sub-socket authenticates on its own credentials even when the carrier did not`() =
+        probe { engine ->
+            val physical = engine.openSocket(TestServer.multiplex, HttpHeaders.EMPTY)
+            engine.startChannel(physical, "c1", tokenQuery())
+            engine.sendOnChannel(physical, "c1", "direct:${Uuid.random()}")
+
+            val requests = requests()
+            val carrier = requests.rowFor(physical.initiator.socketId)
+            assertNotNull(carrier)
+            assertNull(carrier.principal, "the carrier was supposed to be anonymous")
+
+            val sub = requests.single { it.endpoint == "/socket" }
+            assertTrue(
+                sub.principal?.contains(user.toString()) == true,
+                "the sub-socket did not authenticate on its own query parameters: ${sub.principal}",
+            )
+        }
+
+    /**
+     * The two columns pulling apart, on one row.
+     *
+     * `attributedTo` names the sub-socket, which authenticated; `rootExecutionId` names the carrier,
+     * which did not. Both are correct answers to their own question — "who did it" and "what set
+     * this off" — and pinned together here so that neither can later be collapsed into the other on
+     * the grounds that they usually agree.
+     */
+    @Test
+    fun `a direct mutation from an authenticated sub-socket attributes to the person while its root stays anonymous`() =
+        probe { engine ->
+            val physical = engine.openSocket(TestServer.multiplex, HttpHeaders.EMPTY)
+            engine.startChannel(physical, "c1", tokenQuery())
+            engine.sendOnChannel(physical, "c1", "direct:${Uuid.random()}")
+
+            val requests = requests()
+            val mutation = mutations().single()
+
+            val byAttribution = requests.rowFor(mutation.attributedTo)
+            assertNotNull(byAttribution, "attributedTo ${mutation.attributedTo} names no request row")
+            assertEquals("/socket", byAttribution.endpoint)
+            assertTrue(
+                byAttribution.principal?.contains(user.toString()) == true,
+                "the sub-socket's own row does not name the person: ${byAttribution.principal}",
+            )
+
+            val byRoot = requests.rowFor(mutation.rootExecutionId)
+            assertNotNull(byRoot, "rootExecutionId ${mutation.rootExecutionId} names no request row")
+            assertEquals("/multiplex", byRoot.endpoint)
+            assertNull(
+                byRoot.principal,
+                "the root is the causal head, which here is the anonymous carrier; it must not be " +
+                    "what an auditor reads to name the person",
+            )
+            assertTrue(
+                byAttribution._id != byRoot._id,
+                "the whole reason for two columns is that they can differ, and here they must",
+            )
+        }
+
+    /**
+     * The hardest case, and the one `attributedTo` exists for.
+     *
+     * A task has no request row of its own, so `requestId` is null and there is exactly one column
+     * left to trace it by. That column must not be `rootExecutionId`: the root is the head of the
+     * *causal* chain, which here is the multiplex carrier — an execution that authenticated nobody,
+     * because the credential arrived on the sub-socket's own query parameters. Anchoring to the
+     * causal head would therefore answer "anonymous" for a change a known person made.
+     *
+     * `attributedTo` anchors instead to the innermost execution that had a request row, and a task
+     * inherits its launcher's anchor through the serialized `ExecutionCause` — so it survives the
+     * queue, which is the only reason it works on a serverless engine at all.
+     */
+    @Test
+    fun `a task launched from an authenticated sub-socket attributes to the person who opened it`() =
+        probe { engine ->
+            val physical = engine.openSocket(TestServer.multiplex, HttpHeaders.EMPTY)
+            engine.startChannel(physical, "c1", tokenQuery())
+            engine.sendOnChannel(physical, "c1", "task:${Uuid.random()}")
+            engine.drainTasks()
+
+            val mutation = mutations().single()
+            assertEquals("task", mutation.initiatorKind)
+            assertNull(mutation.requestId, "a task has no request row, so attributedTo is the only handle")
+
+            val requests = requests()
+            val byAttribution = requests.rowFor(mutation.attributedTo)
+            assertNotNull(byAttribution, "attributedTo ${mutation.attributedTo} names no request row")
+            assertEquals("/socket", byAttribution.endpoint, "the task inherited the sub-socket's anchor")
+            assertTrue(
+                byAttribution.principal?.contains(user.toString()) == true,
+                "a change a person made through a multiplexed socket must name that person: " +
+                    "${byAttribution.principal}",
+            )
+
+            // And the column that used to be the only handle still answers the causal question,
+            // still lands on the carrier, and is still anonymous.
+            val byRoot = requests.rowFor(mutation.rootExecutionId)
+            assertNotNull(byRoot)
+            assertEquals("/multiplex", byRoot.endpoint)
+            assertNull(byRoot.principal)
+        }
+
+    /**
+     * The minting bug underneath all of this: `subConnection` used to draw two separate ids for a
+     * virtual socket's `executionId` and its `socketId`.
+     *
+     * A socket's request row is keyed by `socketId`, so with two ids the row was unreachable from the
+     * execution id anything descending from the socket names — the sub-socket's own row existed and
+     * nothing could find it. Observable here because a phase names its connect in `causedBy` while
+     * the row is keyed by `socketId`: the two are the same id only if the connect minted one.
+     */
+    @Test
+    fun `a virtual sub-socket's connect execution and its socket id are the same id`() = probe { engine ->
+        val physical = engine.openSocket(TestServer.multiplex, authHeaders())
+        engine.startChannel(physical, "c1")
+        engine.sendOnChannel(physical, "c1", "direct:${Uuid.random()}")
+
+        val mutation = mutations().single()
+        val subRow = requests().single { it.endpoint == "/socket" }
+
+        // subRow._id is the sub-socket's socketId; mutation.causedBy is its connect executionId.
+        assertEquals(
+            subRow._id,
+            mutation.causedBy,
+            "a sub-socket that mints separate connect and socket ids leaves its own request row " +
+                "unreachable from everything descending from it",
+        )
+        assertEquals(subRow._id, mutation.attributedTo)
+    }
+
+    /**
+     * What the root actually points at for a virtual socket, recorded because it is the fidelity the
+     * join gives up: the row found is the *physical* connection's, whose endpoint is the multiplex
+     * path, not the sub-socket's own row.
+     */
+    @Test
+    fun `a virtual sub-socket gets its own request row, but the root names the physical connection`() =
+        probe { engine ->
+            val physical = engine.openSocket(TestServer.multiplex, authHeaders())
+            engine.startChannel(physical, "c1")
+            engine.sendOnChannel(physical, "c1", "direct:${Uuid.random()}")
+
+            val requests = requests()
+            val mutation = mutations().single()
+
+            val subRow = requests.rowFor(mutation.requestId)
+            assertNotNull(subRow, "the virtual sub-socket has no request row of its own")
+            assertEquals("/socket", subRow.endpoint, "the sub-socket's row should name the sub-socket's endpoint")
+
+            val rootRow = requests.rowFor(mutation.rootExecutionId)
+            assertNotNull(rootRow)
+            assertEquals(
+                "/multiplex",
+                rootRow.endpoint,
+                "the root resolves to the physical connection, so the endpoint an auditor sees is the carrier",
+            )
+        }
+}
+
+// ===================== the server under test =====================
+
+@Serializable
+private data class SocketUser(override val _id: Uuid) : HasId<Uuid> {
+    companion object : PrincipalType<SocketUser, Uuid> {
+        override val idSerializer: KSerializer<Uuid> = Uuid.serializer()
+        override val subjectSerializer: KSerializer<SocketUser> = serializer()
+
+        context(server: ServerRuntime)
+        override suspend fun fetch(id: Uuid): SocketUser = SocketUser(id)
+    }
+}
+
+/**
+ * The whole of the id as the credential, read from the Authorization header *or* the Authorization
+ * query parameter.
+ *
+ * Both, because that is what the shipped reader does: `SessionManager.read` falls back to the
+ * `Authorization` and `jwt` query parameters precisely because a browser cannot set headers on a
+ * WebSocket. A reader that only looked at headers would make the query-parameter cases below
+ * unconstructible for a reason that does not exist in the real server.
+ */
+private object TokenReader : Authentication.Reader<SocketUser> {
+    override val priority: Double = 1.0
+
+    context(server: ServerRuntime)
+    override suspend fun read(request: Request<*>): Authentication<SocketUser>? {
+        val raw = request.headers[HttpHeader.Authorization]?.root
+            ?: request.queryParameters.find { it.first.equals(HttpHeader.Authorization, ignoreCase = true) }?.second
+            ?: return null
+        return SocketUser.testAuth(SocketUser(Uuid.parse(raw)))
+    }
+}
+
+private object TestServer : ServerBuilder() {
+    val database = setting("database", Database.Settings())
+    val cache = setting("cache", Cache.Settings())
+
+    val audit = path.path("audit") include AuditCore(database)
+    val mutationLog = path.path("audit-mutation") include MutationLog(audit)
+
+    init {
+        registerBasicMediaTypeCoders()
+        register(SocketUser)
+        authReaders.register(TokenReader)
+    }
+
+    val patients = database.registerTable("Patient", Patient.serializer())
+
+    /** Present only so the registry, which scans endpoint serializers, assigns Patient an id. */
+    val sample = Patient(_id = Uuid.parse("00000000-0000-0000-0000-0000000000c2"), name = "", ssn = "")
+
+    val patientEndpoint = path.path("patient").get bind ApiHttpHandler(
+        summary = "Patient",
+        auth = noAuth,
+        implementation = { _: Unit -> sample },
+    )
+
+    /** The indirect path: the change happens in an execution of its own, with no request behind it. */
+    val mutateTask: Task<Uuid> = path.path("mutate-task") bind Task(Uuid.serializer()) { id ->
+        mutationLog.mutationLogged(patients()).insert(listOf(Patient(_id = id, name = "FromTask", ssn = "t")))
+    }
+
+    val socket = path.path("socket") bind WebSocketHandler<PathSpec0, Unit>(
+        willConnect = { },
+        messageFromClient = { frame ->
+            val text = (frame as WebSocketFrame.Text).content
+            val id = Uuid.parse(text.substringAfter(':'))
+            when (text.substringBefore(':')) {
+                "direct" -> mutationLog.mutationLogged(patients())
+                    .insert(listOf(Patient(_id = id, name = "FromSocket", ssn = "s")))
+
+                "task" -> mutateTask(id)
+                else -> throw IllegalArgumentException("Unknown socket command: $text")
+            }
+        },
+    )
+
+    val multiplex = path.path("multiplex") bind MultiplexWebSocketHandler()
+}
+
+// ===================== the engine =====================
+
+/**
+ * An engine that drives sockets through the real interceptor chain and puts tasks through a real
+ * queue.
+ *
+ * `TestRunner` cannot answer the question these tests ask. It runs tasks inline, inside the launching
+ * execution, so a task there never becomes an execution of its own and would appear to inherit the
+ * socket's attribution no matter what the engines actually record. The queue here serializes the
+ * payload and drops every live object, as a Lambda invocation does, so what the task run sees is only
+ * what was written into that payload — the same technique `TaskParentageTest` uses in core.
+ *
+ * Nothing here builds an [Initiator] the framework would not: the connect initiator is minted exactly
+ * as every engine and `TestRunner` mints it, and every id after that is derived by `phase`,
+ * `subConnection` or `executeWithMetrics`.
+ */
+@OptIn(InternalLightningServerApi::class)
+private class ProbeEngine : EngineBase(TestServer.build()), ServerRuntime {
+    override val serverId: String = "probe"
+    override val serverVersion: String = "test"
+    override val initiator: Initiator = Initiator.Direct(Uuid.random())
+
+    override suspend fun <PATH : PathSpec, T> sendWebSocketSubscriptionMessage(
+        event: WebSocketSubscriptionMessage<PATH, T>,
+    ): Unit = Unit
+
+    fun ready() {
+        with(settings) {
+            TestServer.database set Database.Settings()
+            TestServer.cache set Cache.Settings()
+        }
+        settings.readyUsingDefaults()
+    }
+
+    /** Assigns the audit bit indices, as the deploy pipeline does before a version serves. */
+    suspend fun preDeploy(): Unit = runPreDeployTasks()
+
+    // ----- tasks, over a queue that keeps nothing but the payload -----
+
+    @Serializable
+    private data class Queued(val location: String, val cause: ExecutionCause?, val input: String)
+
+    private val queue = ArrayDeque<Queued>()
+
+    override suspend fun <T> Task<T>.invoke(input: T, cause: ExecutionCause?) {
+        queue.addLast(
+            Queued(
+                location = location.toString(),
+                cause = cause,
+                input = internalSerialization.json.encodeToString(serializer, input),
+            )
+        )
+    }
+
+    suspend fun drainTasks() {
+        while (queue.isNotEmpty()) {
+            val queued = queue.removeFirst()
+            val location = PathSpec0.fromString(queued.location)
+            @Suppress("UNCHECKED_CAST")
+            val task = server.tasks.getValue(location) as Task<Any?>
+            task.executeWithMetrics(
+                location,
+                internalSerialization.json.decodeFromString(task.serializer, queued.input),
+                queued.cause,
+            )
+        }
+    }
+
+    // ----- sockets -----
+
+    inner class ProbeSocket<PATH : PathSpec, STORAGE>(
+        private val handler: WebSocketHandler<PATH, STORAGE>,
+        val request: WebSocketConnectRequest<PATH>,
+        val initiator: Initiator.WebSocket,
+        private var state: STORAGE,
+    ) {
+        val sent: MutableList<WebSocketFrame> = mutableListOf()
+
+        val connection: WebSocketConnection<PATH, STORAGE> = object : WebSocketConnection<PATH, STORAGE> {
+            override val request: WebSocketConnectRequest<PATH> get() = this@ProbeSocket.request
+            override val currentState: STORAGE get() = state
+            override suspend fun repullState(): STORAGE = state
+            override suspend fun queueStateUpdate(modification: (STORAGE) -> STORAGE) {
+                state = modification(state)
+            }
+
+            override suspend fun updateStateImmediately(modification: (STORAGE) -> STORAGE): STORAGE {
+                state = modification(state)
+                return state
+            }
+
+            override suspend fun subscribe(topic: WebSocketSubscriptionRequest<*, *>): Unit = Unit
+            override suspend fun unsubscribe(topic: WebSocketSubscriptionRequest<*, *>): Unit = Unit
+            override suspend fun send(frame: WebSocketFrame) {
+                sent += frame
+            }
+
+            override suspend fun close(reason: WebSocketClose): Unit = Unit
+        }
+
+        suspend fun send(text: String) {
+            with(forExecution(initiator.phase(Initiator.WebSocket.Phase.ClientMessage))) {
+                handler.messageFromClient(connection, WebSocketFrame.Text(text))
+            }
+        }
+    }
+
+    suspend fun <STORAGE> openSocket(
+        handler: WebSocketHandler<PathSpec0, STORAGE>,
+        headers: HttpHeaders,
+    ): ProbeSocket<PathSpec0, STORAGE> {
+        val intercepted = server.interceptIncomingSocket(handler)
+        val request = WebSocketConnectRequest(
+            path = RawWebSocketPath(handler.location),
+            headers = headers,
+            domain = "example.com",
+            protocol = "wss",
+            sourceIp = "10.0.0.9",
+        )
+        val socketId = generateRequestId()
+        val initiator = Initiator.WebSocket(
+            executionId = socketId,
+            socketId = socketId,
+            path = request.path,
+            phase = Initiator.WebSocket.Phase.Connect,
+        )
+        val storage = with(forExecution(initiator)) { intercepted.willConnect(request) }
+        return ProbeSocket(intercepted, request, initiator, storage).also {
+            with(forExecution(initiator.phase(Initiator.WebSocket.Phase.Connected))) {
+                intercepted.didConnect(it.connection)
+            }
+        }
+    }
+
+    /**
+     * Opens a virtual socket onto `/socket` inside a physical multiplex connection.
+     *
+     * [queryParams] are the client's own, for the sub-socket only — the multiplex handler merges them
+     * into the sub-connection's request, which is how a sub-socket can carry a credential the carrier
+     * never saw.
+     */
+    suspend fun startChannel(
+        physical: ProbeSocket<PathSpec0, *>,
+        channel: String,
+        queryParams: Map<String, List<String>>? = null,
+    ) {
+        physical.send(
+            externalSerialization.json.encodeToString(
+                MultiplexMessage(channel = channel, path = "/socket", start = true, queryParams = queryParams)
+            )
+        )
+        failOnMultiplexError(physical)
+    }
+
+    suspend fun sendOnChannel(physical: ProbeSocket<PathSpec0, *>, channel: String, data: String) {
+        physical.send(
+            externalSerialization.json.encodeToString(MultiplexMessage(channel = channel, data = data))
+        )
+        failOnMultiplexError(physical)
+    }
+
+    /**
+     * The multiplex handler answers a failed sub-socket with an error frame rather than throwing, so a
+     * broken test would otherwise look like a passing one that simply recorded nothing.
+     */
+    private fun failOnMultiplexError(physical: ProbeSocket<PathSpec0, *>) {
+        physical.sent.mapNotNull { (it as? WebSocketFrame.Text)?.content }
+            .map { externalSerialization.json.decodeFromString<MultiplexMessage>(it) }
+            .firstOrNull { it.error != null }
+            ?.let { throw IllegalStateException("The multiplexed socket failed: ${it.error}") }
+    }
+}


### PR DESCRIPTION
**Stack: 14 of 16.** Based on `split/a4` — review that one first.
One row per audited record that changed, carrying the old and new values, the
`Initiator` that caused it, and the request record that names who is
responsible.

Its own table rather than more columns on the data access log, because
looking for tampering and looking for query abuse are unrelated
investigations with unrelated volumes, and a deployment should be able to
install either without paying for the other.

A `DataAccessRecord` cannot answer this. It carries the `Modification` that
was *submitted*, which is intent, not effect: it does not say which rows a
condition matched, and a modification like `count assign count + 1` names no
resulting value at all.

## Two id columns, because they answer different questions

`rootExecutionId` is causal — what set this off. `attributedTo` is the
request record that names the person. For a plain request or socket the two
name the same execution, which is why one column looked like enough.

They come apart wherever the framework makes an *inner* execution that
carries its own credentials. A `/meta/bulk` sub-request and a multiplexed
sub-socket both take per-sub query parameters, and `SessionManager.read`
falls back to the `Authorization` and `jwt` query parameters — so an
anonymous carrier can dispatch an authenticated inner execution. A task
launched from one has no request row of its own, so before `attributedTo`
its only handle was the causal root, which is the carrier, which names
nobody. A change a known person made was untraceable.

Both shapes are pinned end to end, driven through real sockets and a real
`/meta/bulk` request rather than hand-built initiators, with tasks replayed
through a serializing queue so they are genuinely separate executions:

- `WebSocketMutationAttributionTest` (9)
- `BulkSubRequestMutationAttributionTest` (5)

Each asserts both halves — that `attributedTo` names the person *and* that
`rootExecutionId` still lands on the anonymous carrier — so the two columns
cannot later be collapsed into one without a test saying so. Each file also
carries a control with the credential on the carrier instead, which is what
establishes that the variable is where the credential sat rather than
anything about tasks, bulk, or sockets.

## The rest

**The `Ignoring*` methods are upgraded by default** so that every changed row
is still recorded, even though those methods exist precisely to discard the
effect. A log with a cheaper path that records less is a log with a bypass,
and a bypass in an audit trail is a critical defect rather than a
performance tuning knob. `BulkMutationDetail.SummaryOnly` makes it a
deliberate, named choice instead. The cost is real and accepted: an
`updateMany` over ten thousand rows writes ten thousand audit rows.

**Fail-open, and necessarily so.** The layers that gate disclosure record
first and throw. That option does not exist here — the effect *is* the
record, so there is nothing to write until the change is made, and once it is
made, throwing reports failure for something that happened and invites a
retry that applies it twice. Where "no unrecorded write" matters more than
"no double write", install the data access log alongside: it fails closed and
records the attempt before it runs.

All six `Ignoring*` derivations were checked against `InMemoryTable`,
including `upsertOneIgnoringResult`, whose boolean means "existed" rather
than "changed".

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd