### PR TITLE
Record magic-link issuance as an authentication event

### DIFF
--- a/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/AuthEventRecord.kt
+++ b/audit-shared/src/commonMain/kotlin/com/lightningkite/lightningserver/audit/AuthEventRecord.kt
@@ -35,6 +35,16 @@ public enum class AuthEventType {
 
     /** A proof was rejected. */
     ProofRejected,
+
+    /**
+     * A proof was minted and sent to someone with no credential presented by anyone — a magic link.
+     *
+     * Separate from [ProofAccepted] because nothing was proven: the server decided to trust an
+     * address and mailed a bearer credential to it. Whoever reads that message can authenticate as
+     * the address, so issuance is itself the act worth tracking — an attacker who can cause a link
+     * to be issued to an address they control needs no credential at all.
+     */
+    ProofIssued,
 }
 
 /**

--- a/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/ProofAuthEventWiringTest.kt
+++ b/audit/src/test/kotlin/com/lightningkite/lightningserver/audit/ProofAuthEventWiringTest.kt
@@ -1,5 +1,7 @@
 package com.lightningkite.lightningserver.audit
 
+import com.lightningkite.lightningserver.auth.noAuth
+import com.lightningkite.lightningserver.typed.ApiHttpHandler
 import com.lightningkite.lightningserver.HttpMethod
 import com.lightningkite.lightningserver.auth.PrincipalType
 import com.lightningkite.lightningserver.auth.idString
@@ -51,7 +53,7 @@ import kotlin.uuid.Uuid
  * Proof *issuance* and proof *acceptance* are different events. `Signer.makeProof` is reached both by
  * a `prove` handler that has just checked a secret and by `PinBasedProofEndpoints.issueProof`, which
  * mints a proof to be mailed to somebody (a magic link) with nothing presented at all. Only the first
- * is an acceptance; `a mailed magic link is not recorded as an accepted proof` pins that down.
+ * is an acceptance; `a mailed magic link is recorded as issued, not as accepted` pins that down.
  */
 class ProofAuthEventWiringTest {
 
@@ -99,6 +101,27 @@ class ProofAuthEventWiringTest {
         /** Reaches the magic-link mint, which is `protected` on the base class. */
         context(_: ServerRuntime)
         suspend fun mintMagicLink(destination: String): Proof = issueProof(destination)
+
+        /**
+         * Stands in for an application's own "email me a login link" route.
+         *
+         * The framework ships no such endpoint — magic links are always the application calling
+         * `send(destination) { ... }` from a route of its own — so the realistic case has to be
+         * modelled here. It passes `request`, which is the whole point: that is where the IP and
+         * user agent of whoever asked for the link come from.
+         */
+        val sendLink: ApiHttpHandler<PathSpec0, HasId<*>?, String, Boolean> =
+            path.path("send-link").post bind ApiHttpHandler(
+                auth = noAuth,
+                summary = "Send a magic link",
+                description = "Mints a proof to be mailed to the address, presenting nothing.",
+                errorCases = emptyList(),
+                successCode = HttpStatus.OK,
+                implementation = { destination: String ->
+                    issueProof(destination, request)
+                    true
+                },
+            )
     }
 
     object TestServer : ServerBuilder() {
@@ -441,16 +464,74 @@ class ProofAuthEventWiringTest {
     /**
      * The issuance/acceptance split, asserted rather than assumed. `issueProof` mints a proof to be
      * mailed to an address — a magic link — with no credential presented by anyone. Recording that as
-     * `ProofAccepted` would put a login in the log that never happened.
+     * `ProofAccepted` would put a login in the log that never happened, and would make "how many
+     * times did this account authenticate" wrong.
+     *
+     * It *is* recorded, as [AuthEventType.ProofIssued]. The link is a bearer credential from the
+     * moment it exists, so an attacker who can cause one to be issued to an address they control
+     * needs no credential at all — and the resulting login looks entirely ordinary. The issuance is
+     * the only point at which that shows up.
      */
     @Test
-    fun `a mailed magic link is not recorded as an accepted proof`() = onServer {
+    fun `a mailed magic link is recorded as issued, not as accepted`() = onServer {
         TestServer.pin.mintMagicLink("victim@example.com")
 
-        assertTrue(
-            events().isEmpty(),
-            "minting a proof to mail to someone was recorded as a presented credential being accepted",
+        val event = events().single()
+        assertEquals(
+            AuthEventType.ProofIssued,
+            event.type,
+            "minting a proof to mail to someone must not read as a presented credential being accepted",
         )
+        assertEquals("victim@example.com", event.principal)
+        assertEquals("testpin", event.method)
+    }
+
+    /**
+     * The trace this event exists for, end to end: a frontend asks for a link to be mailed, and the
+     * log can name who asked.
+     *
+     * A magic link is a bearer credential, so "someone caused a link to be sent to an address they
+     * control" is the attack, and it is invisible at login time — the resulting authentication looks
+     * entirely ordinary. The issuance is the only point where the requester's origin is knowable, so
+     * an issuance event with no origin would record that something happened while losing the one
+     * fact worth having.
+     */
+    @Test
+    fun `an issuance names the origin of the request that asked for it`() = onServer {
+        serverRuntime.handle(post("/pin/send-link", "\"victim@example.com\""), testId(20))
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofIssued, event.type)
+        assertEquals("victim@example.com", event.principal)
+        assertEquals("203.0.113.7", event.sourceIp, "the log must name who asked for the link")
+        assertEquals("probe/1.0", event.userAgent)
+    }
+
+    /** And the same origin is reachable through the request log, independently of the event's own columns. */
+    @Test
+    fun `an issuance joins the request record of the call that asked for it`() = onServer {
+        serverRuntime.handle(post("/pin/send-link", "\"victim@example.com\""), testId(21))
+
+        val event = events().single()
+        assertEquals(testId(21), event.requestId)
+        val requests = TestServer.audit.requests().find(Condition.Always).toList()
+        val row = requests.singleOrNull { it._id == testId(21) }
+        assertEquals("203.0.113.7", row?.sourceIp, "the issuance points at no request record")
+    }
+
+    /**
+     * Where issuance genuinely has no request behind it — a scheduled re-invite, say — the origin
+     * stays absent rather than becoming a placeholder. A fabricated IP reads as a real observation
+     * to whoever queries the log.
+     */
+    @Test
+    fun `an issuance with no request records no origin rather than a fake one`() = onServer {
+        TestServer.pin.mintMagicLink("victim@example.com")
+
+        val event = events().single()
+        assertEquals(AuthEventType.ProofIssued, event.type)
+        assertNull(event.sourceIp, "a request-less issuance must not be given a fabricated origin")
+        assertNull(event.userAgent, "a request-less issuance must not be given a fabricated user agent")
     }
 
     // ---- WebAuthN ----------------------------------------------------------------------------

--- a/plans/audit-logging.md
+++ b/plans/audit-logging.md
@@ -1111,6 +1111,8 @@ acting and target principal where they differ:
 - token issuance, refresh, and refresh failure
 - session termination, including the acting principal when terminated by an administrator
 - proof submission per method, success and failure
+- proof *issuance* where nothing was presented — a mailed magic link is a bearer credential, and
+  whoever receives it can authenticate as the address, so the issuance is its own event
 - masquerade assumed and released, with actor and target
 - scope or permission change
 

--- a/sessions-email/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/EmailProofEndpoints.kt
+++ b/sessions-email/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/EmailProofEndpoints.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.sessions.proofs
 
+import com.lightningkite.lightningserver.data.Request
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.encryption.Signer
 import com.lightningkite.lightningserver.encryption.signer
@@ -84,8 +85,19 @@ public class EmailProofEndpoints(
      * Security: The email address mismatch check prevents accidentally sending proofs to wrong addresses.
      */
     context(_: ServerRuntime)
-    public suspend fun send(destination: String, content: (Proof) -> Email) {
-        email().send(content(issueProof(destination)).also {
+    public suspend fun send(destination: String, content: (Proof) -> Email): Unit =
+        send(destination, request = null, content = content)
+
+    /**
+     * As [send], naming the request that asked for the link to be sent.
+     *
+     * Pass the request wherever the caller has one — a frontend's "email me a login link" endpoint
+     * always does. The link is a bearer credential, so the audit record of its issuance is only as
+     * useful as the origin it names, and without this it names none.
+     */
+    context(_: ServerRuntime)
+    public suspend fun send(destination: String, request: Request<*>?, content: (Proof) -> Email) {
+        email().send(content(issueProof(destination, request)).also {
             if (it.to.singleOrNull()?.value?.equals(destination) != true) {
                 throw IllegalArgumentException("Email mismatch")
             }

--- a/sessions-sms/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/SmsProofEndpoints.kt
+++ b/sessions-sms/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/SmsProofEndpoints.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.sessions.proofs
 
+import com.lightningkite.lightningserver.data.Request
 import com.lightningkite.lightningserver.definition.*
 import com.lightningkite.lightningserver.encryption.Signer
 import com.lightningkite.lightningserver.encryption.signer
@@ -121,8 +122,18 @@ public class SmsProofEndpoints(
      * Security: The proof is signed and time-limited to prevent tampering or replay.
      */
     context(_: ServerRuntime)
-    public suspend fun send(destination: String, content: (Proof) -> String) {
-        sms().send(destination.toPhoneNumber(), content(issueProof(destination)))
+    public suspend fun send(destination: String, content: (Proof) -> String): Unit =
+        send(destination, request = null, content = content)
+
+    /**
+     * As [send], naming the request that asked for the link to be sent.
+     *
+     * Pass the request wherever the caller has one. The proof is a bearer credential, so the audit
+     * record of its issuance is only as useful as the origin it names.
+     */
+    context(_: ServerRuntime)
+    public suspend fun send(destination: String, request: Request<*>?, content: (Proof) -> String) {
+        sms().send(destination.toPhoneNumber(), content(issueProof(destination, request)))
     }
 }
 

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PinBasedProofEndpoints.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/PinBasedProofEndpoints.kt
@@ -1,5 +1,6 @@
 package com.lightningkite.lightningserver.sessions.proofs
 
+import com.lightningkite.lightningserver.data.Request
 import com.lightningkite.lightningserver.BadRequestException
 import com.lightningkite.lightningserver.NotFoundException
 import com.lightningkite.lightningserver.auth.PrincipalType
@@ -65,11 +66,20 @@ public abstract class PinBasedProofEndpoints(
         )
 
     context(_: ServerRuntime)
-    protected suspend fun issueProof(destination: String): Proof {
-        return proofSigner.await().makeProof(
+    protected suspend fun issueProof(destination: String, request: Request<*>? = null): Proof {
+        val proof = proofSigner.await().makeProof(
             property = property,
             value = destination,
         )
+        // Recorded here rather than at the call sites that mail it: every path that mints an
+        // unpresented proof goes through this function, so instrumenting it is what makes the record
+        // complete. The proof is a bearer credential the moment it exists, so the mint is the event.
+        //
+        // `request` is the request that asked for the link to be sent, where the caller has one —
+        // which is the normal case, since a frontend triggers this. It carries the IP and user agent
+        // of whoever asked, which is what an investigation into a misused link starts from.
+        reportProofIssued(info, principal = destination, request = request)
+        return proof
     }
 
     override val prove: ApiHttpHandler<PathSpec0, HasId<*>?, FinishProof, Proof> =

--- a/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/proofAuthEvents.kt
+++ b/sessions/src/main/kotlin/com/lightningkite/lightningserver/sessions/proofs/proofAuthEvents.kt
@@ -98,7 +98,7 @@ public suspend fun reportProofRejected(
  * Raised where the acceptance happens — at the end of a `prove` handler, after the secret has been
  * checked — and deliberately not where proofs are *minted*. `Signer.makeProof` also mints a proof to
  * be mailed to someone (a magic link), which is not a credential having been presented and must not
- * be recorded as one. See the module notes on that split.
+ * be recorded as one. That path raises [reportProofIssued] instead.
  *
  * @param principal The account that authenticated. For a method that proves ownership of an address
  *   rather than of an account (an emailed or texted PIN), this is that address: those endpoints
@@ -111,6 +111,41 @@ public suspend fun reportProofAccepted(
     principal: String? = null,
     request: Request<*>? = null,
 ): Unit = reportProofEvent("ProofAccepted", method, principal, request, null)
+
+/**
+ * Records that a proof was minted to be sent to someone, with nothing presented by anyone.
+ *
+ * This is the magic-link case: the server decides to trust an address and mails it a signed proof.
+ * The result is a bearer credential — whoever reads that message can authenticate as the address —
+ * so the issuance is the act an investigation starts from. Without this the whole flow was invisible:
+ * a link issued to an address an attacker controls produces a perfectly ordinary [ProofAccepted]
+ * later, and nothing records that the credential was handed out in the first place.
+ *
+ * Deliberately not [reportProofAccepted]. Recording issuance as an acceptance would put a login in
+ * the log that never happened, and would make "how many times did this account authenticate" wrong.
+ *
+ * ## Origin is the point, so pass the request
+ * Issuance is normally caused by an inbound request — a frontend calling "email this person a link"
+ * — and that request is what an investigation actually wants: the IP and user agent of whoever asked
+ * for the credential to be sent. Pass it. The event also carries the execution's request id, so the
+ * request log is a second route to the same origin even where a caller does not.
+ *
+ * Where issuance genuinely has no request behind it — a scheduled re-invite, say — the origin stays
+ * null rather than becoming a placeholder, as everywhere else here.
+ *
+ * @param method The proof method the credential was minted for; its `via` and `property` land on the
+ *   record.
+ * @param principal The address the proof was issued for. As with an emailed PIN, these endpoints
+ *   never resolve a subject — that happens later, at login — so the address is the truthful answer
+ *   to who this was about.
+ * @param request The request that caused the issuance, where there was one.
+ */
+context(server: ServerRuntime)
+public suspend fun reportProofIssued(
+    method: ProofMethodInfo,
+    principal: String? = null,
+    request: Request<*>? = null,
+): Unit = reportProofEvent("ProofIssued", method, principal, request, null)
 
 context(server: ServerRuntime)
 private suspend fun reportProofEvent(


### PR DESCRIPTION
**Stack: 16 of 16.** Based on `split/a6` — review that one first.
A magic link is a bearer credential from the moment it is minted: whoever
reads that message can authenticate as the address it was issued for. Until
now issuance left no trace at all — only the eventual login did, and that
login looks entirely ordinary. Someone who can cause a link to be issued to
an address they control needs no credential, and nothing in the log said the
credential was handed out.

`PinBasedProofEndpoints.issueProof` now raises `ProofIssued`. Every path that
mints an unpresented proof goes through that one function — the email and SMS
`send(destination) { ... }` overloads both call it — so instrumenting it is
what makes the record complete rather than per-transport.

Deliberately not `ProofAccepted`. Nothing was presented by anyone, so
recording it as an acceptance would put a login in the log that never
happened and make "how many times did this account authenticate" wrong. The
existing test that pinned the issuance/acceptance split now asserts the new
type instead of asserting silence.

## The origin is the point, so it is threaded through

Issuance is normally caused by an inbound request: a frontend calling "email
me a login link". That request carries the IP and user agent of whoever asked
for the credential to be sent, which is exactly what an investigation into a
misused link starts from. `issueProof` and both `send` overloads now take an
optional `Request`, defaulted so existing callers still compile.

Three tests cover it, driven through an endpoint that stands in for an
application's own "email me a link" route, since the framework ships no such
endpoint of its own:

- the event names the requester's IP and user agent
- the event joins the request record of the call that asked, so the origin is
  reachable through the request log independently of the event's own columns
- an issuance with genuinely no request behind it — a scheduled re-invite —
  records no origin rather than a fabricated one

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jybc9zdLT2sEfJUpErf2cd